### PR TITLE
quest target by name

### DIFF
--- a/Systems/Quests/QuestSystem.cs
+++ b/Systems/Quests/QuestSystem.cs
@@ -374,7 +374,10 @@ internal static class QuestSystem
         for (int i = 0; i < questData.Count; i++)
         {
             var quest = questData.ElementAt(i);
-            if (quest.Value.Objective.Target == target)
+
+            Core.SystemService.PrefabCollectionSystem._PrefabGuidToEntityMap.TryGetValue(quest.Value.Objective.Target, out Entity questEntity);
+            Core.SystemService.PrefabCollectionSystem._PrefabGuidToEntityMap.TryGetValue(target, out Entity targetEntity);
+            if (quest.Value.Objective.Target.GetPrefabName() == target.GetPrefabName() && questEntity.Read<UnitLevel>().Level._Value <= targetEntity.Read<UnitLevel>().Level._Value)
             {
                 updated = true;
                 string colorType = quest.Key == QuestType.Daily ? $"<color=#00FFFF>{QuestType.Daily} Quest</color>" : $"<color=#BF40BF>{QuestType.Weekly} Quest</color>";


### PR DESCRIPTION
After displaying the target's level, I found that sometimes quest target wouldn't update when killing Cultists. I believe all cultists are the same level but some have different guid.

- compares target's name instead of guid
- requires killing >= level monster with same name