### PR TITLE
Add free resets per type

### DIFF
--- a/Commands/BloodCommands.cs
+++ b/Commands/BloodCommands.cs
@@ -214,6 +214,17 @@ internal static class BloodCommands
             return;
         }
 
+        string freeKey = PlayerBoolsManager.GetFreeBloodResetKey(bloodType);
+        if (GetPlayerBool(steamId, freeKey))
+        {
+            ResetStats(steamId, bloodType);
+            Buffs.RefreshStats(playerCharacter);
+
+            SetPlayerBool(steamId, freeKey, false);
+            LocalizationService.HandleReply(ctx, $"Your blood stats have been reset for <color=red>{bloodType}</color>!");
+            return;
+        }
+
         if (!ConfigService.ResetLegacyItem.Equals(0))
         {
             PrefabGUID item = new(ConfigService.ResetLegacyItem);

--- a/Commands/WeaponCommands.cs
+++ b/Commands/WeaponCommands.cs
@@ -189,6 +189,17 @@ internal static class WeaponCommands
 
         WeaponType weaponType = GetCurrentWeaponType(playerCharacter);
 
+        string freeKey = PlayerBoolsManager.GetFreeWeaponResetKey(weaponType);
+        if (GetPlayerBool(steamId, freeKey))
+        {
+            ResetStats(steamId, weaponType);
+            Buffs.RefreshStats(playerCharacter);
+
+            SetPlayerBool(steamId, freeKey, false);
+            LocalizationService.HandleReply(ctx, $"Your weapon stats have been reset for <color=#c0c0c0>{weaponType}</color>!");
+            return;
+        }
+
         if (!ConfigService.ResetExpertiseItem.Equals(0))
         {
             PrefabGUID item = new(ConfigService.ResetExpertiseItem);

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Jairon O.; Odjit; Jera; Kokuren TCG and Gaming Shop; Rexxn; Eduardo G.; DirtyMik
 - Pick stats to enhance per weapon when equipped.
   - `.wep lst` (view weapon bonus stat options)
   - `.wep cst` [Weapon] [WeaponStat] (select bonus stat for entered weapon)
-  - `.wep rst` (reset stat selection for current weapon)
+  - `.wep rst` (reset stat selection for current weapon; first reset per weapon is free)
 - Stat bonus values scale with player weapon expertise level per weapon.
   - classes have synergies with different weapon stats (see Classes)
 
@@ -44,7 +44,7 @@ Jairon O.; Odjit; Jera; Kokuren TCG and Gaming Shop; Rexxn; Eduardo G.; DirtyMik
 - Pick stats to enhance per blood when using.
   - `.bl lst` (view blood bonus stat options)
   - `.bl cst` [Blood] [BloodStat] (select bonus stat for entered weapon)
-  - `.bl rst` (reset stat selection for current weapon)
+  - `.bl rst` (reset stat selection for current blood; first reset per blood is free)
 - Stat bonus values scale with player blood legacy level per blood.
   - classes have synergies with different blood stats (see Classes)
 
@@ -115,7 +115,7 @@ Jairon O.; Odjit; Jera; Kokuren TCG and Gaming Shop; Rexxn; Eduardo G.; DirtyMik
   - Toggles Legacy progress logging.
   - Shortcut: *.bl log*
 - `.bloodlegacy resetstats`
-  - Reset stats for current blood.
+  - Reset stats for current blood. First reset per blood is free.
   - Shortcut: *.bl rst*
 - `.bloodlegacy set [Player] [Blood] [Level]` 🔒
   - Sets player blood legacy level.
@@ -367,8 +367,8 @@ Jairon O.; Odjit; Jera; Kokuren TCG and Gaming Shop; Rexxn; Eduardo G.; DirtyMik
 - `.weapon log`
   - Toggles expertise logging.
   - Shortcut: *.wep log*
-- `.weapon resetstats`
-  - Reset the stats for current weapon.
+  - `.weapon resetstats`
+  - Reset the stats for current weapon. First reset per weapon is free.
   - Shortcut: *.wep rst*
 - `.weapon set [Name] [Weapon] [Level]` 🔒
   - Sets player weapon expertise level.

--- a/Utilities/Misc.cs
+++ b/Utilities/Misc.cs
@@ -154,6 +154,18 @@ internal static class Misc
         public const string SHROUD_KEY = "Shroud";
         public const string CLASS_BUFFS_KEY = "Passives";
         public const string PRESTIGE_BUFFS_KEY = "PrestigeBuffs";
+        public const string FREE_BLOOD_RST_PREFIX = "FreeBloodReset_";
+        public const string FREE_WEAPON_RST_PREFIX = "FreeWeaponReset_";
+
+        public static string GetFreeBloodResetKey(BloodType type)
+        {
+            return $"{FREE_BLOOD_RST_PREFIX}{type}";
+        }
+
+        public static string GetFreeWeaponResetKey(WeaponType type)
+        {
+            return $"{FREE_WEAPON_RST_PREFIX}{type}";
+        }
 
         public static readonly Dictionary<string, bool> DefaultBools = new()
         {
@@ -181,6 +193,19 @@ internal static class Misc
             [CLASS_BUFFS_KEY] = false,
             [PRESTIGE_BUFFS_KEY] = true
         };
+
+        static PlayerBoolsManager()
+        {
+            foreach (WeaponType weaponType in Enum.GetValues(typeof(WeaponType)))
+            {
+                DefaultBools[GetFreeWeaponResetKey(weaponType)] = true;
+            }
+
+            foreach (BloodType bloodType in Enum.GetValues(typeof(BloodType)))
+            {
+                DefaultBools[GetFreeBloodResetKey(bloodType)] = true;
+            }
+        }
         public static bool GetPlayerBool(ulong steamId, string boolKey)
         {
             var bools = DataService.PlayerBoolsManager.LoadPlayerBools(steamId);


### PR DESCRIPTION
## Summary
- allow one free reset per weapon and blood type
- add bool flags per weapon/blood type
- document free reset in README

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68818e77a374832d98025ce8d38242ea