### PR TITLE
Add Codex workflow documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -794,5 +794,13 @@ Jairon O.; Odjit; Jera; Kokuren TCG and Gaming Shop; Rexxn; Eduardo G.; DirtyMik
 - [XPRising](https://thunderstore.io/c/v-rising/p/XPRising/XPRising/)
   If you like the idea of a mod with RPG features but Bloodcraft doesn't float your boat maybe this will!
 
+## Codex Workflow
+
+1. Run `.codex/install.sh` once to install dependencies.
+2. Build and deploy locally with `./dev_init.sh`.
+3. Use the keywords (**CreatePrd**, **CreateTasks**, **TaskMaster**, **ClosePrd**) to manage PRDs and tasks.
+
+Current PRDs and task lists are stored in `.project-management/current-prd/`, while completed items are moved to `.project-management/closed-prd/`.
+
 ## Credits
 Do my best to mention/attribute where ideas and bug reports come from in the changelog and commit history, if I've missed something or someone on a specific change please let me know!


### PR DESCRIPTION
## Summary
- document Codex workflow in the README

## Testing
- `bash .codex/install.sh` *(fails: dotnet download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6885803f9118832db28c82f6ac9e5e14