### PR TITLE
Add Codex workflow section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,3 +73,14 @@
 - Never use the 'private' accessibility modifier, as things will be private by default unless made public/internal/etc.
 
 ---
+
+## Codex Keywords & Workflow
+
+The Codex system uses the following keywords:
+
+* **CreatePrd** – create a Product Requirements Document.
+* **CreateTasks** – generate task lists from the PRD.
+* **TaskMaster** – execute tasks and update their status.
+* **ClosePrd** – finalize and archive completed PRDs.
+
+`.codex/install.sh` and `dev_init.sh` handle environment setup.


### PR DESCRIPTION
## Summary
- add Codex workflow keywords section to AGENTS guidelines

## Testing
- `bash .codex/install.sh` *(fails: Unable to load the service index for source https://nuget.bepinex.dev/v3/index.json)*

------
https://chatgpt.com/codex/tasks/task_e_6885803bc948832d9e145ff544b2f71a