### PR TITLE
Rename PlayerBoolsManager utility and simplify reset keys

### DIFF
--- a/Commands/BloodCommands.cs
+++ b/Commands/BloodCommands.cs
@@ -10,7 +10,7 @@ using VampireCommandFramework;
 using static Bloodcraft.Services.PlayerService;
 using static Bloodcraft.Systems.Legacies.BloodManager;
 using static Bloodcraft.Systems.Legacies.BloodManager.BloodStats;
-using static Bloodcraft.Utilities.Misc.PlayerBoolsManager;
+using static Bloodcraft.Utilities.Misc.PlayerBools;
 using static Bloodcraft.Utilities.Progression;
 using static Bloodcraft.Utilities.Progression.ModifyUnitStatBuffSettings;
 using static VCF.Core.Basics.RoleCommands;
@@ -214,7 +214,7 @@ internal static class BloodCommands
             return;
         }
 
-        string freeKey = PlayerBoolsManager.GetFreeBloodResetKey(bloodType);
+        string freeKey = bloodType.ToString();
         if (GetPlayerBool(steamId, freeKey))
         {
             ResetStats(steamId, bloodType);

--- a/Commands/ClassCommands.cs
+++ b/Commands/ClassCommands.cs
@@ -7,7 +7,7 @@ using Unity.Entities;
 using VampireCommandFramework;
 using static Bloodcraft.Systems.Leveling.ClassManager;
 using static Bloodcraft.Utilities.Classes;
-using static Bloodcraft.Utilities.Misc.PlayerBoolsManager;
+using static Bloodcraft.Utilities.Misc.PlayerBools;
 using static VCF.Core.Basics.RoleCommands;
 using User = ProjectM.Network.User;
 

--- a/Commands/FamiliarCommands.cs
+++ b/Commands/FamiliarCommands.cs
@@ -25,7 +25,7 @@ using static Bloodcraft.Systems.Familiars.FamiliarLevelingSystem;
 using static Bloodcraft.Systems.Familiars.FamiliarUnlockSystem;
 using static Bloodcraft.Utilities.Familiars;
 using static Bloodcraft.Utilities.Familiars.ActiveFamiliarManager;
-using static Bloodcraft.Utilities.Misc.PlayerBoolsManager;
+using static Bloodcraft.Utilities.Misc.PlayerBools;
 using static Bloodcraft.Utilities.Progression;
 
 namespace Bloodcraft.Commands;

--- a/Commands/LevelingCommands.cs
+++ b/Commands/LevelingCommands.cs
@@ -4,7 +4,7 @@ using Bloodcraft.Systems.Leveling;
 using ProjectM.Network;
 using VampireCommandFramework;
 using static Bloodcraft.Services.PlayerService;
-using static Bloodcraft.Utilities.Misc.PlayerBoolsManager;
+using static Bloodcraft.Utilities.Misc.PlayerBools;
 using static Bloodcraft.Utilities.Progression;
 
 namespace Bloodcraft.Commands;

--- a/Commands/MiscCommands.cs
+++ b/Commands/MiscCommands.cs
@@ -7,7 +7,7 @@ using Stunlock.Core;
 using Unity.Entities;
 using VampireCommandFramework;
 using static Bloodcraft.Utilities.Misc;
-using static Bloodcraft.Utilities.Misc.PlayerBoolsManager;
+using static Bloodcraft.Utilities.Misc.PlayerBools;
 using static VCF.Core.Basics.RoleCommands;
 
 namespace Bloodcraft.Commands;

--- a/Commands/PrestigeCommands.cs
+++ b/Commands/PrestigeCommands.cs
@@ -11,7 +11,7 @@ using Unity.Entities;
 using VampireCommandFramework;
 using static Bloodcraft.Services.PlayerService;
 using static Bloodcraft.Systems.Leveling.PrestigeManager;
-using static Bloodcraft.Utilities.Misc.PlayerBoolsManager;
+using static Bloodcraft.Utilities.Misc.PlayerBools;
 
 namespace Bloodcraft.Commands;
 

--- a/Commands/ProfessionCommands.cs
+++ b/Commands/ProfessionCommands.cs
@@ -3,7 +3,7 @@ using Bloodcraft.Services;
 using Bloodcraft.Systems.Professions;
 using VampireCommandFramework;
 using static Bloodcraft.Services.PlayerService;
-using static Bloodcraft.Utilities.Misc.PlayerBoolsManager;
+using static Bloodcraft.Utilities.Misc.PlayerBools;
 using static Bloodcraft.Utilities.Progression;
 
 namespace Bloodcraft.Commands;

--- a/Commands/QuestCommands.cs
+++ b/Commands/QuestCommands.cs
@@ -8,7 +8,7 @@ using Unity.Entities;
 using VampireCommandFramework;
 using static Bloodcraft.Services.PlayerService;
 using static Bloodcraft.Systems.Quests.QuestSystem;
-using static Bloodcraft.Utilities.Misc.PlayerBoolsManager;
+using static Bloodcraft.Utilities.Misc.PlayerBools;
 
 namespace Bloodcraft.Commands;
 

--- a/Commands/WeaponCommands.cs
+++ b/Commands/WeaponCommands.cs
@@ -12,7 +12,7 @@ using static Bloodcraft.Services.PlayerService;
 using static Bloodcraft.Systems.Expertise.WeaponManager;
 using static Bloodcraft.Systems.Expertise.WeaponManager.WeaponStats;
 using static Bloodcraft.Systems.Expertise.WeaponSystem;
-using static Bloodcraft.Utilities.Misc.PlayerBoolsManager;
+using static Bloodcraft.Utilities.Misc.PlayerBools;
 using static Bloodcraft.Utilities.Progression;
 using static Bloodcraft.Utilities.Progression.ModifyUnitStatBuffSettings;
 using static VCF.Core.Basics.RoleCommands;
@@ -189,7 +189,7 @@ internal static class WeaponCommands
 
         WeaponType weaponType = GetCurrentWeaponType(playerCharacter);
 
-        string freeKey = PlayerBoolsManager.GetFreeWeaponResetKey(weaponType);
+        string freeKey = weaponType.ToString();
         if (GetPlayerBool(steamId, freeKey))
         {
             ResetStats(steamId, weaponType);

--- a/Patches/BuffSpawnServerPatches.cs
+++ b/Patches/BuffSpawnServerPatches.cs
@@ -9,7 +9,7 @@ using ProjectM.Network;
 using ProjectM.Scripting;
 using Stunlock.Core;
 using Unity.Entities;
-using static Bloodcraft.Utilities.Misc.PlayerBoolsManager;
+using static Bloodcraft.Utilities.Misc.PlayerBools;
 
 namespace Bloodcraft.Patches;
 

--- a/Patches/EmoteSystemPatch.cs
+++ b/Patches/EmoteSystemPatch.cs
@@ -10,7 +10,7 @@ using Unity.Collections;
 using Unity.Entities;
 using static Bloodcraft.Services.DataService.FamiliarPersistence.FamiliarEquipmentManager;
 using static Bloodcraft.Utilities.Familiars;
-using static Bloodcraft.Utilities.Misc.PlayerBoolsManager;
+using static Bloodcraft.Utilities.Misc.PlayerBools;
 using static Bloodcraft.Utilities.Shapeshifts;
 using User = ProjectM.Network.User;
 

--- a/Patches/ReplaceAbilityOnSlotSystemPatch.cs
+++ b/Patches/ReplaceAbilityOnSlotSystemPatch.cs
@@ -6,7 +6,7 @@ using ProjectM.Scripting;
 using Stunlock.Core;
 using Unity.Collections;
 using Unity.Entities;
-using static Bloodcraft.Utilities.Misc.PlayerBoolsManager;
+using static Bloodcraft.Utilities.Misc.PlayerBools;
 
 namespace Bloodcraft.Patches;
 

--- a/Patches/ServerBootstrapSystemPatches.cs
+++ b/Patches/ServerBootstrapSystemPatches.cs
@@ -15,7 +15,7 @@ using UnityEngine;
 using static Bloodcraft.Services.DataService.FamiliarPersistence;
 using static Bloodcraft.Services.PlayerService;
 using static Bloodcraft.Utilities.Familiars;
-using static Bloodcraft.Utilities.Misc.PlayerBoolsManager;
+using static Bloodcraft.Utilities.Misc.PlayerBools;
 using static Bloodcraft.Utilities.Progression;
 using User = ProjectM.Network.User;
 using WeaponType = Bloodcraft.Interfaces.WeaponType;

--- a/Patches/UpdateBuffsBufferDestroyPatch.cs
+++ b/Patches/UpdateBuffsBufferDestroyPatch.cs
@@ -9,7 +9,7 @@ using ProjectM.Network;
 using Stunlock.Core;
 using Unity.Collections;
 using Unity.Entities;
-using static Bloodcraft.Utilities.Misc.PlayerBoolsManager;
+using static Bloodcraft.Utilities.Misc.PlayerBools;
 
 namespace Bloodcraft.Patches;
 

--- a/Services/DataService.cs
+++ b/Services/DataService.cs
@@ -999,7 +999,7 @@ internal static class DataService
                 }
             }
 
-            bools[Misc.PlayerBoolsManager.CLASS_BUFFS_KEY] = false;
+            bools[Misc.PlayerBools.CLASS_BUFFS_KEY] = false;
             SavePlayerBools(steamId, bools);
             return bools;
         }

--- a/Systems/Expertise/WeaponSystem.cs
+++ b/Systems/Expertise/WeaponSystem.cs
@@ -9,7 +9,7 @@ using Unity.Entities;
 using Unity.Mathematics;
 using UnityEngine;
 using static Bloodcraft.Patches.DeathEventListenerSystemPatch;
-using static Bloodcraft.Utilities.Misc.PlayerBoolsManager;
+using static Bloodcraft.Utilities.Misc.PlayerBools;
 using static Bloodcraft.Utilities.Progression;
 using WeaponType = Bloodcraft.Interfaces.WeaponType;
 

--- a/Systems/Familiars/FamiliarBindingSystem.cs
+++ b/Systems/Familiars/FamiliarBindingSystem.cs
@@ -18,7 +18,7 @@ using static Bloodcraft.Services.DataService.FamiliarPersistence;
 using static Bloodcraft.Services.DataService.FamiliarPersistence.FamiliarBuffsManager;
 using static Bloodcraft.Services.DataService.FamiliarPersistence.FamiliarEquipmentManager;
 using static Bloodcraft.Services.DataService.FamiliarPersistence.FamiliarExperienceManager;
-using static Bloodcraft.Utilities.Misc.PlayerBoolsManager;
+using static Bloodcraft.Utilities.Misc.PlayerBools;
 using static Bloodcraft.Utilities.Progression;
 
 namespace Bloodcraft.Systems.Familiars;

--- a/Systems/Familiars/FamiliarLevelingSystem.cs
+++ b/Systems/Familiars/FamiliarLevelingSystem.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 using static Bloodcraft.Patches.DeathEventListenerSystemPatch;
 using static Bloodcraft.Services.DataService.FamiliarPersistence;
 using static Bloodcraft.Services.DataService.FamiliarPersistence.FamiliarExperienceManager;
-using static Bloodcraft.Utilities.Misc.PlayerBoolsManager;
+using static Bloodcraft.Utilities.Misc.PlayerBools;
 using static Bloodcraft.Utilities.Progression;
 
 namespace Bloodcraft.Systems.Familiars;

--- a/Systems/Legacies/BloodSystem.cs
+++ b/Systems/Legacies/BloodSystem.cs
@@ -10,7 +10,7 @@ using Unity.Entities;
 using Unity.Mathematics;
 using UnityEngine;
 using static Bloodcraft.Patches.DeathEventListenerSystemPatch;
-using static Bloodcraft.Utilities.Misc.PlayerBoolsManager;
+using static Bloodcraft.Utilities.Misc.PlayerBools;
 using static Bloodcraft.Utilities.Progression;
 
 namespace Bloodcraft.Systems.Legacies;

--- a/Systems/Leveling/LevelingSystem.cs
+++ b/Systems/Leveling/LevelingSystem.cs
@@ -11,7 +11,7 @@ using Unity.Mathematics;
 using UnityEngine;
 using static Bloodcraft.Patches.DeathEventListenerSystemPatch;
 using static Bloodcraft.Systems.Leveling.ClassManager;
-using static Bloodcraft.Utilities.Misc.PlayerBoolsManager;
+using static Bloodcraft.Utilities.Misc.PlayerBools;
 using static Bloodcraft.Utilities.Progression;
 using User = ProjectM.Network.User;
 

--- a/Systems/Leveling/PrestigeManager.cs
+++ b/Systems/Leveling/PrestigeManager.cs
@@ -10,7 +10,7 @@ using Stunlock.Core;
 using Unity.Entities;
 using VampireCommandFramework;
 using static Bloodcraft.Services.PlayerService;
-using static Bloodcraft.Utilities.Misc.PlayerBoolsManager;
+using static Bloodcraft.Utilities.Misc.PlayerBools;
 
 namespace Bloodcraft.Systems.Leveling;
 internal static class PrestigeManager

--- a/Systems/Professions/ProfessionSystem.cs
+++ b/Systems/Professions/ProfessionSystem.cs
@@ -9,7 +9,7 @@ using System.Collections;
 using Unity.Entities;
 using Unity.Mathematics;
 using UnityEngine;
-using static Bloodcraft.Utilities.Misc.PlayerBoolsManager;
+using static Bloodcraft.Utilities.Misc.PlayerBools;
 using static Bloodcraft.Utilities.Progression;
 using Random = System.Random;
 using User = ProjectM.Network.User;

--- a/Systems/Quests/QuestSystem.cs
+++ b/Systems/Quests/QuestSystem.cs
@@ -19,7 +19,7 @@ using Unity.Collections;
 using Unity.Entities;
 using UnityEngine;
 using static Bloodcraft.Patches.DeathEventListenerSystemPatch;
-using static Bloodcraft.Utilities.Misc.PlayerBoolsManager;
+using static Bloodcraft.Utilities.Misc.PlayerBools;
 using static Bloodcraft.Utilities.Progression;
 using Match = System.Text.RegularExpressions.Match;
 using Random = System.Random;

--- a/Utilities/Classes.cs
+++ b/Utilities/Classes.cs
@@ -20,7 +20,7 @@ using static Bloodcraft.Systems.Legacies.BloodManager.BloodStats;
 using static Bloodcraft.Systems.Leveling.ClassManager;
 using static Bloodcraft.Systems.Leveling.LevelingSystem;
 using static Bloodcraft.Utilities.EntityQueries;
-using static Bloodcraft.Utilities.Misc.PlayerBoolsManager;
+using static Bloodcraft.Utilities.Misc.PlayerBools;
 
 namespace Bloodcraft.Utilities;
 internal static class Classes

--- a/Utilities/Familiars.cs
+++ b/Utilities/Familiars.cs
@@ -24,7 +24,7 @@ using static Bloodcraft.Services.PlayerService;
 using static Bloodcraft.Systems.Familiars.FamiliarBindingSystem;
 using static Bloodcraft.Systems.Familiars.FamiliarUnlockSystem;
 using static Bloodcraft.Utilities.Familiars.ActiveFamiliarManager;
-using static Bloodcraft.Utilities.Misc.PlayerBoolsManager;
+using static Bloodcraft.Utilities.Misc.PlayerBools;
 
 namespace Bloodcraft.Utilities;
 internal static class Familiars

--- a/Utilities/Misc.cs
+++ b/Utilities/Misc.cs
@@ -9,7 +9,7 @@ using System.Text;
 using Unity.Entities;
 using VampireCommandFramework;
 using static Bloodcraft.Systems.Expertise.WeaponManager;
-using static Bloodcraft.Utilities.Misc.PlayerBoolsManager;
+using static Bloodcraft.Utilities.Misc.PlayerBools;
 
 namespace Bloodcraft.Utilities;
 internal static class Misc
@@ -127,7 +127,7 @@ internal static class Misc
         { ScrollingTextMessage.ProfessionExperience, SCT_PROFESSIONS_KEY },
         { ScrollingTextMessage.ProfessionYields, SCT_YIELD_KEY }
     };
-    public static class PlayerBoolsManager
+    public static class PlayerBools
     {
         public const string EXPERIENCE_LOG_KEY = "ExperienceLogging";
         public const string QUEST_LOG_KEY = "QuestLogging";
@@ -152,18 +152,37 @@ internal static class Misc
         public const string SHROUD_KEY = "Shroud";
         public const string CLASS_BUFFS_KEY = "Passives";
         public const string PRESTIGE_BUFFS_KEY = "PrestigeBuffs";
-        public const string FREE_BLOOD_RST_PREFIX = "FreeBloodReset_";
-        public const string FREE_WEAPON_RST_PREFIX = "FreeWeaponReset_";
 
-        public static string GetFreeBloodResetKey(BloodType type)
-        {
-            return $"{FREE_BLOOD_RST_PREFIX}{type}";
-        }
+        public const string WORKER_KEY = nameof(BloodType.Worker);
+        public const string WARRIOR_KEY = nameof(BloodType.Warrior);
+        public const string SCHOLAR_KEY = nameof(BloodType.Scholar);
+        public const string ROGUE_KEY = nameof(BloodType.Rogue);
+        public const string MUTANT_KEY = nameof(BloodType.Mutant);
+        public const string VBLOOD_KEY = nameof(BloodType.VBlood);
+        public const string NONE_BLOOD_KEY = nameof(BloodType.None);
+        public const string GATE_BOSS_KEY = nameof(BloodType.GateBoss);
+        public const string DRACULIN_KEY = nameof(BloodType.Draculin);
+        public const string IMMORTAL_KEY = nameof(BloodType.Immortal);
+        public const string CREATURE_KEY = nameof(BloodType.Creature);
+        public const string BRUTE_KEY = nameof(BloodType.Brute);
+        public const string CORRUPTION_KEY = nameof(BloodType.Corruption);
 
-        public static string GetFreeWeaponResetKey(WeaponType type)
-        {
-            return $"{FREE_WEAPON_RST_PREFIX}{type}";
-        }
+        public const string SWORD_KEY = nameof(WeaponType.Sword);
+        public const string AXE_KEY = nameof(WeaponType.Axe);
+        public const string MACE_KEY = nameof(WeaponType.Mace);
+        public const string SPEAR_KEY = nameof(WeaponType.Spear);
+        public const string CROSSBOW_KEY = nameof(WeaponType.Crossbow);
+        public const string GREATSWORD_KEY = nameof(WeaponType.GreatSword);
+        public const string SLASHERS_KEY = nameof(WeaponType.Slashers);
+        public const string PISTOLS_KEY = nameof(WeaponType.Pistols);
+        public const string REAPER_KEY = nameof(WeaponType.Reaper);
+        public const string LONGBOW_KEY = nameof(WeaponType.Longbow);
+        public const string WHIP_KEY = nameof(WeaponType.Whip);
+        public const string UNARMED_KEY = nameof(WeaponType.Unarmed);
+        public const string FISHING_POLE_KEY = nameof(WeaponType.FishingPole);
+        public const string TWIN_BLADES_KEY = nameof(WeaponType.TwinBlades);
+        public const string DAGGERS_KEY = nameof(WeaponType.Daggers);
+        public const string CLAWS_KEY = nameof(WeaponType.Claws);
 
         public static readonly Dictionary<string, bool> DefaultBools = new()
         {
@@ -189,21 +208,39 @@ internal static class Misc
             [SHAPESHIFT_KEY] = false,
             [SHROUD_KEY] = true,
             [CLASS_BUFFS_KEY] = false,
-            [PRESTIGE_BUFFS_KEY] = true
+            [PRESTIGE_BUFFS_KEY] = true,
+
+            [WORKER_KEY] = true,
+            [WARRIOR_KEY] = true,
+            [SCHOLAR_KEY] = true,
+            [ROGUE_KEY] = true,
+            [MUTANT_KEY] = true,
+            [VBLOOD_KEY] = true,
+            [NONE_BLOOD_KEY] = true,
+            [GATE_BOSS_KEY] = true,
+            [DRACULIN_KEY] = true,
+            [IMMORTAL_KEY] = true,
+            [CREATURE_KEY] = true,
+            [BRUTE_KEY] = true,
+            [CORRUPTION_KEY] = true,
+
+            [SWORD_KEY] = true,
+            [AXE_KEY] = true,
+            [MACE_KEY] = true,
+            [SPEAR_KEY] = true,
+            [CROSSBOW_KEY] = true,
+            [GREATSWORD_KEY] = true,
+            [SLASHERS_KEY] = true,
+            [PISTOLS_KEY] = true,
+            [REAPER_KEY] = true,
+            [LONGBOW_KEY] = true,
+            [WHIP_KEY] = true,
+            [UNARMED_KEY] = true,
+            [FISHING_POLE_KEY] = true,
+            [TWIN_BLADES_KEY] = true,
+            [DAGGERS_KEY] = true,
+            [CLAWS_KEY] = true
         };
-
-        static PlayerBoolsManager()
-        {
-            foreach (WeaponType weaponType in Enum.GetValues(typeof(WeaponType)))
-            {
-                DefaultBools[GetFreeWeaponResetKey(weaponType)] = true;
-            }
-
-            foreach (BloodType bloodType in Enum.GetValues(typeof(BloodType)))
-            {
-                DefaultBools[GetFreeBloodResetKey(bloodType)] = true;
-            }
-        }
         public static bool GetPlayerBool(ulong steamId, string boolKey)
         {
             var bools = DataService.PlayerBoolsManager.LoadPlayerBools(steamId);


### PR DESCRIPTION
## Summary
- rename PlayerBoolsManager to PlayerBools
- remove helper methods for reset keys
- add explicit keys for every `WeaponType` and `BloodType`
- populate `DefaultBools` with those keys
- update command logic and using statements

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-7.0` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_688297322898832d942612215be4e681