### PR TITLE
Replace ctx.Reply calls with LocalizationService.Reply

### DIFF
--- a/Commands/BloodCommands.cs
+++ b/Commands/BloodCommands.cs
@@ -29,7 +29,7 @@ internal static class BloodCommands
     {
         if (!ConfigService.LegacySystem)
         {
-            LocalizationService.HandleReply(ctx, "Blood Legacies are not enabled.");
+            LocalizationService.Reply(ctx, "Blood Legacies are not enabled.");
             return;
         }
 
@@ -43,7 +43,7 @@ internal static class BloodCommands
         }
         else if (!Enum.TryParse(blood, true, out bloodType))
         {
-            LocalizationService.HandleReply(ctx, "Invalid blood, use '.bl l' to see options.");
+            LocalizationService.Reply(ctx, "Invalid blood, use '.bl l' to see options.");
             return;
         }
 
@@ -52,7 +52,7 @@ internal static class BloodCommands
 
         if (handler == null)
         {
-            LocalizationService.HandleReply(ctx, "Invalid blood legacy.");
+            LocalizationService.Reply(ctx, "Invalid blood legacy.");
             return;
         }
 
@@ -63,7 +63,7 @@ internal static class BloodCommands
 
         if (data.Key > 0)
         {
-            LocalizationService.HandleReply(ctx, $"You're level [<color=white>{data.Key}</color>][<color=#90EE90>{prestigeLevel}</color>] with <color=yellow>{progress}</color> <color=#FFC0CB>essence</color> (<color=white>{BloodSystem.GetLevelProgress(steamId, handler)}%</color>) in <color=red>{handler.GetBloodType()}</color>!");
+            LocalizationService.Reply(ctx, $"You're level [<color=white>{data.Key}</color>][<color=#90EE90>{prestigeLevel}</color>] with <color=yellow>{progress}</color> <color=#FFC0CB>essence</color> (<color=white>{BloodSystem.GetLevelProgress(steamId, handler)}%</color>) in <color=red>{handler.GetBloodType()}</color>!");
 
             if (steamId.TryGetPlayerBloodStats(out var bloodTypeStats) && bloodTypeStats.TryGetValue(bloodType, out var bloodStatTypes))
             {
@@ -82,17 +82,17 @@ internal static class BloodCommands
                 {
                     var batch = bloodLegacyStats.Skip(i).Take(6);
                     string bonuses = string.Join(", ", batch.Select(stat => $"<color=#00FFFF>{stat.Key}</color>: <color=white>{stat.Value}</color>"));
-                    LocalizationService.HandleReply(ctx, $"<color=red>{bloodType}</color> Stats: {bonuses}");
+                    LocalizationService.Reply(ctx, $"<color=red>{bloodType}</color> Stats: {bonuses}");
                 }
             }
             else
             {
-                LocalizationService.HandleReply(ctx, $"No stats selected for <color=red>{bloodType}</color>, use <color=white>'.bl lst'</color> to see valid options.");
+                LocalizationService.Reply(ctx, $"No stats selected for <color=red>{bloodType}</color>, use <color=white>'.bl lst'</color> to see valid options.");
             }
         }
         else
         {
-            LocalizationService.HandleReply(ctx, $"No progress in <color=red>{handler.GetBloodType()}</color> yet.");
+            LocalizationService.Reply(ctx, $"No progress in <color=red>{handler.GetBloodType()}</color> yet.");
         }
     }
 
@@ -101,14 +101,14 @@ internal static class BloodCommands
     {
         if (!ConfigService.LegacySystem)
         {
-            LocalizationService.HandleReply(ctx, "Blood Legacies are not enabled.");
+            LocalizationService.Reply(ctx, "Blood Legacies are not enabled.");
             return;
         }
 
         var steamId = ctx.Event.User.PlatformId;
 
         TogglePlayerBool(steamId, BLOOD_LOG_KEY);
-        LocalizationService.HandleReply(ctx, $"Blood Legacy logging {(GetPlayerBool(steamId, BLOOD_LOG_KEY) ? "<color=green>enabled</color>" : "<color=red>disabled</color>")}.");
+        LocalizationService.Reply(ctx, $"Blood Legacy logging {(GetPlayerBool(steamId, BLOOD_LOG_KEY) ? "<color=green>enabled</color>" : "<color=red>disabled</color>")}.");
     }
 
     [Command(name: "choosestat", shortHand: "cst", adminOnly: false, usage: ".bl cst [BloodOrStat] [BloodStat]", description: "Choose a bonus stat to enhance for your blood legacy.")]
@@ -116,7 +116,7 @@ internal static class BloodCommands
     {
         if (!ConfigService.LegacySystem)
         {
-            LocalizationService.HandleReply(ctx, "Legacies are not enabled.");
+            LocalizationService.Reply(ctx, "Legacies are not enabled.");
             return;
         }
 
@@ -133,7 +133,7 @@ internal static class BloodCommands
 
             if (!Enum.IsDefined(typeof(BloodStatType), numericStat))
             {
-                LocalizationService.HandleReply(ctx,
+                LocalizationService.Reply(ctx,
                     "Invalid blood stat, use '<color=white>.bl lst</color>' to see valid options.");
                 return;
             }
@@ -145,7 +145,7 @@ internal static class BloodCommands
             if (ChooseStat(steamId, finalBloodType, finalBloodStat))
             {
                 Buffs.RefreshStats(playerCharacter);
-                LocalizationService.HandleReply(ctx,
+                LocalizationService.Reply(ctx,
                     $"<color=#00FFFF>{finalBloodStat}</color> selected for <color=red>{finalBloodType}</color>!");
             }
         }
@@ -153,21 +153,21 @@ internal static class BloodCommands
         {
             if (!Enum.TryParse(bloodOrStat, true, out finalBloodType))
             {
-                LocalizationService.HandleReply(ctx,
+                LocalizationService.Reply(ctx,
                     "Invalid blood type, use '<color=white>.bl l</color>' to see valid options.");
                 return;
             }
 
             if (finalBloodType == BloodType.GateBoss || finalBloodType == BloodType.None || finalBloodType == BloodType.VBlood)
             {
-                LocalizationService.HandleReply(ctx,
+                LocalizationService.Reply(ctx,
                     "Invalid blood legacy, use '<color=white>.bl l</color>' to see valid options.");
                 return;
             }
 
             if (statType <= 0)
             {
-                LocalizationService.HandleReply(ctx,
+                LocalizationService.Reply(ctx,
                     "Invalid blood stat, use '<color=white>.bl lst</color>' to see valid options.");
                 return;
             }
@@ -176,7 +176,7 @@ internal static class BloodCommands
 
             if (!Enum.IsDefined(typeof(BloodStatType), typedStat))
             {
-                LocalizationService.HandleReply(ctx,
+                LocalizationService.Reply(ctx,
                     "Invalid blood stat, use '<color=white>.bl lst</color>' to see valid options.");
                 return;
             }
@@ -186,7 +186,7 @@ internal static class BloodCommands
             if (ChooseStat(steamId, finalBloodType, finalBloodStat))
             {
                 Buffs.RefreshStats(playerCharacter);
-                LocalizationService.HandleReply(ctx,
+                LocalizationService.Reply(ctx,
                     $"<color=#00FFFF>{finalBloodStat}</color> selected for <color=red>{finalBloodType}</color>!");
             }
         }
@@ -197,7 +197,7 @@ internal static class BloodCommands
     {
         if (!ConfigService.LegacySystem)
         {
-            LocalizationService.HandleReply(ctx, "Legacies are not enabled.");
+            LocalizationService.Reply(ctx, "Legacies are not enabled.");
             return;
         }
 
@@ -210,7 +210,7 @@ internal static class BloodCommands
 
         if (bloodType.Equals(BloodType.GateBoss) || bloodType.Equals(BloodType.None) || bloodType.Equals(BloodType.VBlood))
         {
-            LocalizationService.HandleReply(ctx, $"No legacy available for <color=white>{bloodType}</color>.");
+            LocalizationService.Reply(ctx, $"No legacy available for <color=white>{bloodType}</color>.");
             return;
         }
 
@@ -221,7 +221,7 @@ internal static class BloodCommands
             Buffs.RefreshStats(playerCharacter);
 
             SetPlayerBool(steamId, freeKey, false);
-            LocalizationService.HandleReply(ctx, $"Your blood stats have been reset for <color=red>{bloodType}</color>!");
+            LocalizationService.Reply(ctx, $"Your blood stats have been reset for <color=red>{bloodType}</color>!");
             return;
         }
 
@@ -237,12 +237,12 @@ internal static class BloodCommands
                     ResetStats(steamId, bloodType);
                     Buffs.RefreshStats(playerCharacter);
 
-                    LocalizationService.HandleReply(ctx, $"Your blood stats have been reset for <color=red>{bloodType}</color>!");
+                    LocalizationService.Reply(ctx, $"Your blood stats have been reset for <color=red>{bloodType}</color>!");
                 }
             }
             else
             {
-                LocalizationService.HandleReply(ctx, $"You do not have the required item to reset your blood stats (<color=#ffd9eb>{item.GetLocalizedName()}</color>x<color=white>{quantity}</color>)");
+                LocalizationService.Reply(ctx, $"You do not have the required item to reset your blood stats (<color=#ffd9eb>{item.GetLocalizedName()}</color>x<color=white>{quantity}</color>)");
             }
         }
         else
@@ -250,7 +250,7 @@ internal static class BloodCommands
             ResetStats(steamId, bloodType);
             Buffs.RefreshStats(playerCharacter);
 
-            LocalizationService.HandleReply(ctx, $"Your blood stats have been reset for <color=red>{bloodType}</color>.");
+            LocalizationService.Reply(ctx, $"Your blood stats have been reset for <color=red>{bloodType}</color>.");
         }
     }
 
@@ -259,7 +259,7 @@ internal static class BloodCommands
     {
         if (!ConfigService.LegacySystem)
         {
-            LocalizationService.HandleReply(ctx, "Legacies are not enabled.");
+            LocalizationService.Reply(ctx, "Legacies are not enabled.");
             return;
         }
 
@@ -271,7 +271,7 @@ internal static class BloodCommands
 
         if (bloodStatsWithCaps.Count == 0)
         {
-            LocalizationService.HandleReply(ctx, "No blood stats available at this time.");
+            LocalizationService.Reply(ctx, "No blood stats available at this time.");
         }
         else
         {
@@ -279,7 +279,7 @@ internal static class BloodCommands
             {
                 var batch = bloodStatsWithCaps.Skip(i).Take(4);
                 string replyMessage = string.Join(", ", batch);
-                LocalizationService.HandleReply(ctx, replyMessage);
+                LocalizationService.Reply(ctx, replyMessage);
             }
         }
     }
@@ -289,34 +289,34 @@ internal static class BloodCommands
     {
         if (!ConfigService.LegacySystem)
         {
-            LocalizationService.HandleReply(ctx, "Blood Legacies are not enabled.");
+            LocalizationService.Reply(ctx, "Blood Legacies are not enabled.");
             return;
         }
 
         PlayerInfo playerInfo = GetPlayerInfo(name);
         if (!playerInfo.UserEntity.Exists())
         {
-            ctx.Reply($"Couldn't find player.");
+            LocalizationService.Reply(ctx, $"Couldn't find player.");
             return;
         }
 
         User foundUser = playerInfo.User;
         if (level < 0 || level > ConfigService.MaxBloodLevel)
         {
-            LocalizationService.HandleReply(ctx, $"Level must be between 0 and {ConfigService.MaxBloodLevel}.");
+            LocalizationService.Reply(ctx, $"Level must be between 0 and {ConfigService.MaxBloodLevel}.");
             return;
         }
 
         if (!Enum.TryParse<BloodType>(blood, true, out var bloodType))
         {
-            LocalizationService.HandleReply(ctx, "Invalid blood legacy.");
+            LocalizationService.Reply(ctx, "Invalid blood legacy.");
             return;
         }
 
         var BloodHandler = BloodLegacyFactory.GetBloodHandler(bloodType);
         if (BloodHandler == null)
         {
-            LocalizationService.HandleReply(ctx, "Invalid blood legacy.");
+            LocalizationService.Reply(ctx, "Invalid blood legacy.");
             return;
         }
 
@@ -325,7 +325,7 @@ internal static class BloodCommands
         BloodHandler.SetLegacyData(steamId, xpData);
 
         Buffs.RefreshStats(playerInfo.CharEntity);
-        LocalizationService.HandleReply(ctx, $"<color=red>{BloodHandler.GetBloodType()}</color> legacy set to [<color=white>{level}</color>] for <color=green>{foundUser.CharacterName}</color>");
+        LocalizationService.Reply(ctx, $"<color=red>{BloodHandler.GetBloodType()}</color> legacy set to [<color=white>{level}</color>] for <color=green>{foundUser.CharacterName}</color>");
     }
 
     [Command(name: "list", shortHand: "l", adminOnly: false, usage: ".bl l", description: "Lists blood legacies available.")]
@@ -333,7 +333,7 @@ internal static class BloodCommands
     {
         if (!ConfigService.LegacySystem)
         {
-            LocalizationService.HandleReply(ctx, "Blood Legacies are not enabled.");
+            LocalizationService.Reply(ctx, "Blood Legacies are not enabled.");
             return;
         }
 
@@ -344,6 +344,6 @@ internal static class BloodCommands
                               .Select(b => b.ToString());
 
         string bloodTypesList = string.Join(", ", bloodTypes);
-        LocalizationService.HandleReply(ctx, $"Available Blood Legacies: <color=red>{bloodTypesList}</color>");
+        LocalizationService.Reply(ctx, $"Available Blood Legacies: <color=red>{bloodTypesList}</color>");
     }
 }

--- a/Commands/ClassCommands.cs
+++ b/Commands/ClassCommands.cs
@@ -25,7 +25,7 @@ internal static class ClassCommands
     {
         if (!_classes)
         {
-            LocalizationService.HandleReply(ctx, "Classes are not enabled.");
+            LocalizationService.Reply(ctx, "Classes are not enabled.");
             return;
         }
 
@@ -42,16 +42,16 @@ internal static class ClassCommands
                 UpdatePlayerClass(playerCharacter, playerClass, steamId);
                 // ApplyClassBuffs(playerCharacter, steamId);
 
-                LocalizationService.HandleReply(ctx, $"You've selected {FormatClassName(playerClass)}!");
+                LocalizationService.Reply(ctx, $"You've selected {FormatClassName(playerClass)}!");
             }
             else
             {
-                LocalizationService.HandleReply(ctx, $"You've already selected {FormatClassName(currentClass.Value)}, use <color=white>'.class c [Class]'</color> to change. (<color=#ffd9eb>{new PrefabGUID(ConfigService.ChangeClassItem).GetLocalizedName()}</color>x<color=white>{ConfigService.ChangeClassQuantity}</color>)");
+                LocalizationService.Reply(ctx, $"You've already selected {FormatClassName(currentClass.Value)}, use <color=white>'.class c [Class]'</color> to change. (<color=#ffd9eb>{new PrefabGUID(ConfigService.ChangeClassItem).GetLocalizedName()}</color>x<color=white>{ConfigService.ChangeClassQuantity}</color>)");
             }
         }
         else
         {
-            LocalizationService.HandleReply(ctx, "Invalid class, use '<color=white>.class l</color>' to see options.");
+            LocalizationService.Reply(ctx, "Invalid class, use '<color=white>.class l</color>' to see options.");
         }
     }
 
@@ -60,13 +60,13 @@ internal static class ClassCommands
     {
         if (!_classes)
         {
-            LocalizationService.HandleReply(ctx, "Classes are not enabled.");
+            LocalizationService.Reply(ctx, "Classes are not enabled.");
             return;
         }
 
         if (!ConfigService.ShiftSlot)
         {
-            LocalizationService.HandleReply(ctx, "Shift spells are not enabled.");
+            LocalizationService.Reply(ctx, "Shift spells are not enabled.");
             return;
         }
 
@@ -74,7 +74,7 @@ internal static class ClassCommands
 
         if (!InventoryUtilities.TryGetInventoryEntity(EntityManager, playerCharacter, out Entity inventoryEntity) || InventoryUtilities.IsInventoryFull(EntityManager, inventoryEntity))
         {
-            LocalizationService.HandleReply(ctx, "Can't change or activate class spells when inventory is full, need at least one space to safely handle jewels when switching.");
+            LocalizationService.Reply(ctx, "Can't change or activate class spells when inventory is full, need at least one space to safely handle jewels when switching.");
             return;
         }
 
@@ -90,12 +90,12 @@ internal static class ClassCommands
 
                 if (spells.Count == 0)
                 {
-                    LocalizationService.HandleReply(ctx, $"No spells for {FormatClassName(playerClass.Value)} configured!");
+                    LocalizationService.Reply(ctx, $"No spells for {FormatClassName(playerClass.Value)} configured!");
                     return;
                 }
                 else if (choice < 0 || choice > spells.Count)
                 {
-                    LocalizationService.HandleReply(ctx, $"Invalid spell, use '<color=white>.class lsp</color>' to see options.");
+                    LocalizationService.Reply(ctx, $"Invalid spell, use '<color=white>.class lsp</color>' to see options.");
                     return;
                 }
 
@@ -103,12 +103,12 @@ internal static class ClassCommands
                 {
                     if (ConfigService.DefaultClassSpell == 0)
                     {
-                        LocalizationService.HandleReply(ctx, "No spell for class default configured!");
+                        LocalizationService.Reply(ctx, "No spell for class default configured!");
                         return;
                     }
                     else if (prestigeLevel < Configuration.ParseIntegersFromString(ConfigService.PrestigeLevelsToUnlockClassSpells)[choice])
                     {
-                        LocalizationService.HandleReply(ctx, "You don't have the required prestige level for that spell!");
+                        LocalizationService.Reply(ctx, "You don't have the required prestige level for that spell!");
                         return;
                     }
                     else if (steamId.TryGetPlayerSpells(out var data))
@@ -124,7 +124,7 @@ internal static class ClassCommands
                 }
                 else if (prestigeLevel < Configuration.ParseIntegersFromString(ConfigService.PrestigeLevelsToUnlockClassSpells)[choice])
                 {
-                    LocalizationService.HandleReply(ctx, "You don't have the required prestige level for that spell!");
+                    LocalizationService.Reply(ctx, "You don't have the required prestige level for that spell!");
                     return;
                 }
                 else if (steamId.TryGetPlayerSpells(out var spellsData))
@@ -141,12 +141,12 @@ internal static class ClassCommands
 
                 if (spells.Count == 0)
                 {
-                    LocalizationService.HandleReply(ctx, $"No spells for {FormatClassName(playerClass.Value)} configured!");
+                    LocalizationService.Reply(ctx, $"No spells for {FormatClassName(playerClass.Value)} configured!");
                     return;
                 }
                 else if (choice < 0 || choice > spells.Count)
                 {
-                    LocalizationService.HandleReply(ctx, $"Invalid spell, use <color=white>'.class lsp'</color> to see options.");
+                    LocalizationService.Reply(ctx, $"Invalid spell, use <color=white>'.class lsp'</color> to see options.");
                     return;
                 }
 
@@ -156,7 +156,7 @@ internal static class ClassCommands
                     {
                         if (ConfigService.DefaultClassSpell == 0)
                         {
-                            LocalizationService.HandleReply(ctx, "No spell for class default configured!");
+                            LocalizationService.Reply(ctx, "No spell for class default configured!");
                             return;
                         }
 
@@ -181,7 +181,7 @@ internal static class ClassCommands
         }
         else
         {
-            LocalizationService.HandleReply(ctx, "You haven't selected a class or you haven't activated shift spells! (<color=white>'.class s [Class]'</color> | <color=white>'.class shift'</color>)");
+            LocalizationService.Reply(ctx, "You haven't selected a class or you haven't activated shift spells! (<color=white>'.class s [Class]'</color> | <color=white>'.class shift'</color>)");
         }
     }
 
@@ -190,7 +190,7 @@ internal static class ClassCommands
     {
         if (!_classes)
         {
-            LocalizationService.HandleReply(ctx, "Classes are not enabled.");
+            LocalizationService.Reply(ctx, "Classes are not enabled.");
             return;
         }
 
@@ -205,13 +205,13 @@ internal static class ClassCommands
 
             if (!steamId.HasClass(out PlayerClass? currentClass) || !currentClass.HasValue)
             {
-                LocalizationService.HandleReply(ctx, "You haven't selected a class yet, use <color=white>'.class s [Class]'</color> instead.");
+                LocalizationService.Reply(ctx, "You haven't selected a class yet, use <color=white>'.class s [Class]'</color> instead.");
                 return;
             }
 
             if (GetPlayerBool(steamId, CLASS_BUFFS_KEY))
             {
-                LocalizationService.HandleReply(ctx, "You have class buffs enabled, use <color=white>'.class passives'</color> to disable them before changing classes!");
+                LocalizationService.Reply(ctx, "You have class buffs enabled, use <color=white>'.class passives'</color> to disable them before changing classes!");
                 return;
             }
 
@@ -221,11 +221,11 @@ internal static class ClassCommands
             }
 
             UpdatePlayerClass(playerCharacter, playerClass, steamId);
-            LocalizationService.HandleReply(ctx, $"Class changed to {FormatClassName(playerClass)}!");
+            LocalizationService.Reply(ctx, $"Class changed to {FormatClassName(playerClass)}!");
         }
         else
         {
-            LocalizationService.HandleReply(ctx, "Invalid class, use '<color=white>.class l</color>' to see options.");
+            LocalizationService.Reply(ctx, "Invalid class, use '<color=white>.class l</color>' to see options.");
         }
     }
 
@@ -234,7 +234,7 @@ internal static class ClassCommands
     {
         if (!_classes)
         {
-            LocalizationService.HandleReply(ctx, "Classes are not enabled.");
+            LocalizationService.Reply(ctx, "Classes are not enabled.");
             return;
         }
 
@@ -244,7 +244,7 @@ internal static class ClassCommands
         }).ToList();
 
         string classTypes = string.Join(", ", classes);
-        LocalizationService.HandleReply(ctx, $"Classes: {classTypes}");
+        LocalizationService.Reply(ctx, $"Classes: {classTypes}");
     }
 
     [Command(name: "listspells", shortHand: "lsp", adminOnly: false, usage: ".class lsp [Class]", description: "Shows spells that can be gained from class.")]
@@ -252,7 +252,7 @@ internal static class ClassCommands
     {
         if (!_classes)
         {
-            LocalizationService.HandleReply(ctx, "Classes are not enabled.");
+            LocalizationService.Reply(ctx, "Classes are not enabled.");
             return;
         }
 
@@ -271,7 +271,7 @@ internal static class ClassCommands
         /*
         else
         {
-            LocalizationService.HandleReply(ctx, "Invalid class, use '<color=white>.class l</color>' to see options.");
+            LocalizationService.Reply(ctx, "Invalid class, use '<color=white>.class l</color>' to see options.");
         }
 
         ulong steamId = ctx.Event.User.PlatformId;
@@ -294,7 +294,7 @@ internal static class ClassCommands
             }
             else
             {
-                LocalizationService.HandleReply(ctx, "Invalid class, use <color=white>'.class l'</color> to see options.");
+                LocalizationService.Reply(ctx, "Invalid class, use <color=white>'.class l'</color> to see options.");
             }
         }
         */
@@ -305,7 +305,7 @@ internal static class ClassCommands
     {
         if (!_classes)
         {
-            LocalizationService.HandleReply(ctx, "Classes are not enabled.");
+            LocalizationService.Reply(ctx, "Classes are not enabled.");
             return;
         }
 
@@ -322,7 +322,7 @@ internal static class ClassCommands
         }
         else
         {
-            LocalizationService.HandleReply(ctx, "Invalid class, use '<color=white>.class l</color>' to see options.");
+            LocalizationService.Reply(ctx, "Invalid class, use '<color=white>.class l</color>' to see options.");
         }
 
         /*
@@ -346,7 +346,7 @@ internal static class ClassCommands
             }
             else
             {
-                LocalizationService.HandleReply(ctx, "Invalid class, use <color=white>'.class l'</color> to see options.");
+                LocalizationService.Reply(ctx, "Invalid class, use <color=white>'.class l'</color> to see options.");
             }
         }
         */
@@ -357,13 +357,13 @@ internal static class ClassCommands
     {
         if (!_classes)
         {
-            LocalizationService.HandleReply(ctx, "Classes are not enabled and spells can't be set to shift.");
+            LocalizationService.Reply(ctx, "Classes are not enabled and spells can't be set to shift.");
             return;
         }
 
         if (!ConfigService.ShiftSlot)
         {
-            LocalizationService.HandleReply(ctx, "Shift slots are not enabled.");
+            LocalizationService.Reply(ctx, "Shift slots are not enabled.");
             return;
         }
 
@@ -374,7 +374,7 @@ internal static class ClassCommands
 
         if (!InventoryUtilities.TryGetInventoryEntity(EntityManager, character, out Entity inventoryEntity) || InventoryUtilities.IsInventoryFull(EntityManager, inventoryEntity))
         {
-            LocalizationService.HandleReply(ctx, "Can't change or active class spells when inventory is full, need at least one space to safely handle jewels when switching.");
+            LocalizationService.Reply(ctx, "Can't change or active class spells when inventory is full, need at least one space to safely handle jewels when switching.");
             return;
         }
 
@@ -391,13 +391,13 @@ internal static class ClassCommands
                 }
             }
 
-            LocalizationService.HandleReply(ctx, "Shift spell <color=green>enabled</color>!");
+            LocalizationService.Reply(ctx, "Shift spell <color=green>enabled</color>!");
         }
         else
         {
             RemoveShift(ctx.Event.SenderCharacterEntity);
 
-            LocalizationService.HandleReply(ctx, "Shift spell <color=red>disabled</color>!");
+            LocalizationService.Reply(ctx, "Shift spell <color=red>disabled</color>!");
         }
     }
 }

--- a/Commands/FamiliarCommands.cs
+++ b/Commands/FamiliarCommands.cs
@@ -72,7 +72,7 @@ internal static class FamiliarCommands
     {
         if (!ConfigService.FamiliarSystem)
         {
-            LocalizationService.HandleReply(ctx, "Familiars are not enabled.");
+            LocalizationService.Reply(ctx, "Familiars are not enabled.");
             return;
         }
 
@@ -87,7 +87,7 @@ internal static class FamiliarCommands
     {
         if (!ConfigService.FamiliarSystem)
         {
-            LocalizationService.HandleReply(ctx, "Familiars are not enabled.");
+            LocalizationService.Reply(ctx, "Familiars are not enabled.");
             return;
         }
 
@@ -102,7 +102,7 @@ internal static class FamiliarCommands
     {
         if (!ConfigService.FamiliarSystem)
         {
-            LocalizationService.HandleReply(ctx, "Familiars are not enabled.");
+            LocalizationService.Reply(ctx, "Familiars are not enabled.");
             return;
         }
 
@@ -118,7 +118,7 @@ internal static class FamiliarCommands
         if (!string.IsNullOrEmpty(box) && familiarUnlocksData.FamiliarUnlocks.TryGetValue(box, out var famKeys))
         {
             int count = 1;
-            LocalizationService.HandleReply(ctx, $"<color=white>{box}</color>:");
+            LocalizationService.Reply(ctx, $"<color=white>{box}</color>:");
 
             foreach (var famKey in famKeys)
             {
@@ -139,14 +139,14 @@ internal static class FamiliarCommands
                 int prestiges = familiarPrestigeData_V2.FamiliarPrestige.TryGetValue(famKey, out var prestigeData) ? prestigeData : 0;
 
                 string levelAndPrestiges = prestiges > 0 ? $"[<color=white>{level}</color>][<color=#90EE90>{prestiges}</color>]" : $"[<color=white>{level}</color>]";
-                LocalizationService.HandleReply(ctx, $"<color=yellow>{count}</color>| <color=green>{famName}</color>{(familiarBuffsData.FamiliarBuffs.ContainsKey(famKey) ? $"{colorCode}*</color> {levelAndPrestiges}" : $" {levelAndPrestiges}")}");
+                LocalizationService.Reply(ctx, $"<color=yellow>{count}</color>| <color=green>{famName}</color>{(familiarBuffsData.FamiliarBuffs.ContainsKey(famKey) ? $"{colorCode}*</color> {levelAndPrestiges}" : $" {levelAndPrestiges}")}");
                 count++;
             }
         }
         else if (string.IsNullOrEmpty(box))
         {
-            // LocalizationService.HandleReply(ctx, "No active box! Try using <color=white>'.fam sb [Name]'</color> if you know the familiar you're looking for. (use quotes for names with a space)");
-            LocalizationService.HandleReply(ctx, "Couldn't find active box!");
+            // LocalizationService.Reply(ctx, "No active box! Try using <color=white>'.fam sb [Name]'</color> if you know the familiar you're looking for. (use quotes for names with a space)");
+            LocalizationService.Reply(ctx, "Couldn't find active box!");
         }
     }
 
@@ -155,7 +155,7 @@ internal static class FamiliarCommands
     {
         if (!ConfigService.FamiliarSystem)
         {
-            LocalizationService.HandleReply(ctx, "Familiars are not enabled.");
+            LocalizationService.Reply(ctx, "Familiars are not enabled.");
             return;
         }
 
@@ -170,7 +170,7 @@ internal static class FamiliarCommands
                 sets.Add(key);
             }
 
-            LocalizationService.HandleReply(ctx, $"Familiar Boxes:");
+            LocalizationService.Reply(ctx, $"Familiar Boxes:");
 
             List<string> colorizedBoxes = [..sets.Select(set => $"<color=white>{set}</color>")];
             const int maxPerMessage = 6;
@@ -179,12 +179,12 @@ internal static class FamiliarCommands
                 var batch = colorizedBoxes.Skip(i).Take(maxPerMessage);
                 string fams = string.Join(", ", batch);
 
-                LocalizationService.HandleReply(ctx, $"{fams}");
+                LocalizationService.Reply(ctx, $"{fams}");
             }
         }
         else
         {
-            LocalizationService.HandleReply(ctx, "You don't have any unlocks yet!");
+            LocalizationService.Reply(ctx, "You don't have any unlocks yet!");
         }
     }
 
@@ -193,7 +193,7 @@ internal static class FamiliarCommands
     {
         if (!ConfigService.FamiliarSystem)
         {
-            LocalizationService.HandleReply(ctx, "Familiars are not enabled.");
+            LocalizationService.Reply(ctx, "Familiars are not enabled.");
             return;
         }
 
@@ -203,11 +203,11 @@ internal static class FamiliarCommands
         if (data.FamiliarUnlocks.TryGetValue(name, out var _))
         {
             steamId.SetFamiliarBox(name);
-            LocalizationService.HandleReply(ctx, $"Box Selected - <color=white>{name}</color>");
+            LocalizationService.Reply(ctx, $"Box Selected - <color=white>{name}</color>");
         }
         else
         {
-            LocalizationService.HandleReply(ctx, "Couldn't find box!");
+            LocalizationService.Reply(ctx, "Couldn't find box!");
         }
     }
 
@@ -216,7 +216,7 @@ internal static class FamiliarCommands
     {
         if (!ConfigService.FamiliarSystem)
         {
-            LocalizationService.HandleReply(ctx, "Familiars are not enabled.");
+            LocalizationService.Reply(ctx, "Familiars are not enabled.");
             return;
         }
 
@@ -238,11 +238,11 @@ internal static class FamiliarCommands
 
             // Save changes back to the FamiliarUnlocksManager
             SaveFamiliarUnlocksData(steamId, data);
-            LocalizationService.HandleReply(ctx, $"Box <color=white>{current}</color> renamed - <color=yellow>{name}</color>");
+            LocalizationService.Reply(ctx, $"Box <color=white>{current}</color> renamed - <color=yellow>{name}</color>");
         }
         else
         {
-            LocalizationService.HandleReply(ctx, "Couldn't find box to rename or there's already a box with that name!");
+            LocalizationService.Reply(ctx, "Couldn't find box to rename or there's already a box with that name!");
         }
     }
 
@@ -251,7 +251,7 @@ internal static class FamiliarCommands
     {
         if (!ConfigService.FamiliarSystem)
         {
-            LocalizationService.HandleReply(ctx, "Familiars are not enabled.");
+            LocalizationService.Reply(ctx, "Familiars are not enabled.");
             return;
         }
 
@@ -279,16 +279,16 @@ internal static class FamiliarCommands
                 }
 
                 PrefabGUID PrefabGUID = new(familiarId);
-                LocalizationService.HandleReply(ctx, $"<color=green>{PrefabGUID.GetLocalizedName()}</color> moved - <color=white>{name}</color>");
+                LocalizationService.Reply(ctx, $"<color=green>{PrefabGUID.GetLocalizedName()}</color> moved - <color=white>{name}</color>");
             }
         }
         else if (data.FamiliarUnlocks.ContainsKey(name))
         {
-            LocalizationService.HandleReply(ctx, "Box is full!");
+            LocalizationService.Reply(ctx, "Box is full!");
         }
         else
         {
-            LocalizationService.HandleReply(ctx, "Couldn't find box!");
+            LocalizationService.Reply(ctx, "Couldn't find box!");
         }
     }
 
@@ -297,7 +297,7 @@ internal static class FamiliarCommands
     {
         if (!ConfigService.FamiliarSystem)
         {
-            LocalizationService.HandleReply(ctx, "Familiars are not enabled.");
+            LocalizationService.Reply(ctx, "Familiars are not enabled.");
             return;
         }
 
@@ -310,15 +310,15 @@ internal static class FamiliarCommands
             data.FamiliarUnlocks.Remove(name);
             SaveFamiliarUnlocksData(steamId, data);
 
-            LocalizationService.HandleReply(ctx, $"Deleted box - <color=white>{name}</color>");
+            LocalizationService.Reply(ctx, $"Deleted box - <color=white>{name}</color>");
         }
         else if (data.FamiliarUnlocks.ContainsKey(name))
         {
-            LocalizationService.HandleReply(ctx, "Box is not empty!");
+            LocalizationService.Reply(ctx, "Box is not empty!");
         }
         else
         {
-            LocalizationService.HandleReply(ctx, "Couldn't find box!");
+            LocalizationService.Reply(ctx, "Couldn't find box!");
         }
     }
 
@@ -327,7 +327,7 @@ internal static class FamiliarCommands
     {
         if (!ConfigService.FamiliarSystem)
         {
-            LocalizationService.HandleReply(ctx, "Familiars are not enabled.");
+            LocalizationService.Reply(ctx, "Familiars are not enabled.");
             return;
         }
 
@@ -340,11 +340,11 @@ internal static class FamiliarCommands
             data.FamiliarUnlocks.Add(name, []);
             SaveFamiliarUnlocksData(steamId, data);
 
-            LocalizationService.HandleReply(ctx, $"Added box - <color=white>{name}</color>");
+            LocalizationService.Reply(ctx, $"Added box - <color=white>{name}</color>");
         }
         else
         {
-            LocalizationService.HandleReply(ctx, $"Must have at least one unit unlocked to start adding boxes. Additionally, the total number of boxes cannot exceed <color=yellow>{BOX_CAP}</color>.");
+            LocalizationService.Reply(ctx, $"Must have at least one unit unlocked to start adding boxes. Additionally, the total number of boxes cannot exceed <color=yellow>{BOX_CAP}</color>.");
         }
     }
 
@@ -353,14 +353,14 @@ internal static class FamiliarCommands
     {
         if (!ConfigService.FamiliarSystem)
         {
-            LocalizationService.HandleReply(ctx, "Familiars are not enabled.");
+            LocalizationService.Reply(ctx, "Familiars are not enabled.");
             return;
         }
 
         PlayerInfo playerInfo = GetPlayerInfo(name);
         if (!playerInfo.UserEntity.Exists())
         {
-            ctx.Reply($"Couldn't find player.");
+            LocalizationService.Reply(ctx, $"Couldn't find player.");
             return;
         }
 
@@ -397,17 +397,17 @@ internal static class FamiliarCommands
     {
         if (!ConfigService.FamiliarSystem)
         {
-            LocalizationService.HandleReply(ctx, "Familiars are not enabled.");
+            LocalizationService.Reply(ctx, "Familiars are not enabled.");
             return;
         }
         else if (!ConfigService.AllowVBloods)
         {
-            LocalizationService.HandleReply(ctx, "VBlood familiars are not enabled.");
+            LocalizationService.Reply(ctx, "VBlood familiars are not enabled.");
             return;
         }
         else if (!ConfigService.PrimalEchoes)
         {
-            LocalizationService.HandleReply(ctx, "VBlood purchasing is not enabled.");
+            LocalizationService.Reply(ctx, "VBlood purchasing is not enabled.");
             return;
         }
 
@@ -417,12 +417,12 @@ internal static class FamiliarCommands
 
         if (!vBloodPrefabGuids.Any())
         {
-            LocalizationService.HandleReply(ctx, "Couldn't find matching vBlood!");
+            LocalizationService.Reply(ctx, "Couldn't find matching vBlood!");
             return;
         }
         else if (vBloodPrefabGuids.Count > 1)
         {
-            LocalizationService.HandleReply(ctx, "Multiple matches, please be more specific!");
+            LocalizationService.Reply(ctx, "Multiple matches, please be more specific!");
             return;
         }
 
@@ -430,7 +430,7 @@ internal static class FamiliarCommands
 
         if (IsBannedPrefabGuid(vBloodPrefabGuid))
         {
-            LocalizationService.HandleReply(ctx, $"<color=white>{vBloodPrefabGuid.GetLocalizedName()}</color> is not available per configured familiar bans!");
+            LocalizationService.Reply(ctx, $"<color=white>{vBloodPrefabGuid.GetLocalizedName()}</color> is not available per configured familiar bans!");
             return;
         }
         else
@@ -442,7 +442,7 @@ internal static class FamiliarCommands
 
                 if (unlocksData.FamiliarUnlocks.Values.Any(list => list.Contains(vBloodPrefabGuid.GuidHash)))
                 {
-                    LocalizationService.HandleReply(ctx, $"<color=white>{vBloodPrefabGuid.GetLocalizedName()}</color> is already unlocked!");
+                    LocalizationService.Reply(ctx, $"<color=white>{vBloodPrefabGuid.GetLocalizedName()}</color> is already unlocked!");
                     return;
                 }
 
@@ -458,11 +458,11 @@ internal static class FamiliarCommands
 
                 if (factoredCost <= 0)
                 {
-                    LocalizationService.HandleReply(ctx, $"Unable to verify cost for {vBloodPrefabGuid.GetPrefabName()}!");
+                    LocalizationService.Reply(ctx, $"Unable to verify cost for {vBloodPrefabGuid.GetPrefabName()}!");
                 }
                 else if (!PrefabCollectionSystem._PrefabGuidToEntityMap.ContainsKey(exoItem))
                 {
-                    LocalizationService.HandleReply(ctx, $"Unable to verify exo prestige reward item! (<color=yellow>{exoItem}</color>)");
+                    LocalizationService.Reply(ctx, $"Unable to verify exo prestige reward item! (<color=yellow>{exoItem}</color>)");
                 }
                 else if (InventoryUtilities.TryGetInventoryEntity(EntityManager, ctx.Event.SenderCharacterEntity, out Entity inventoryEntity) && ServerGameManager.GetInventoryItemCount(inventoryEntity, exoItem) >= factoredCost)
                 {
@@ -478,25 +478,25 @@ internal static class FamiliarCommands
                             unlocksData.FamiliarUnlocks[lastBoxName].Add(vBloodPrefabGuid.GuidHash);
 
                             SaveFamiliarUnlocksData(steamId, unlocksData);
-                            LocalizationService.HandleReply(ctx, $"New unit unlocked: <color=green>{vBloodPrefabGuid.GetLocalizedName()}</color>");
+                            LocalizationService.Reply(ctx, $"New unit unlocked: <color=green>{vBloodPrefabGuid.GetLocalizedName()}</color>");
                         }
                         else if (unlocksData.FamiliarUnlocks.ContainsKey(lastBoxName))
                         {
                             unlocksData.FamiliarUnlocks[lastBoxName].Add(vBloodPrefabGuid.GuidHash);
 
                             SaveFamiliarUnlocksData(steamId, unlocksData);
-                            LocalizationService.HandleReply(ctx, $"New unit unlocked: <color=green>{vBloodPrefabGuid.GetLocalizedName()}</color>");
+                            LocalizationService.Reply(ctx, $"New unit unlocked: <color=green>{vBloodPrefabGuid.GetLocalizedName()}</color>");
                         }
                     }
                 }
                 else
                 {
-                    LocalizationService.HandleReply(ctx, $"Not enough <color=#ffd9eb>{exoItem.GetLocalizedName()}</color>x<color=white>{factoredCost}</color> for {vBloodPrefabGuid.GetPrefabName()}!");
+                    LocalizationService.Reply(ctx, $"Not enough <color=#ffd9eb>{exoItem.GetLocalizedName()}</color>x<color=white>{factoredCost}</color> for {vBloodPrefabGuid.GetPrefabName()}!");
                 }
             }
             else
             {
-                LocalizationService.HandleReply(ctx, $"Unable to verify tier for {vBloodPrefabGuid.GetPrefabName()}! Shouldn't really happen at this point and may want to inform the developer.");
+                LocalizationService.Reply(ctx, $"Unable to verify tier for {vBloodPrefabGuid.GetPrefabName()}! Shouldn't really happen at this point and may want to inform the developer.");
                 return;
             }
         }
@@ -507,7 +507,7 @@ internal static class FamiliarCommands
     {
         if (!ConfigService.FamiliarSystem)
         {
-            LocalizationService.HandleReply(ctx, "Familiars are not enabled.");
+            LocalizationService.Reply(ctx, "Familiars are not enabled.");
             return;
         }
 
@@ -518,7 +518,7 @@ internal static class FamiliarCommands
         {
             if (choice < 1 || choice > familiarSet.Count)
             {
-                LocalizationService.HandleReply(ctx, $"Invalid choice, please use <color=white>1</color> to <color=white>{familiarSet.Count}</color> (Current List:<color=yellow>{activeBox}</color>)");
+                LocalizationService.Reply(ctx, $"Invalid choice, please use <color=white>1</color> to <color=white>{familiarSet.Count}</color> (Current List:<color=yellow>{activeBox}</color>)");
                 return;
             }
 
@@ -527,11 +527,11 @@ internal static class FamiliarCommands
             familiarSet.RemoveAt(choice - 1);
             SaveFamiliarUnlocksData(steamId, data);
 
-            LocalizationService.HandleReply(ctx, $"<color=green>{familiarId.GetLocalizedName()}</color> removed from <color=white>{activeBox}</color>.");
+            LocalizationService.Reply(ctx, $"<color=green>{familiarId.GetLocalizedName()}</color> removed from <color=white>{activeBox}</color>.");
         }
         else
         {
-            LocalizationService.HandleReply(ctx, "Couldn't find active familiar box to remove from...");
+            LocalizationService.Reply(ctx, "Couldn't find active familiar box to remove from...");
         }
     }
 
@@ -540,7 +540,7 @@ internal static class FamiliarCommands
     {
         if (!ConfigService.FamiliarSystem)
         {
-            LocalizationService.HandleReply(ctx, "Familiars are not enabled.");
+            LocalizationService.Reply(ctx, "Familiars are not enabled.");
             return;
         }
 
@@ -549,12 +549,12 @@ internal static class FamiliarCommands
 
         if (ServerGameManager.HasBuff(playerCharacter, _dominateBuff.ToIdentifier()))
         {
-            LocalizationService.HandleReply(ctx, "You can't call a familiar when using dominating presence!");
+            LocalizationService.Reply(ctx, "You can't call a familiar when using dominating presence!");
             return;
         }
         else if (ServerGameManager.HasBuff(playerCharacter, _takeFlightBuff.ToIdentifier()))
         {
-            LocalizationService.HandleReply(ctx, "You can't call a familiar when using batform!");
+            LocalizationService.Reply(ctx, "You can't call a familiar when using batform!");
             return;
         }
 
@@ -566,7 +566,7 @@ internal static class FamiliarCommands
     {
         if (!ConfigService.FamiliarSystem)
         {
-            LocalizationService.HandleReply(ctx, "Familiars are not enabled.");
+            LocalizationService.Reply(ctx, "Familiars are not enabled.");
             return;
         }
 
@@ -574,17 +574,17 @@ internal static class FamiliarCommands
 
         if (ServerGameManager.HasBuff(playerCharacter, _dominateBuff.ToIdentifier()))
         {
-            LocalizationService.HandleReply(ctx, "You can't toggle combat for a familiar when using dominating presence!");
+            LocalizationService.Reply(ctx, "You can't toggle combat for a familiar when using dominating presence!");
             return;
         }
         else if (ServerGameManager.HasBuff(playerCharacter, _takeFlightBuff.ToIdentifier()))
         {
-            LocalizationService.HandleReply(ctx, "You can't toggle combat for a familiar when using batform!");
+            LocalizationService.Reply(ctx, "You can't toggle combat for a familiar when using batform!");
             return;
         }
         else if (playerCharacter.HasBuff(_pveCombatBuff) || playerCharacter.HasBuff(_pvpCombatBuff))
         {
-            LocalizationService.HandleReply(ctx, "You can't toggle combat for a familiar in PvP/PvE combat!");
+            LocalizationService.Reply(ctx, "You can't toggle combat for a familiar in PvP/PvE combat!");
             return;
         }
 
@@ -597,14 +597,14 @@ internal static class FamiliarCommands
     {
         if (!ConfigService.FamiliarSystem)
         {
-            LocalizationService.HandleReply(ctx, "Familiars are not enabled.");
+            LocalizationService.Reply(ctx, "Familiars are not enabled.");
             return;
         }
 
         ulong steamId = ctx.User.PlatformId;
         TogglePlayerBool(steamId, EMOTE_ACTIONS_KEY);
 
-        LocalizationService.HandleReply(ctx, $"Emote actions {(GetPlayerBool(steamId, EMOTE_ACTIONS_KEY) ? "<color=green>enabled</color>" : "<color=red>disabled</color>")}!");
+        LocalizationService.Reply(ctx, $"Emote actions {(GetPlayerBool(steamId, EMOTE_ACTIONS_KEY) ? "<color=green>enabled</color>" : "<color=red>disabled</color>")}!");
     }
 
     [Command(name: "emoteactions", shortHand: "actions", usage: ".fam actions", description: "Shows available emote actions.", adminOnly: false)]
@@ -612,7 +612,7 @@ internal static class FamiliarCommands
     {
         if (!ConfigService.FamiliarSystem)
         {
-            LocalizationService.HandleReply(ctx, "Familiars are not enabled.");
+            LocalizationService.Reply(ctx, "Familiars are not enabled.");
             return;
         }
 
@@ -627,7 +627,7 @@ internal static class FamiliarCommands
         }
 
         string emotes = string.Join(", ", emoteInfoList);
-        LocalizationService.HandleReply(ctx, emotes);
+        LocalizationService.Reply(ctx, emotes);
     }
 
     [Command(name: "getlevel", shortHand: "gl", adminOnly: false, usage: ".fam gl", description: "Display current familiar leveling progress.")]
@@ -635,7 +635,7 @@ internal static class FamiliarCommands
     {
         if (!ConfigService.FamiliarSystem)
         {
-            LocalizationService.HandleReply(ctx, "Familiars are not enabled.");
+            LocalizationService.Reply(ctx, "Familiars are not enabled.");
             return;
         }
 
@@ -667,7 +667,7 @@ internal static class FamiliarCommands
                 prestigeLevel = prestigeData.FamiliarPrestige[familiarId];
             }
 
-            LocalizationService.HandleReply(ctx, $"Your familiar is level [<color=white>{xpData.Key}</color>][<color=#90EE90>{prestigeLevel}</color>] and has <color=yellow>{progress}</color> <color=#FFC0CB>experience</color> (<color=white>{percent}%</color>)!");
+            LocalizationService.Reply(ctx, $"Your familiar is level [<color=white>{xpData.Key}</color>][<color=#90EE90>{prestigeLevel}</color>] and has <color=yellow>{progress}</color> <color=#FFC0CB>experience</color> (<color=white>{percent}%</color>)!");
             
             if (familiar.Exists())
             {
@@ -773,7 +773,7 @@ internal static class FamiliarCommands
                 string familiarName = GetFamiliarName(familiarId, buffsData);
 
                 string infoHeader = string.IsNullOrEmpty(shinyInfo) ? $"{familiarName}:" : $"{familiarName} - {shinyInfo}";
-                LocalizationService.HandleReply(ctx, infoHeader);
+                LocalizationService.Reply(ctx, infoHeader);
 
                 for (int i = 0; i < statPairs.Count; i += 4)
                 {
@@ -783,13 +783,13 @@ internal static class FamiliarCommands
                         batch.Select(stat => $"<color=#00FFFF>{stat.Key}</color>: <color=white>{stat.Value}</color>")
                     );
 
-                    LocalizationService.HandleReply(ctx, $"{line}");
+                    LocalizationService.Reply(ctx, $"{line}");
                 }
             }
         }
         else
         {
-            LocalizationService.HandleReply(ctx, "Couldn't find active familiar!");
+            LocalizationService.Reply(ctx, "Couldn't find active familiar!");
         }
     }
 
@@ -798,20 +798,20 @@ internal static class FamiliarCommands
     {
         if (!ConfigService.FamiliarSystem)
         {
-            LocalizationService.HandleReply(ctx, "Familiars are not enabled.");
+            LocalizationService.Reply(ctx, "Familiars are not enabled.");
             return;
         }
 
         if (level < 1 || level > ConfigService.MaxFamiliarLevel)
         {
-            LocalizationService.HandleReply(ctx, $"Level must be between 1 and {ConfigService.MaxFamiliarLevel}");
+            LocalizationService.Reply(ctx, $"Level must be between 1 and {ConfigService.MaxFamiliarLevel}");
             return;
         }
 
         PlayerInfo playerInfo = GetPlayerInfo(name);
         if (!playerInfo.UserEntity.Exists())
         {
-            ctx.Reply($"Couldn't find player.");
+            LocalizationService.Reply(ctx, $"Couldn't find player.");
             return;
         }
 
@@ -833,12 +833,12 @@ internal static class FamiliarCommands
 
             if (ModifyFamiliar(user, steamId, familiarId, playerCharacter, familiar, level))
             {
-                LocalizationService.HandleReply(ctx, $"Active familiar for <color=green>{user.CharacterName.Value}</color> has been set to level <color=white>{level}</color>.");
+                LocalizationService.Reply(ctx, $"Active familiar for <color=green>{user.CharacterName.Value}</color> has been set to level <color=white>{level}</color>.");
             }
         }
         else
         {
-            LocalizationService.HandleReply(ctx, "Couldn't find active familiar....");
+            LocalizationService.Reply(ctx, "Couldn't find active familiar....");
         }
     }
 
@@ -847,13 +847,13 @@ internal static class FamiliarCommands
     {
         if (!ConfigService.FamiliarSystem)
         {
-            LocalizationService.HandleReply(ctx, "Familiars are not enabled.");
+            LocalizationService.Reply(ctx, "Familiars are not enabled.");
             return;
         }
 
         if (!ConfigService.FamiliarPrestige)
         {
-            LocalizationService.HandleReply(ctx, "Familiar prestige is not enabled.");
+            LocalizationService.Reply(ctx, "Familiar prestige is not enabled.");
             return;
         }
 
@@ -887,7 +887,7 @@ internal static class FamiliarCommands
 
                 if (prestigeData.FamiliarPrestige[familiarId] >= ConfigService.MaxFamiliarPrestiges)
                 {
-                    LocalizationService.HandleReply(ctx, "Familiar is already at maximum number of prestiges!");
+                    LocalizationService.Reply(ctx, "Familiar is already at maximum number of prestiges!");
                     return;
                 }
 
@@ -900,7 +900,7 @@ internal static class FamiliarCommands
 
                         if (value < 1 || value > length)
                         {
-                            LocalizationService.HandleReply(ctx, $"Invalid familiar prestige stat type, use '<color=white>.fam lst</color>' to see options.");
+                            LocalizationService.Reply(ctx, $"Invalid familiar prestige stat type, use '<color=white>.fam lst</color>' to see options.");
                             return;
                         }
                         
@@ -912,19 +912,19 @@ internal static class FamiliarCommands
                         }
                         else
                         {
-                            LocalizationService.HandleReply(ctx, $"Familiar already has <color=#00FFFF>{FamiliarPrestigeStats[value]}</color> (<color=yellow>{value + 1}</color>) from prestiging, use '<color=white>.fam lst</color>' to see options.");
+                            LocalizationService.Reply(ctx, $"Familiar already has <color=#00FFFF>{FamiliarPrestigeStats[value]}</color> (<color=yellow>{value + 1}</color>) from prestiging, use '<color=white>.fam lst</color>' to see options.");
                             return;
                         }
                     }
                     else
                     {
-                        LocalizationService.HandleReply(ctx, $"Invalid familiar prestige stat, use '<color=white>.fam lst</color>' to see options.");
+                        LocalizationService.Reply(ctx, $"Invalid familiar prestige stat, use '<color=white>.fam lst</color>' to see options.");
                         return;
                     }
                 }
                 else if (stats.Count >= FamiliarPrestigeStats.Count && !string.IsNullOrEmpty(statType))
                 {
-                    LocalizationService.HandleReply(ctx, "Familiar already has all prestige stats! ('<color=white>.fam pr</color>' instead of '<color=white>.fam pr [PrestigeStat]</color>')");
+                    LocalizationService.Reply(ctx, "Familiar already has all prestige stats! ('<color=white>.fam pr</color>' instead of '<color=white>.fam pr [PrestigeStat]</color>')");
                     return;
                 }
                 */
@@ -940,27 +940,27 @@ internal static class FamiliarCommands
                 Entity familiar = GetActiveFamiliar(playerCharacter);
                 ModifyUnitStats(familiar, newXP.Key, steamId, familiarId);
 
-                LocalizationService.HandleReply(ctx, $"Your familiar has prestiged [<color=#90EE90>{prestigeLevel}</color>]!");
+                LocalizationService.Reply(ctx, $"Your familiar has prestiged [<color=#90EE90>{prestigeLevel}</color>]!");
 
                 /*
                 if (value == -1)
                 {
-                    LocalizationService.HandleReply(ctx, $"Your familiar has prestiged [<color=#90EE90>{prestigeLevel}</color>] and is now level <color=white>{newXP.Key}</color>!");
+                    LocalizationService.Reply(ctx, $"Your familiar has prestiged [<color=#90EE90>{prestigeLevel}</color>] and is now level <color=white>{newXP.Key}</color>!");
                 }
                 else
                 {
-                    LocalizationService.HandleReply(ctx, $"Your familiar has prestiged [<color=#90EE90>{prestigeLevel}</color>] and is now level <color=white>{newXP.Key}</color>! (+<color=#00FFFF>{FamiliarPrestigeStats[value]}</color>)");
+                    LocalizationService.Reply(ctx, $"Your familiar has prestiged [<color=#90EE90>{prestigeLevel}</color>] and is now level <color=white>{newXP.Key}</color>! (+<color=#00FFFF>{FamiliarPrestigeStats[value]}</color>)");
                 }
                 */
             }
             else
             {
-                LocalizationService.HandleReply(ctx, $"Familiar attempting to prestige must be at max level (<color=white>{ConfigService.MaxFamiliarLevel}</color>) or requires <color=#ffd9eb>{_itemSchematic.GetLocalizedName()}</color><color=yellow>x</color><color=white>{clampedCost}</color>.");
+                LocalizationService.Reply(ctx, $"Familiar attempting to prestige must be at max level (<color=white>{ConfigService.MaxFamiliarLevel}</color>) or requires <color=#ffd9eb>{_itemSchematic.GetLocalizedName()}</color><color=yellow>x</color><color=white>{clampedCost}</color>.");
             }
         }
         else
         {
-            LocalizationService.HandleReply(ctx, "Couldn't find active familiar for prestiging!");
+            LocalizationService.Reply(ctx, "Couldn't find active familiar for prestiging!");
         }
     }
 
@@ -969,7 +969,7 @@ internal static class FamiliarCommands
     {
         if (!ConfigService.FamiliarSystem)
         {
-            LocalizationService.HandleReply(ctx, "Familiars are not enabled.");
+            LocalizationService.Reply(ctx, "Familiars are not enabled.");
             return;
         }
 
@@ -978,7 +978,7 @@ internal static class FamiliarCommands
 
         if (familiar.Exists())
         {
-            ctx.Reply("Looks like your familiar is still able to be found; unbind it normally after calling if it's dismissed instead.");
+            LocalizationService.Reply(ctx, "Looks like your familiar is still able to be found; unbind it normally after calling if it's dismissed instead.");
             return;
         }
 
@@ -1001,7 +1001,7 @@ internal static class FamiliarCommands
         ResetActiveFamiliarData(steamId);
         AutoCallMap.TryRemove(playerCharacter, out Entity _);
 
-        LocalizationService.HandleReply(ctx, "Familiar actives and followers cleared.");
+        LocalizationService.Reply(ctx, "Familiar actives and followers cleared.");
     }
 
     [Command(name: "search", shortHand: "s", adminOnly: false, usage: ".fam s [Name]", description: "Searches boxes for familiar(s) with matching name.")]
@@ -1009,7 +1009,7 @@ internal static class FamiliarCommands
     {
         if (!ConfigService.FamiliarSystem)
         {
-            LocalizationService.HandleReply(ctx, "Familiars are not enabled.");
+            LocalizationService.Reply(ctx, "Familiars are not enabled.");
             return;
         }
 
@@ -1052,11 +1052,11 @@ internal static class FamiliarCommands
                 {
                     string foundBoxes = string.Join(", ", foundBoxNames);
                     string message = $"VBlood familiar(s) found in: {foundBoxes}";
-                    LocalizationService.HandleReply(ctx, message);
+                    LocalizationService.Reply(ctx, message);
                 }
                 else
                 {
-                    LocalizationService.HandleReply(ctx, $"Couldn't find matching familiar in boxes.");
+                    LocalizationService.Reply(ctx, $"Couldn't find matching familiar in boxes.");
                 }
             }
             else if (!name.IsNullOrWhiteSpace())
@@ -1088,17 +1088,17 @@ internal static class FamiliarCommands
                 {
                     string foundBoxes = string.Join(", ", foundBoxNames);
                     string message = $"Matching familiar(s) found in: {foundBoxes}";
-                    LocalizationService.HandleReply(ctx, message);
+                    LocalizationService.Reply(ctx, message);
                 }
                 else
                 {
-                    LocalizationService.HandleReply(ctx, $"Couldn't find any matches...");
+                    LocalizationService.Reply(ctx, $"Couldn't find any matches...");
                 }
             }
         }
         else
         {
-            LocalizationService.HandleReply(ctx, "You don't have any unlocked familiars yet.");
+            LocalizationService.Reply(ctx, "You don't have any unlocked familiars yet.");
         }
     }
 
@@ -1107,7 +1107,7 @@ internal static class FamiliarCommands
     {
         if (!ConfigService.FamiliarSystem)
         {
-            LocalizationService.HandleReply(ctx, "Familiars are not enabled.");
+            LocalizationService.Reply(ctx, "Familiars are not enabled.");
             return;
         }
 
@@ -1124,7 +1124,7 @@ internal static class FamiliarCommands
 
         if (data.FamiliarUnlocks.Count == 0)
         {
-            LocalizationService.HandleReply(ctx, "You haven't unlocked any familiars yet!");
+            LocalizationService.Reply(ctx, "You haven't unlocked any familiars yet!");
             return;
         }
 
@@ -1159,7 +1159,7 @@ internal static class FamiliarCommands
 
         if (!foundBoxMatches.Any())
         {
-            LocalizationService.HandleReply(ctx, $"Couldn't find any matches...");
+            LocalizationService.Reply(ctx, $"Couldn't find any matches...");
         }
         else if (foundBoxMatches.Count == 1)
         {
@@ -1179,7 +1179,7 @@ internal static class FamiliarCommands
         }
         else
         {
-            LocalizationService.HandleReply(ctx, "Multiple matches found! SmartBind doesn't support this yet... (WIP)");
+            LocalizationService.Reply(ctx, "Multiple matches found! SmartBind doesn't support this yet... (WIP)");
         }
     }
 
@@ -1188,7 +1188,7 @@ internal static class FamiliarCommands
     {
         if (!ConfigService.FamiliarSystem)
         {
-            LocalizationService.HandleReply(ctx, "Familiars are not enabled.");
+            LocalizationService.Reply(ctx, "Familiars are not enabled.");
             return;
         }
 
@@ -1197,7 +1197,7 @@ internal static class FamiliarCommands
 
         if (!ShinyBuffColorHexes.ContainsKey(spellSchoolPrefabGuid))
         {
-            LocalizationService.HandleReply(ctx, "Couldn't find matching shinyBuff from entered spell school. (options: blood, storm, unholy, chaos, frost, illusion)");
+            LocalizationService.Reply(ctx, "Couldn't find matching shinyBuff from entered spell school. (options: blood, storm, unholy, chaos, frost, illusion)");
             return;
         }
 
@@ -1219,13 +1219,13 @@ internal static class FamiliarCommands
                 {
                     if (ServerGameManager.TryRemoveInventoryItem(inventoryEntity, _vampiricDust, clampedCost) && HandleShiny(famKey, steamId, 1f, spellSchoolPrefabGuid.GuidHash))
                     {
-                        LocalizationService.HandleReply(ctx, "Shiny added! Rebind familiar to see effects. Use '<color=white>.fam option shiny</color>' to toggle (no chance to apply spell school debuff on hit if shiny buffs are disabled).");
+                        LocalizationService.Reply(ctx, "Shiny added! Rebind familiar to see effects. Use '<color=white>.fam option shiny</color>' to toggle (no chance to apply spell school debuff on hit if shiny buffs are disabled).");
                         return;
                     }
                 }
                 else
                 {
-                    LocalizationService.HandleReply(ctx, $"You don't have the required amount of <color=#ffd9eb>{_vampiricDust.GetLocalizedName()}</color>! (x<color=white>{clampedCost}</color>)");
+                    LocalizationService.Reply(ctx, $"You don't have the required amount of <color=#ffd9eb>{_vampiricDust.GetLocalizedName()}</color>! (x<color=white>{clampedCost}</color>)");
                 }
             }
             else if (buffsData.FamiliarBuffs.ContainsKey(famKey))
@@ -1236,19 +1236,19 @@ internal static class FamiliarCommands
                 {
                     if (ServerGameManager.TryRemoveInventoryItem(inventoryEntity, _vampiricDust, changeQuantity) && HandleShiny(famKey, steamId, 1f, spellSchoolPrefabGuid.GuidHash))
                     {
-                        LocalizationService.HandleReply(ctx, "Shiny changed! Rebind familiar to see effects. Use '<color=white>.fam option shiny</color>' to toggle (no chance to apply spell school debuff on hit if shiny buffs are disabled).");
+                        LocalizationService.Reply(ctx, "Shiny changed! Rebind familiar to see effects. Use '<color=white>.fam option shiny</color>' to toggle (no chance to apply spell school debuff on hit if shiny buffs are disabled).");
                         return;
                     }
                 }
                 else
                 {
-                    LocalizationService.HandleReply(ctx, $"You don't have the required amount of <color=#ffd9eb>{_vampiricDust.GetLocalizedName()}</color>! (x<color=white>{changeQuantity}</color>)");
+                    LocalizationService.Reply(ctx, $"You don't have the required amount of <color=#ffd9eb>{_vampiricDust.GetLocalizedName()}</color>! (x<color=white>{changeQuantity}</color>)");
                 }
             }
         }
         else
         {
-            LocalizationService.HandleReply(ctx, "Couldn't find active familiar...");
+            LocalizationService.Reply(ctx, "Couldn't find active familiar...");
         }
     }
 
@@ -1257,7 +1257,7 @@ internal static class FamiliarCommands
     {
         if (!ConfigService.FamiliarSystem)
         {
-            LocalizationService.HandleReply(ctx, "Familiars are not enabled.");
+            LocalizationService.Reply(ctx, "Familiars are not enabled.");
             return;
         }
 
@@ -1274,7 +1274,7 @@ internal static class FamiliarCommands
         else
         {
             string validOptions = string.Join(", ", _familiarSettings.Keys.Select(kvp => $"<color=white>{kvp}</color>"));
-            LocalizationService.HandleReply(ctx, $"Valid options: {validOptions}");
+            LocalizationService.Reply(ctx, $"Valid options: {validOptions}");
         }
     }
 
@@ -1283,13 +1283,13 @@ internal static class FamiliarCommands
     {
         if (!ConfigService.FamiliarSystem)
         {
-            LocalizationService.HandleReply(ctx, "Familiars are not enabled.");
+            LocalizationService.Reply(ctx, "Familiars are not enabled.");
             return;
         }
 
         if (!ConfigService.FamiliarBattles)
         {
-            LocalizationService.HandleReply(ctx, "Familiar battles are not enabled.");
+            LocalizationService.Reply(ctx, "Familiar battles are not enabled.");
             return;
         }
 
@@ -1299,7 +1299,7 @@ internal static class FamiliarCommands
         if (data.BattleGroups.Count > 0)
         {
             List<string> battleGroupNames = [..data.BattleGroups.Select(bg => bg.Name)];
-            LocalizationService.HandleReply(ctx, "Familiar Battle Groups:");
+            LocalizationService.Reply(ctx, "Familiar Battle Groups:");
 
             List<string> formattedGroups = [..battleGroupNames.Select(bg => $"<color=white>{bg}</color>")];
             const int maxPerMessage = 5;
@@ -1307,12 +1307,12 @@ internal static class FamiliarCommands
             for (int i = 0; i < formattedGroups.Count; i += maxPerMessage)
             {
                 string groups = string.Join(", ", formattedGroups.Skip(i).Take(maxPerMessage));
-                LocalizationService.HandleReply(ctx, groups);
+                LocalizationService.Reply(ctx, groups);
             }
         }
         else
         {
-            LocalizationService.HandleReply(ctx, "You have no battle groups.");
+            LocalizationService.Reply(ctx, "You have no battle groups.");
         }
     }
 
@@ -1321,13 +1321,13 @@ internal static class FamiliarCommands
     {
         if (!ConfigService.FamiliarSystem)
         {
-            LocalizationService.HandleReply(ctx, "Familiars are not enabled.");
+            LocalizationService.Reply(ctx, "Familiars are not enabled.");
             return;
         }
 
         if (!ConfigService.FamiliarBattles)
         {
-            LocalizationService.HandleReply(ctx, "Familiar battles are not enabled.");
+            LocalizationService.Reply(ctx, "Familiar battles are not enabled.");
             return;
         }
 
@@ -1338,7 +1338,7 @@ internal static class FamiliarCommands
             groupName = GetActiveBattleGroupName(steamId);
             if (string.IsNullOrEmpty(groupName))
             {
-                LocalizationService.HandleReply(ctx, "No active battle group selected! Use <color=white>.fam cbg [Name]</color> to select one.");
+                LocalizationService.Reply(ctx, "No active battle group selected! Use <color=white>.fam cbg [Name]</color> to select one.");
                 return;
             }
         }
@@ -1352,24 +1352,24 @@ internal static class FamiliarCommands
     {
         if (!ConfigService.FamiliarSystem)
         {
-            LocalizationService.HandleReply(ctx, "Familiars are not enabled.");
+            LocalizationService.Reply(ctx, "Familiars are not enabled.");
             return;
         }
 
         if (!ConfigService.FamiliarBattles)
         {
-            LocalizationService.HandleReply(ctx, "Familiar battles are not enabled.");
+            LocalizationService.Reply(ctx, "Familiar battles are not enabled.");
             return;
         }
 
         ulong steamId = ctx.Event.User.PlatformId;
         if (SetActiveBattleGroup(ctx, steamId, groupName))
         {
-            LocalizationService.HandleReply(ctx, $"Active battle group set to <color=white>{groupName}</color>.");
+            LocalizationService.Reply(ctx, $"Active battle group set to <color=white>{groupName}</color>.");
         }
         else
         {
-            LocalizationService.HandleReply(ctx, "Battle group not found.");
+            LocalizationService.Reply(ctx, "Battle group not found.");
         }
     }
 
@@ -1378,20 +1378,20 @@ internal static class FamiliarCommands
     {
         if (!ConfigService.FamiliarSystem)
         {
-            LocalizationService.HandleReply(ctx, "Familiars are not enabled.");
+            LocalizationService.Reply(ctx, "Familiars are not enabled.");
             return;
         }
 
         if (!ConfigService.FamiliarBattles)
         {
-            LocalizationService.HandleReply(ctx, "Familiar battles are not enabled.");
+            LocalizationService.Reply(ctx, "Familiar battles are not enabled.");
             return;
         }
 
         ulong steamId = ctx.Event.User.PlatformId;
         if (CreateBattleGroup(ctx, steamId, groupName))
         {
-            LocalizationService.HandleReply(ctx, $"Battle group <color=white>{groupName}</color> created.");
+            LocalizationService.Reply(ctx, $"Battle group <color=white>{groupName}</color> created.");
         }
     }
 
@@ -1400,13 +1400,13 @@ internal static class FamiliarCommands
     {
         if (!ConfigService.FamiliarSystem)
         {
-            LocalizationService.HandleReply(ctx, "Familiars are not enabled.");
+            LocalizationService.Reply(ctx, "Familiars are not enabled.");
             return;
         }
 
         if (!ConfigService.FamiliarBattles)
         {
-            LocalizationService.HandleReply(ctx, "Familiar battles are not enabled.");
+            LocalizationService.Reply(ctx, "Familiar battles are not enabled.");
             return;
         }
 
@@ -1425,19 +1425,19 @@ internal static class FamiliarCommands
 
         if (string.IsNullOrEmpty(groupName))
         {
-            LocalizationService.HandleReply(ctx, "No active battle group selected! Use <color=white>.fam cbg [Name]</color> to select one.");
+            LocalizationService.Reply(ctx, "No active battle group selected! Use <color=white>.fam cbg [Name]</color> to select one.");
             return;
         }
 
         if (slotIndex < 1 || slotIndex > 3)
         {
-            LocalizationService.HandleReply(ctx, "Slot input out of range! (use <color=white>1, 2,</color> or <color=white>3</color>)");
+            LocalizationService.Reply(ctx, "Slot input out of range! (use <color=white>1, 2,</color> or <color=white>3</color>)");
             return;
         }
 
         if (AssignFamiliarToGroup(ctx, steamId, groupName, slotIndex))
         {
-            LocalizationService.HandleReply(ctx, $"Familiar assigned to <color=white>{groupName}</color> in slot {slotIndex}.");
+            LocalizationService.Reply(ctx, $"Familiar assigned to <color=white>{groupName}</color> in slot {slotIndex}.");
         }
     }
 
@@ -1446,20 +1446,20 @@ internal static class FamiliarCommands
     {
         if (!ConfigService.FamiliarSystem)
         {
-            LocalizationService.HandleReply(ctx, "Familiars are not enabled.");
+            LocalizationService.Reply(ctx, "Familiars are not enabled.");
             return;
         }
 
         if (!ConfigService.FamiliarBattles)
         {
-            LocalizationService.HandleReply(ctx, "Familiar battles are not enabled.");
+            LocalizationService.Reply(ctx, "Familiar battles are not enabled.");
             return;
         }
 
         ulong steamId = ctx.Event.User.PlatformId;
         if (DeleteBattleGroup(ctx, steamId, groupName))
         {
-            LocalizationService.HandleReply(ctx, $"Deleted battle group <color=white>{groupName}</color>.");
+            LocalizationService.Reply(ctx, $"Deleted battle group <color=white>{groupName}</color>.");
         }
     }
 
@@ -1468,7 +1468,7 @@ internal static class FamiliarCommands
     {
         if (!ConfigService.FamiliarSystem || !ConfigService.FamiliarBattles)
         {
-            LocalizationService.HandleReply(ctx, "Familiar battles are not enabled.");
+            LocalizationService.Reply(ctx, "Familiar battles are not enabled.");
             return;
         }
 
@@ -1480,11 +1480,11 @@ internal static class FamiliarCommands
             if (isQueued)
             {
                 var (position, timeRemaining) = GetQueuePositionAndTime(steamId);
-                LocalizationService.HandleReply(ctx, $"Position in queue: <color=white>{position}</color> (<color=yellow>{Misc.FormatTimespan(timeRemaining)}</color>)");
+                LocalizationService.Reply(ctx, $"Position in queue: <color=white>{position}</color> (<color=yellow>{Misc.FormatTimespan(timeRemaining)}</color>)");
             }
             else
             {
-                LocalizationService.HandleReply(ctx, "You're not currently queued for battle! Use '<color=white>.fam challenge [PlayerName]</color>' to challenge another player.");
+                LocalizationService.Reply(ctx, "You're not currently queued for battle! Use '<color=white>.fam challenge [PlayerName]</color>' to challenge another player.");
             }
             return;
         }
@@ -1492,43 +1492,43 @@ internal static class FamiliarCommands
         if (isQueued)
         {
             var (position, timeRemaining) = GetQueuePositionAndTime(steamId);
-            LocalizationService.HandleReply(ctx, $"You can't challenge another player while queued for battle! Position in queue: <color=white>{position}</color> (<color=yellow>{Misc.FormatTimespan(timeRemaining)}</color>)");
+            LocalizationService.Reply(ctx, $"You can't challenge another player while queued for battle! Position in queue: <color=white>{position}</color> (<color=yellow>{Misc.FormatTimespan(timeRemaining)}</color>)");
             return;
         }
 
         PlayerInfo playerInfo = GetPlayerInfo(name);
         if (!playerInfo.UserEntity.Exists())
         {
-            ctx.Reply("Couldn't find player.");
+            LocalizationService.Reply(ctx, "Couldn't find player.");
             return;
         }
 
         if (playerInfo.User.PlatformId == steamId)
         {
-            ctx.Reply("You can't challenge yourself!");
+            LocalizationService.Reply(ctx, "You can't challenge yourself!");
             return;
         }
 
         if (Matchmaker.QueuedPlayers.Contains(playerInfo.User.PlatformId))
         {
-            LocalizationService.HandleReply(ctx, $"<color=green>{playerInfo.User.CharacterName}</color> is already queued for battle!");
+            LocalizationService.Reply(ctx, $"<color=green>{playerInfo.User.CharacterName}</color> is already queued for battle!");
             return;
         }
 
         if (EmoteSystemPatch.BattleChallenges.Any(challenge => challenge.Item1 == steamId || challenge.Item2 == steamId))
         {
-            ctx.Reply("Can't challenge another player until an existing challenge expires or is declined!");
+            LocalizationService.Reply(ctx, "Can't challenge another player until an existing challenge expires or is declined!");
             return;
         }
 
         if (EmoteSystemPatch.BattleChallenges.Any(challenge => challenge.Item1 == playerInfo.User.PlatformId || challenge.Item2 == playerInfo.User.PlatformId))
         {
-            ctx.Reply($"<color=green>{playerInfo.User.CharacterName}</color> already has a pending challenge!");
+            LocalizationService.Reply(ctx, $"<color=green>{playerInfo.User.CharacterName}</color> already has a pending challenge!");
             return;
         }
 
         EmoteSystemPatch.BattleChallenges.Add((ctx.User.PlatformId, playerInfo.User.PlatformId));
-        ctx.Reply($"Challenged <color=white>{playerInfo.User.CharacterName.Value}</color> to a battle! (<color=yellow>30s</color> until it expires)");
+        LocalizationService.Reply(ctx, $"Challenged <color=white>{playerInfo.User.CharacterName.Value}</color> to a battle! (<color=yellow>30s</color> until it expires)");
         LocalizationService.HandleServerReply(EntityManager, playerInfo.User, $"<color=white>{ctx.User.CharacterName.Value}</color> has challenged you to a battle! (<color=yellow>30s</color> until it expires, accept by emoting '<color=green>Yes</color>' or decline by emoting '<color=red>No</color>')");
 
         ChallengeExpiredRoutine((ctx.User.PlatformId, playerInfo.User.PlatformId)).Start();
@@ -1539,13 +1539,13 @@ internal static class FamiliarCommands
     {
         if (!ConfigService.FamiliarSystem)
         {
-            LocalizationService.HandleReply(ctx, "Familiars are not enabled.");
+            LocalizationService.Reply(ctx, "Familiars are not enabled.");
             return;
         }
 
         if (!ConfigService.FamiliarBattles)
         {
-            LocalizationService.HandleReply(ctx, "Familiar battles are not enabled.");
+            LocalizationService.Reply(ctx, "Familiar battles are not enabled.");
             return;
         }
 
@@ -1561,14 +1561,14 @@ internal static class FamiliarCommands
         if (_battlePosition.Equals(float3.zero))
         {
             Initialize();
-            LocalizationService.HandleReply(ctx, "Familiar arena position set, battle service started! (only one arena currently allowed)");
+            LocalizationService.Reply(ctx, "Familiar arena position set, battle service started! (only one arena currently allowed)");
         }
         else
         {
             FamiliarBattleCoords.Clear();
             FamiliarBattleCoords.Add(location);
 
-            LocalizationService.HandleReply(ctx, "Familiar arena position changed! (only one arena currently allowed)");
+            LocalizationService.Reply(ctx, "Familiar arena position changed! (only one arena currently allowed)");
         }
     }
 }

--- a/Commands/LevelingCommands.cs
+++ b/Commands/LevelingCommands.cs
@@ -17,14 +17,14 @@ internal static class LevelingCommands
     {
         if (!ConfigService.LevelingSystem)
         {
-            LocalizationService.HandleReply(ctx, "Leveling is not enabled.");
+            LocalizationService.Reply(ctx, "Leveling is not enabled.");
             return;
         }
 
         var SteamID = ctx.Event.User.PlatformId;
 
         TogglePlayerBool(SteamID, EXPERIENCE_LOG_KEY);
-        LocalizationService.HandleReply(ctx, $"Level logging {(GetPlayerBool(SteamID, EXPERIENCE_LOG_KEY) ? "<color=green>enabled</color>" : "<color=red>disabled</color>")}.");
+        LocalizationService.Reply(ctx, $"Level logging {(GetPlayerBool(SteamID, EXPERIENCE_LOG_KEY) ? "<color=green>enabled</color>" : "<color=red>disabled</color>")}.");
     }
 
     [Command(name: "get", adminOnly: false, usage: ".lvl get", description: "Display current leveling progress.")]
@@ -32,7 +32,7 @@ internal static class LevelingCommands
     {
         if (!ConfigService.LevelingSystem)
         {
-            LocalizationService.HandleReply(ctx, "Leveling is not enabled.");
+            LocalizationService.Reply(ctx, "Leveling is not enabled.");
             return;
         }
 
@@ -46,18 +46,18 @@ internal static class LevelingCommands
             int progress = (int)(xpData.Value - ConvertLevelToXp(level));
             int percent = LevelingSystem.GetLevelProgress(steamId);
 
-            LocalizationService.HandleReply(ctx, $"You're level [<color=white>{level}</color>][<color=#90EE90>{prestigeLevel}</color>] with <color=yellow>{progress}</color> <color=#FFC0CB>experience</color> (<color=white>{percent}%</color>)!");
+            LocalizationService.Reply(ctx, $"You're level [<color=white>{level}</color>][<color=#90EE90>{prestigeLevel}</color>] with <color=yellow>{progress}</color> <color=#FFC0CB>experience</color> (<color=white>{percent}%</color>)!");
 
             if (ConfigService.RestedXPSystem && steamId.TryGetPlayerRestedXP(out var restedData) && restedData.Value > 0)
             {
                 int roundedXP = (int)(Math.Round(restedData.Value / 100.0) * 100);
 
-                LocalizationService.HandleReply(ctx, $"<color=#FFD700>{roundedXP}</color> bonus <color=#FFC0CB>experience</color> remaining from <color=green>resting</color>~");
+                LocalizationService.Reply(ctx, $"<color=#FFD700>{roundedXP}</color> bonus <color=#FFC0CB>experience</color> remaining from <color=green>resting</color>~");
             }
         }
         else
         {
-            LocalizationService.HandleReply(ctx, "You haven't earned any experience yet!");
+            LocalizationService.Reply(ctx, "You haven't earned any experience yet!");
         }
     }
 
@@ -66,14 +66,14 @@ internal static class LevelingCommands
     {
         if (!ConfigService.LevelingSystem)
         {
-            LocalizationService.HandleReply(ctx, "Leveling is not enabled.");
+            LocalizationService.Reply(ctx, "Leveling is not enabled.");
             return;
         }
 
         PlayerInfo playerInfo = GetPlayerInfo(name);
         if (!playerInfo.UserEntity.Exists())
         {
-            ctx.Reply($"Couldn't find player.");
+            LocalizationService.Reply(ctx, $"Couldn't find player.");
             return;
         }
 
@@ -81,7 +81,7 @@ internal static class LevelingCommands
 
         if (level < 0 || level > ConfigService.MaxLevel)
         {
-            LocalizationService.HandleReply(ctx, $"Level must be between <color=white>0</color> and <color=white>{ConfigService.MaxLevel}</color>!");
+            LocalizationService.Reply(ctx, $"Level must be between <color=white>0</color> and <color=white>{ConfigService.MaxLevel}</color>!");
             return;
         }
 
@@ -93,11 +93,11 @@ internal static class LevelingCommands
             steamId.SetPlayerExperience(xpData);
 
             LevelingSystem.SetLevel(playerInfo.CharEntity);
-            LocalizationService.HandleReply(ctx, $"Level set to <color=white>{level}</color> for <color=green>{foundUser.CharacterName.Value}</color>!");
+            LocalizationService.Reply(ctx, $"Level set to <color=white>{level}</color> for <color=green>{foundUser.CharacterName.Value}</color>!");
         }
         else
         {
-            LocalizationService.HandleReply(ctx, $"Couldn't find experience data for {foundUser.CharacterName.Value}");
+            LocalizationService.Reply(ctx, $"Couldn't find experience data for {foundUser.CharacterName.Value}");
         }
     }
 
@@ -106,14 +106,14 @@ internal static class LevelingCommands
     {
         if (!ConfigService.LevelingSystem)
         {
-            LocalizationService.HandleReply(ctx, "Leveling is not enabled.");
+            LocalizationService.Reply(ctx, "Leveling is not enabled.");
             return;
         }
 
         PlayerInfo playerInfo = GetPlayerInfo(name);
         if (!playerInfo.UserEntity.Exists())
         {
-            ctx.Reply($"Couldn't find player...");
+            LocalizationService.Reply(ctx, $"Couldn't find player...");
             return;
         }
 
@@ -122,14 +122,14 @@ internal static class LevelingCommands
             DataService.PlayerDictionaries._ignoreSharedExperience.Add(playerInfo.User.PlatformId);
             DataService.PlayerPersistence.SaveIgnoredSharedExperience();
 
-            ctx.Reply($"<color=green>{playerInfo.User.CharacterName.Value}</color> added to the ignore shared experience list!");
+            LocalizationService.Reply(ctx, $"<color=green>{playerInfo.User.CharacterName.Value}</color> added to the ignore shared experience list!");
         }
         else if (DataService.PlayerDictionaries._ignoreSharedExperience.Contains(playerInfo.User.PlatformId))
         {
             DataService.PlayerDictionaries._ignoreSharedExperience.Remove(playerInfo.User.PlatformId);
             DataService.PlayerPersistence.SaveIgnoredSharedExperience();
 
-            ctx.Reply($"<color=green>{playerInfo.User.CharacterName.Value}</color> removed from the ignore shared experience list!");
+            LocalizationService.Reply(ctx, $"<color=green>{playerInfo.User.CharacterName.Value}</color> removed from the ignore shared experience list!");
         }
     }
 }

--- a/Commands/MiscCommands.cs
+++ b/Commands/MiscCommands.cs
@@ -31,7 +31,7 @@ internal static class MiscCommands
         ulong steamId = ctx.Event.User.PlatformId;
 
         TogglePlayerBool(steamId, REMINDERS_KEY);
-        LocalizationService.HandleReply(ctx, $"Reminders {(GetPlayerBool(steamId, REMINDERS_KEY) ? "<color=green>enabled</color>" : "<color=red>disabled</color>")}.");
+        LocalizationService.Reply(ctx, $"Reminders {(GetPlayerBool(steamId, REMINDERS_KEY) ? "<color=green>enabled</color>" : "<color=red>disabled</color>")}.");
     }
 
     [Command(name: "sct", adminOnly: false, usage: ".misc sct [Type]", description: "Toggles various scrolling text elements.")]
@@ -58,14 +58,14 @@ internal static class MiscCommands
 
             if (!ScrollingTextBoolKeyMap.TryGetValue(sctType, out var boolKey))
             {
-                LocalizationService.HandleReply(ctx, "Couldn't find bool key from scrolling text type...");
+                LocalizationService.Reply(ctx, "Couldn't find bool key from scrolling text type...");
                 return;
             }
 
             TogglePlayerBool(steamId, boolKey);
             bool currentState = GetPlayerBool(steamId, boolKey);
 
-            LocalizationService.HandleReply(ctx, $"<color=white>{sctType}</color> scrolling text {(currentState ? "<color=green>enabled</color>" : "<color=red>disabled</color>")}.");
+            LocalizationService.Reply(ctx, $"<color=white>{sctType}</color> scrolling text {(currentState ? "<color=green>enabled</color>" : "<color=red>disabled</color>")}.");
         }
         else
         {
@@ -77,14 +77,14 @@ internal static class MiscCommands
 
             if (!ScrollingTextBoolKeyMap.TryGetValue(sctType, out var boolKey))
             {
-                LocalizationService.HandleReply(ctx, "Couldn't find bool key from scrolling text type...");
+                LocalizationService.Reply(ctx, "Couldn't find bool key from scrolling text type...");
                 return;
             }
 
             TogglePlayerBool(steamId, boolKey);
             bool currentState = GetPlayerBool(steamId, boolKey);
 
-            LocalizationService.HandleReply(ctx, $"<color=white>{sctType}</color> scrolling text {(currentState ? "<color=green>enabled</color>" : "<color=red>disabled</color>")}.");
+            LocalizationService.Reply(ctx, $"<color=white>{sctType}</color> scrolling text {(currentState ? "<color=green>enabled</color>" : "<color=red>disabled</color>")}.");
         }
     }
 
@@ -93,7 +93,7 @@ internal static class MiscCommands
     {
         if (!ConfigService.StarterKit)
         {
-            LocalizationService.HandleReply(ctx, "Starter kit is not enabled.");
+            LocalizationService.Reply(ctx, "Starter kit is not enabled.");
             return;
         }
 
@@ -111,7 +111,7 @@ internal static class MiscCommands
 
             List<string> kitItems = StarterKitItemPrefabGUIDs.Select(x => $"<color=white>{x.Key.GetLocalizedName()}</color>").ToList();
 
-            LocalizationService.HandleReply(ctx, $"You've received a starting kit with:");
+            LocalizationService.Reply(ctx, $"You've received a starting kit with:");
 
             const int maxPerMessage = 6;
             for (int i = 0; i < kitItems.Count; i += maxPerMessage)
@@ -119,12 +119,12 @@ internal static class MiscCommands
                 var batch = kitItems.Skip(i).Take(maxPerMessage);
                 string items = string.Join(", ", batch);
 
-                LocalizationService.HandleReply(ctx, $"{items}");
+                LocalizationService.Reply(ctx, $"{items}");
             }
         }
         else
         {
-            ctx.Reply("You've already used your starting kit!");
+            LocalizationService.Reply(ctx, "You've already used your starting kit!");
         }
     }
 
@@ -133,7 +133,7 @@ internal static class MiscCommands
     {
         if (!ConfigService.LevelingSystem)
         {
-            LocalizationService.HandleReply(ctx, "Leveling is not enabled.");
+            LocalizationService.Reply(ctx, "Leveling is not enabled.");
             return;
         }
 
@@ -145,7 +145,7 @@ internal static class MiscCommands
         Entity achievementOwnerEntity = userEntity.Read<AchievementOwner>().Entity._Entity;
 
         ClaimAchievementSystem.CompleteAchievement(entityCommandBuffer, achievementPrefabGUID, userEntity, characterEntity, achievementOwnerEntity, false, true);
-        LocalizationService.HandleReply(ctx, "You are now prepared for the hunt!");
+        LocalizationService.Reply(ctx, "You are now prepared for the hunt!");
     }
 
     [Command(name: "userstats", adminOnly: false, usage: ".misc userstats", description: "Shows neat information about the player.")]
@@ -167,7 +167,7 @@ internal static class MiscCommands
         float LitresBloodConsumed = userStats.LitresBloodConsumed;
         LitresBloodConsumed = (int)LitresBloodConsumed;
 
-        LocalizationService.HandleReply(ctx, $"<color=white>VBloods Slain</color>: <color=#FF5733>{VBloodKills}</color> | <color=white>Units Killed</color>: <color=#FFD700>{UnitKills}</color> | <color=white>Deaths</color>: <color=#808080>{Deaths}</color> | <color=white>Time Online</color>: <color=#1E90FF>{OnlineTime}</color>hr | <color=white>Distance Traveled</color>: <color=#32CD32>{DistanceTraveled}</color>kf | <color=white>Blood Consumed</color>: <color=red>{LitresBloodConsumed}</color>L");
+        LocalizationService.Reply(ctx, $"<color=white>VBloods Slain</color>: <color=#FF5733>{VBloodKills}</color> | <color=white>Units Killed</color>: <color=#FFD700>{UnitKills}</color> | <color=white>Deaths</color>: <color=#808080>{Deaths}</color> | <color=white>Time Online</color>: <color=#1E90FF>{OnlineTime}</color>hr | <color=white>Distance Traveled</color>: <color=#32CD32>{DistanceTraveled}</color>kf | <color=white>Blood Consumed</color>: <color=red>{LitresBloodConsumed}</color>L");
     }
 
     [Command(name: "silence", adminOnly: false, usage: ".misc silence", description: "Resets stuck combat music if needed.")]
@@ -177,7 +177,7 @@ internal static class MiscCommands
 
         if (ServerGameManager.HasBuff(character, _combatBuff.ToIdentifier()))
         {
-            LocalizationService.HandleReply(ctx, "This command should only be used as required and certainly not while in combat.");
+            LocalizationService.Reply(ctx, "This command should only be used as required and certainly not while in combat.");
             return;
         }
 
@@ -186,6 +186,6 @@ internal static class MiscCommands
         character.Write(combatMusicListener_Shared);
 
         CombatMusicSystemServer.OnUpdate();
-        ctx.Reply($"Combat music cleared!");
+        LocalizationService.Reply(ctx, $"Combat music cleared!");
     }
 }

--- a/Commands/PrestigeCommands.cs
+++ b/Commands/PrestigeCommands.cs
@@ -31,13 +31,13 @@ internal static class PrestigeCommands
     {
         if (!ConfigService.PrestigeSystem)
         {
-            LocalizationService.HandleReply(ctx, "Prestiging is not enabled.");
+            LocalizationService.Reply(ctx, "Prestiging is not enabled.");
             return;
         }
 
         if (!TryParsePrestigeType(prestigeType, out var parsedPrestigeType))
         {
-            LocalizationService.HandleReply(ctx, "Invalid prestige type, use <color=white>'.prestige l'</color> to see options.");
+            LocalizationService.Reply(ctx, "Invalid prestige type, use <color=white>'.prestige l'</color> to see options.");
             return;
         }
 
@@ -50,12 +50,12 @@ internal static class PrestigeCommands
             {
                 if (steamId.TryGetPlayerExperience(out var expData) && expData.Key < ConfigService.MaxLevel)
                 {
-                    LocalizationService.HandleReply(ctx, "You must reach max level before <color=#90EE90>Exo</color> prestiging again.");
+                    LocalizationService.Reply(ctx, "You must reach max level before <color=#90EE90>Exo</color> prestiging again.");
                     return;
                 }
                 else if (prestigeData[PrestigeType.Exo] >= EXO_PRESTIGES)
                 {
-                    LocalizationService.HandleReply(ctx, $"You have reached the maximum amount of <color=#90EE90>Exo</color> prestiges. (<color=white>{EXO_PRESTIGES}</color>)");
+                    LocalizationService.Reply(ctx, $"You have reached the maximum amount of <color=#90EE90>Exo</color> prestiges. (<color=white>{EXO_PRESTIGES}</color>)");
                     return;
                 }
 
@@ -79,31 +79,31 @@ internal static class PrestigeCommands
                 if (ConfigService.ExoPrestigeReward != 0) exoReward = new(ConfigService.ExoPrestigeReward);
                 else if (ConfigService.ExoPrestigeReward == 0)
                 {
-                    LocalizationService.HandleReply(ctx, $"<color=#90EE90>{parsedPrestigeType}</color>[<color=white>{exoPrestiges}</color>] prestige complete!");
+                    LocalizationService.Reply(ctx, $"<color=#90EE90>{parsedPrestigeType}</color>[<color=white>{exoPrestiges}</color>] prestige complete!");
                     return;
                 }
 
                 if (ServerGameManager.TryAddInventoryItem(playerCharacter, exoReward, ConfigService.ExoPrestigeRewardQuantity))
                 {
-                    LocalizationService.HandleReply(ctx, $"<color=#90EE90>{parsedPrestigeType}</color>[<color=white>{exoPrestiges}</color>] prestige complete! You have also been awarded with <color=#ffd9eb>{exoReward.GetLocalizedName()}</color>x<color=white>{ConfigService.ExoPrestigeRewardQuantity}</color>!");
+                    LocalizationService.Reply(ctx, $"<color=#90EE90>{parsedPrestigeType}</color>[<color=white>{exoPrestiges}</color>] prestige complete! You have also been awarded with <color=#ffd9eb>{exoReward.GetLocalizedName()}</color>x<color=white>{ConfigService.ExoPrestigeRewardQuantity}</color>!");
                     return;
                 }
                 else
                 {
                     InventoryUtilitiesServer.CreateDropItem(EntityManager, playerCharacter, exoReward, ConfigService.ExoPrestigeRewardQuantity, new Entity());
-                    LocalizationService.HandleReply(ctx, $"<color=#90EE90>{parsedPrestigeType}</color>[<color=white>{exoPrestiges}</color>] prestige complete! You have been awarded with <color=#ffd9eb>{exoReward.GetLocalizedName()}</color>x<color=white>{ConfigService.ExoPrestigeRewardQuantity}</color>! It dropped on the ground becuase your inventory was full though.");
+                    LocalizationService.Reply(ctx, $"<color=#90EE90>{parsedPrestigeType}</color>[<color=white>{exoPrestiges}</color>] prestige complete! You have been awarded with <color=#ffd9eb>{exoReward.GetLocalizedName()}</color>x<color=white>{ConfigService.ExoPrestigeRewardQuantity}</color>! It dropped on the ground becuase your inventory was full though.");
                     return;
                 }
             }
             else
             {
-                LocalizationService.HandleReply(ctx, "You must reach the maximum level in <color=#90EE90>Experience</color> prestige before <color=#90EE90>Exo</color> prestiging.");
+                LocalizationService.Reply(ctx, "You must reach the maximum level in <color=#90EE90>Experience</color> prestige before <color=#90EE90>Exo</color> prestiging.");
                 return;
             }
         }
         else if (!ConfigService.ExoPrestiging && parsedPrestigeType.Equals(PrestigeType.Exo))
         {
-            LocalizationService.HandleReply(ctx, "<color=#90EE90>Exo</color> prestiging is not enabled.");
+            LocalizationService.Reply(ctx, "<color=#90EE90>Exo</color> prestiging is not enabled.");
             return;
         }
 
@@ -111,7 +111,7 @@ internal static class PrestigeCommands
 
         if (handler == null)
         {
-            LocalizationService.HandleReply(ctx, "Invalid prestige, use <color=white>'.prestige l'</color> to see valid options.");
+            LocalizationService.Reply(ctx, "Invalid prestige, use <color=white>'.prestige l'</color> to see valid options.");
             return;
         }
 
@@ -123,7 +123,7 @@ internal static class PrestigeCommands
         }
         else
         {
-            LocalizationService.HandleReply(ctx, $"You have not reached the required level to prestige in <color=#90EE90>{parsedPrestigeType}</color> or are at maximum prestige level.");
+            LocalizationService.Reply(ctx, $"You have not reached the required level to prestige in <color=#90EE90>{parsedPrestigeType}</color> or are at maximum prestige level.");
         }
     }
 
@@ -132,13 +132,13 @@ internal static class PrestigeCommands
     {
         if (!ConfigService.PrestigeSystem)
         {
-            LocalizationService.HandleReply(ctx, "Prestiging is not enabled.");
+            LocalizationService.Reply(ctx, "Prestiging is not enabled.");
             return;
         }
 
         if (!TryParsePrestigeType(prestigeType, out var parsedPrestigeType))
         {
-            LocalizationService.HandleReply(ctx, "Invalid prestige, use <color=white>'.prestige l'</color> to see valid options.");
+            LocalizationService.Reply(ctx, "Invalid prestige, use <color=white>'.prestige l'</color> to see valid options.");
             return;
         }
 
@@ -147,7 +147,7 @@ internal static class PrestigeCommands
 
         if (parsedPrestigeType == PrestigeType.Exo && steamId.TryGetPlayerPrestiges(out var exoData) && exoData.TryGetValue(parsedPrestigeType, out var exoLevel) && exoLevel > 0)
         {
-            LocalizationService.HandleReply(ctx, $"Current <color=#90EE90>Exo</color> Prestige Level: <color=yellow>{exoLevel}</color>/{PrestigeTypeToMaxPrestiges[parsedPrestigeType]} | Max Form Duration: <color=green>{(int)Shapeshifts.CalculateFormDuration(exoLevel)}</color>s");
+            LocalizationService.Reply(ctx, $"Current <color=#90EE90>Exo</color> Prestige Level: <color=yellow>{exoLevel}</color>/{PrestigeTypeToMaxPrestiges[parsedPrestigeType]} | Max Form Duration: <color=green>{(int)Shapeshifts.CalculateFormDuration(exoLevel)}</color>s");
             Shapeshifts.UpdateExoFormChargeStored(steamId);
 
             if (steamId.TryGetPlayerExoFormData(out var exoFormData))
@@ -158,7 +158,7 @@ internal static class PrestigeCommands
                 }
                 else if (exoFormData.Value >= Shapeshifts.BASE_DURATION)
                 {
-                    LocalizationService.HandleReply(ctx, $"Enough charge to maintain form for <color=white>{(int)exoFormData.Value}</color>s");
+                    LocalizationService.Reply(ctx, $"Enough charge to maintain form for <color=white>{(int)exoFormData.Value}</color>s");
                 }
 
                 /*
@@ -181,7 +181,7 @@ internal static class PrestigeCommands
                 {
                     var batch = exoFormSkills.Skip(i).Take(4);
                     string replyMessage = string.Join(", ", batch);
-                    LocalizationService.HandleReply(ctx, replyMessage);
+                    LocalizationService.Reply(ctx, replyMessage);
                 }
                 */
             }
@@ -190,14 +190,14 @@ internal static class PrestigeCommands
         }
         else if (parsedPrestigeType == PrestigeType.Exo)
         {
-            LocalizationService.HandleReply(ctx, "You have not prestiged in <color=#90EE90>Exo</color> yet.");
+            LocalizationService.Reply(ctx, "You have not prestiged in <color=#90EE90>Exo</color> yet.");
             return;
         }
 
         IPrestige handler = PrestigeFactory.GetPrestige(parsedPrestigeType);
         if (handler == null)
         {
-            LocalizationService.HandleReply(ctx, "Invalid prestige, use <color=white>'.prestige l'</color> to see valid options.");
+            LocalizationService.Reply(ctx, "Invalid prestige, use <color=white>'.prestige l'</color> to see valid options.");
             return;
         }
 
@@ -209,7 +209,7 @@ internal static class PrestigeCommands
         }
         else
         {
-            LocalizationService.HandleReply(ctx, $"You have not prestiged in <color=#90EE90>{parsedPrestigeType}</color>.");
+            LocalizationService.Reply(ctx, $"You have not prestiged in <color=#90EE90>{parsedPrestigeType}</color>.");
         }
     }
 
@@ -218,20 +218,20 @@ internal static class PrestigeCommands
     {
         if (!ConfigService.PrestigeSystem)
         {
-            LocalizationService.HandleReply(ctx, "Prestiging is not enabled.");
+            LocalizationService.Reply(ctx, "Prestiging is not enabled.");
             return;
         }
 
         if (!TryParsePrestigeType(prestigeType, out var parsedPrestigeType))
         {
-            LocalizationService.HandleReply(ctx, "Invalid prestige, use <color=white>'.prestige l'</color> to see valid options.");
+            LocalizationService.Reply(ctx, "Invalid prestige, use <color=white>'.prestige l'</color> to see valid options.");
             return;
         }
 
         PlayerInfo playerInfo = GetPlayerInfo(name);
         if (!playerInfo.UserEntity.Exists())
         {
-            ctx.Reply($"Couldn't find player.");
+            LocalizationService.Reply(ctx, $"Couldn't find player.");
             return;
         }
 
@@ -242,13 +242,13 @@ internal static class PrestigeCommands
         {
             if (!ConfigService.ExoPrestiging)
             {
-                LocalizationService.HandleReply(ctx, $"<color=#90EE90>{parsedPrestigeType}</color> prestiging is not enabled.");
+                LocalizationService.Reply(ctx, $"<color=#90EE90>{parsedPrestigeType}</color> prestiging is not enabled.");
                 return;
             }
 
             if (level > PrestigeTypeToMaxPrestiges[parsedPrestigeType] || level < 1)
             {
-                LocalizationService.HandleReply(ctx, $"The maximum level for <color=#90EE90>{parsedPrestigeType}</color> prestige is {PrestigeTypeToMaxPrestiges[parsedPrestigeType]}.");
+                LocalizationService.Reply(ctx, $"The maximum level for <color=#90EE90>{parsedPrestigeType}</color> prestige is {PrestigeTypeToMaxPrestiges[parsedPrestigeType]}.");
                 return;
             }
 
@@ -262,7 +262,7 @@ internal static class PrestigeCommands
                 KeyValuePair<DateTime, float> timeEnergyPair = new(DateTime.UtcNow, Shapeshifts.CalculateFormDuration(exoPrestige));
                 steamId.SetPlayerExoFormData(timeEnergyPair);
 
-                LocalizationService.HandleReply(ctx, $"Player <color=green>{playerInfo.User.CharacterName.Value}</color> has been set to level <color=white>{level}</color> in <color=#90EE90>{parsedPrestigeType}</color> prestige.");
+                LocalizationService.Reply(ctx, $"Player <color=green>{playerInfo.User.CharacterName.Value}</color> has been set to level <color=white>{level}</color> in <color=#90EE90>{parsedPrestigeType}</color> prestige.");
                 return;
             }
         }
@@ -271,7 +271,7 @@ internal static class PrestigeCommands
 
         if (handler == null)
         {
-            LocalizationService.HandleReply(ctx, "Invalid prestige, use <color=white>'.prestige l'</color> to see valid options.");
+            LocalizationService.Reply(ctx, "Invalid prestige, use <color=white>'.prestige l'</color> to see valid options.");
             return;
         }
 
@@ -288,7 +288,7 @@ internal static class PrestigeCommands
 
         if (level > PrestigeTypeToMaxPrestiges[parsedPrestigeType])
         {
-            LocalizationService.HandleReply(ctx, $"The maximum level for <color=#90EE90>{parsedPrestigeType}</color> prestige is {PrestigeTypeToMaxPrestiges[parsedPrestigeType]}.");
+            LocalizationService.Reply(ctx, $"The maximum level for <color=#90EE90>{parsedPrestigeType}</color> prestige is {PrestigeTypeToMaxPrestiges[parsedPrestigeType]}.");
             return;
         }
 
@@ -307,7 +307,7 @@ internal static class PrestigeCommands
             ReplyOtherPrestigeEffects(playerInfo.User, steamId, parsedPrestigeType, level);
         }
 
-        LocalizationService.HandleReply(ctx, $"Player <color=green>{playerInfo.User.CharacterName.Value}</color> has been set to level <color=white>{level}</color> in <color=#90EE90>{parsedPrestigeType}</color> prestige.");
+        LocalizationService.Reply(ctx, $"Player <color=green>{playerInfo.User.CharacterName.Value}</color> has been set to level <color=white>{level}</color> in <color=#90EE90>{parsedPrestigeType}</color> prestige.");
     }
 
     [Command(name: "reset", shortHand: "r", adminOnly: true, usage: ".prestige r [Player] [PrestigeType]", description: "Handles resetting prestiging.")]
@@ -315,26 +315,26 @@ internal static class PrestigeCommands
     {
         if (!ConfigService.PrestigeSystem)
         {
-            LocalizationService.HandleReply(ctx, "Prestiging is not enabled.");
+            LocalizationService.Reply(ctx, "Prestiging is not enabled.");
             return;
         }
 
         if (!TryParsePrestigeType(prestigeType, out var parsedPrestigeType))
         {
-            LocalizationService.HandleReply(ctx, "Invalid prestige, use <color=white>'.prestige l'</color> to see valid options.");
+            LocalizationService.Reply(ctx, "Invalid prestige, use <color=white>'.prestige l'</color> to see valid options.");
             return;
         }
 
         if (!ConfigService.ExoPrestiging && parsedPrestigeType == PrestigeType.Exo)
         {
-            LocalizationService.HandleReply(ctx, "Exo prestiging is not enabled.");
+            LocalizationService.Reply(ctx, "Exo prestiging is not enabled.");
             return;
         }
 
         PlayerInfo playerInfo = GetPlayerInfo(name);
         if (!playerInfo.UserEntity.Exists())
         {
-            ctx.Reply($"Couldn't find player...");
+            LocalizationService.Reply(ctx, $"Couldn't find player...");
             return;
         }
 
@@ -363,7 +363,7 @@ internal static class PrestigeCommands
                 if (GetPlayerBool(steamId, SHAPESHIFT_KEY)) SetPlayerBool(steamId, SHAPESHIFT_KEY, false);
             }
 
-            LocalizationService.HandleReply(ctx, $"<color=#90EE90>{parsedPrestigeType}</color> prestige reset for <color=white>{playerInfo.User.CharacterName.Value}</color>.");
+            LocalizationService.Reply(ctx, $"<color=#90EE90>{parsedPrestigeType}</color> prestige reset for <color=white>{playerInfo.User.CharacterName.Value}</color>.");
         }
     }
 
@@ -372,7 +372,7 @@ internal static class PrestigeCommands
     {
         if (!ConfigService.PrestigeSystem)
         {
-            LocalizationService.HandleReply(ctx, "Prestiging is not enabled.");
+            LocalizationService.Reply(ctx, "Prestiging is not enabled.");
             return;
         }
 
@@ -384,11 +384,11 @@ internal static class PrestigeCommands
             Entity character = ctx.Event.SenderCharacterEntity;
             ApplyPrestigeBuffs(character, prestigeLevel);
 
-            LocalizationService.HandleReply(ctx, "Prestige buffs applied! (if they were missing)");
+            LocalizationService.Reply(ctx, "Prestige buffs applied! (if they were missing)");
         }
         else
         {
-            LocalizationService.HandleReply(ctx, $"You have not prestiged in <color=#90EE90>{PrestigeType.Experience}</color>.");
+            LocalizationService.Reply(ctx, $"You have not prestiged in <color=#90EE90>{PrestigeType.Experience}</color>.");
         }
     }
 
@@ -397,7 +397,7 @@ internal static class PrestigeCommands
     {
         if (!ConfigService.PrestigeSystem)
         {
-            LocalizationService.HandleReply(ctx, "Prestiging is not enabled.");
+            LocalizationService.Reply(ctx, "Prestiging is not enabled.");
             return;
         }
 
@@ -405,12 +405,12 @@ internal static class PrestigeCommands
 
         const int maxPerMessage = 6;
 
-        LocalizationService.HandleReply(ctx, $"Prestiges:");
+        LocalizationService.Reply(ctx, $"Prestiges:");
         for (int i = 0; i < prestigeTypes.Count; i += maxPerMessage)
         {
             var batch = prestigeTypes.Skip(i).Take(maxPerMessage);
             string prestiges = string.Join(", ", batch);
-            LocalizationService.HandleReply(ctx, $"{prestiges}");
+            LocalizationService.Reply(ctx, $"{prestiges}");
         }
     }
 
@@ -419,25 +419,25 @@ internal static class PrestigeCommands
     {
         if (!ConfigService.PrestigeSystem)
         {
-            LocalizationService.HandleReply(ctx, "Prestiging is not enabled.");
+            LocalizationService.Reply(ctx, "Prestiging is not enabled.");
             return;
         }
 
         if (!ConfigService.PrestigeLeaderboard)
         {
-            LocalizationService.HandleReply(ctx, "Leaderboards are not enabled.");
+            LocalizationService.Reply(ctx, "Leaderboards are not enabled.");
             return;
         }
 
         if (!TryParsePrestigeType(prestigeType, out var parsedPrestigeType))
         {
-            LocalizationService.HandleReply(ctx, "Invalid prestige, use <color=white>'.prestige l'</color> to see valid options.");
+            LocalizationService.Reply(ctx, "Invalid prestige, use <color=white>'.prestige l'</color> to see valid options.");
             return;
         }
 
         if (!ConfigService.ExoPrestiging && parsedPrestigeType == PrestigeType.Exo)
         {
-            LocalizationService.HandleReply(ctx, "Exo prestiging is not enabled.");
+            LocalizationService.Reply(ctx, "Exo prestiging is not enabled.");
             return;
         }
 
@@ -448,7 +448,7 @@ internal static class PrestigeCommands
 
         if (!prestigeData.Any())
         {
-            LocalizationService.HandleReply(ctx, $"No players have prestiged in <color=#90EE90>{parsedPrestigeType}</color> yet!");
+            LocalizationService.Reply(ctx, $"No players have prestiged in <color=#90EE90>{parsedPrestigeType}</color> yet!");
             return;
         }
 
@@ -463,7 +463,7 @@ internal static class PrestigeCommands
 
         if (leaderboard.Count == 0)
         {
-            LocalizationService.HandleReply(ctx, $"No players have prestiged in <color=#90EE90>{parsedPrestigeType}</color> yet!");
+            LocalizationService.Reply(ctx, $"No players have prestiged in <color=#90EE90>{parsedPrestigeType}</color> yet!");
         }
         else
         {
@@ -472,7 +472,7 @@ internal static class PrestigeCommands
                 var batch = leaderboard.Skip(i).Take(4);
                 string replyMessage = string.Join(", ", batch);
 
-                LocalizationService.HandleReply(ctx, replyMessage);
+                LocalizationService.Reply(ctx, replyMessage);
             }
         }
     }
@@ -482,7 +482,7 @@ internal static class PrestigeCommands
     {
         if (!ConfigService.ExoPrestiging)
         {
-            ctx.Reply("Exo prestiging is not enabled.");
+            LocalizationService.Reply(ctx, "Exo prestiging is not enabled.");
             return;
         }
 
@@ -492,16 +492,16 @@ internal static class PrestigeCommands
         {
             if (!Progression.ConsumedMegara(ctx.Event.SenderUserEntity) && !Progression.ConsumedDracula(ctx.Event.SenderUserEntity))
             {
-                ctx.Reply("You must consume at least one primordial essence...");
+                LocalizationService.Reply(ctx, "You must consume at least one primordial essence...");
                 return;
             }
 
             TogglePlayerBool(steamId, SHAPESHIFT_KEY);
-            ctx.Reply($"Exo form emote action (<color=white>taunt</color>) {(GetPlayerBool(steamId, SHAPESHIFT_KEY) ? "<color=green>enabled</color>" : "<color=red>disabled</color>")}");
+            LocalizationService.Reply(ctx, $"Exo form emote action (<color=white>taunt</color>) {(GetPlayerBool(steamId, SHAPESHIFT_KEY) ? "<color=green>enabled</color>" : "<color=red>disabled</color>")}");
         }
         else
         {
-            ctx.Reply("You are not yet worthy...");
+            LocalizationService.Reply(ctx, "You are not yet worthy...");
         }
     }
 
@@ -510,14 +510,14 @@ internal static class PrestigeCommands
     {
         if (!ConfigService.ExoPrestiging)
         {
-            ctx.Reply("Exo prestiging is not enabled.");
+            LocalizationService.Reply(ctx, "Exo prestiging is not enabled.");
             return;
         }
 
         if (!Enum.TryParse<ShapeshiftType>(shapeshift, ignoreCase: true, out var form))
         {
             var shapeshifts = string.Join(", ", Enum.GetNames(typeof(ShapeshiftType)).Select(name => $"<color=white>{name}</color>"));
-            ctx.Reply($"Invalid shapeshift! Valid options: {shapeshifts}");
+            LocalizationService.Reply(ctx, $"Invalid shapeshift! Valid options: {shapeshifts}");
             return;
         }
 
@@ -527,22 +527,22 @@ internal static class PrestigeCommands
         {
             if (form.Equals(ShapeshiftType.EvolvedVampire) && !Progression.ConsumedDracula(ctx.Event.SenderUserEntity))
             {
-                ctx.Reply("You must consume Dracula's essence before manifesting his form...");
+                LocalizationService.Reply(ctx, "You must consume Dracula's essence before manifesting his form...");
                 return;
             }
 
             if (form.Equals(ShapeshiftType.CorruptedSerpent) && !Progression.ConsumedMegara(ctx.Event.SenderUserEntity))
             {
-                ctx.Reply("You must consume Megara's essence before manifesting her form...");
+                LocalizationService.Reply(ctx, "You must consume Megara's essence before manifesting her form...");
                 return;
             }
 
             steamId.SetPlayerShapeshift(form);
-            ctx.Reply($"Current Exoform: <color=white>{form}</color>");
+            LocalizationService.Reply(ctx, $"Current Exoform: <color=white>{form}</color>");
         }
         else
         {
-            ctx.Reply("You are not yet worthy...");
+            LocalizationService.Reply(ctx, "You are not yet worthy...");
         }
     }
 
@@ -551,14 +551,14 @@ internal static class PrestigeCommands
     {
         if (!ConfigService.PrestigeSystem)
         {
-            LocalizationService.HandleReply(ctx, "Prestiging is not enabled.");
+            LocalizationService.Reply(ctx, "Prestiging is not enabled.");
             return;
         }
 
         PlayerInfo playerInfo = GetPlayerInfo(name);
         if (!playerInfo.UserEntity.Exists())
         {
-            ctx.Reply($"Couldn't find player...");
+            LocalizationService.Reply(ctx, $"Couldn't find player...");
             return;
         }
 
@@ -567,14 +567,14 @@ internal static class PrestigeCommands
             DataService.PlayerDictionaries._ignorePrestigeLeaderboard.Add(playerInfo.User.PlatformId);
             DataService.PlayerPersistence.SaveIgnoredPrestigeLeaderboard();
 
-            ctx.Reply($"<color=green>{playerInfo.User.CharacterName.Value}</color> added to the ignore prestige leaderboard list!");
+            LocalizationService.Reply(ctx, $"<color=green>{playerInfo.User.CharacterName.Value}</color> added to the ignore prestige leaderboard list!");
         }
         else if (DataService.PlayerDictionaries._ignorePrestigeLeaderboard.Contains(playerInfo.User.PlatformId))
         {
             DataService.PlayerDictionaries._ignorePrestigeLeaderboard.Remove(playerInfo.User.PlatformId);
             DataService.PlayerPersistence.SaveIgnoredPrestigeLeaderboard();
 
-            ctx.Reply($"<color=green>{playerInfo.User.CharacterName.Value}</color> removed from the ignore prestige leaderboard list!");
+            LocalizationService.Reply(ctx, $"<color=green>{playerInfo.User.CharacterName.Value}</color> removed from the ignore prestige leaderboard list!");
         }
     }
 
@@ -583,7 +583,7 @@ internal static class PrestigeCommands
     {
         if (!ConfigService.PrestigeSystem)
         {
-            LocalizationService.HandleReply(ctx, "Prestiging is not enabled.");
+            LocalizationService.Reply(ctx, "Prestiging is not enabled.");
             return;
         }
 
@@ -593,7 +593,7 @@ internal static class PrestigeCommands
         TogglePlayerBool(steamId, SHROUD_KEY);
         if (GetPlayerBool(steamId, SHROUD_KEY))
         {
-            LocalizationService.HandleReply(ctx, "Permashroud <color=green>enabled</color>!");
+            LocalizationService.Reply(ctx, "Permashroud <color=green>enabled</color>!");
 
             if (UpdateBuffsBufferDestroyPatch.PrestigeBuffs.Contains(_shroudBuff) && !playerCharacter.HasBuff(_shroudBuff)
                 && steamId.TryGetPlayerPrestiges(out var prestigeData) && prestigeData.TryGetValue(PrestigeType.Experience, out var experiencePrestiges) && experiencePrestiges > UpdateBuffsBufferDestroyPatch.PrestigeBuffs.IndexOf(_shroudBuff))
@@ -603,7 +603,7 @@ internal static class PrestigeCommands
         }
         else
         {
-            LocalizationService.HandleReply(ctx, "Permashroud <color=red>disabled</color>!");
+            LocalizationService.Reply(ctx, "Permashroud <color=red>disabled</color>!");
             Equipment equipment = playerCharacter.Read<Equipment>();
 
             if (!equipment.IsEquipped(_shroudCloak, out var _) && playerCharacter.HasBuff(_shroudBuff))
@@ -618,7 +618,7 @@ internal static class PrestigeCommands
     {
         if (!ConfigService.PrestigeSystem)
         {
-            LocalizationService.HandleReply(ctx, "Prestiging is not enabled.");
+            LocalizationService.Reply(ctx, "Prestiging is not enabled.");
             return;
         }
 

--- a/Commands/ProfessionCommands.cs
+++ b/Commands/ProfessionCommands.cs
@@ -18,14 +18,14 @@ internal static class ProfessionCommands
     {
         if (!ConfigService.ProfessionSystem)
         {
-            LocalizationService.HandleReply(ctx, "Professions are not enabled.");
+            LocalizationService.Reply(ctx, "Professions are not enabled.");
             return;
         }
 
         ulong steamId = ctx.Event.User.PlatformId;
 
         TogglePlayerBool(steamId, PROFESSION_LOG_KEY);
-        LocalizationService.HandleReply(ctx, $"Profession logging is now {(GetPlayerBool(steamId, PROFESSION_LOG_KEY) ? "<color=green>enabled</color>" : "<color=red>disabled</color>")}.");
+        LocalizationService.Reply(ctx, $"Profession logging is now {(GetPlayerBool(steamId, PROFESSION_LOG_KEY) ? "<color=green>enabled</color>" : "<color=red>disabled</color>")}.");
     }
 
     [Command(name: "get", adminOnly: false, usage: ".prof get [Profession]", description: "Display your current profession progress.")]
@@ -33,13 +33,13 @@ internal static class ProfessionCommands
     {
         if (!ConfigService.ProfessionSystem)
         {
-            LocalizationService.HandleReply(ctx, "Professions are not enabled.");
+            LocalizationService.Reply(ctx, "Professions are not enabled.");
             return;
         }
 
         if (!Enum.TryParse(profession, true, out ProfessionType professionType))
         {
-            LocalizationService.HandleReply(ctx, $"Valid professions: {ProfessionFactory.GetProfessionNames()}");
+            LocalizationService.Reply(ctx, $"Valid professions: {ProfessionFactory.GetProfessionNames()}");
             return;
         }
 
@@ -48,7 +48,7 @@ internal static class ProfessionCommands
         IProfession professionHandler = ProfessionFactory.GetProfession(professionType);
         if (professionHandler == null)
         {
-            LocalizationService.HandleReply(ctx, "Invalid profession.");
+            LocalizationService.Reply(ctx, "Invalid profession.");
             return;
         }
 
@@ -56,11 +56,11 @@ internal static class ProfessionCommands
         if (data.Key > 0)
         {
             int progress = (int)(data.Value - ConvertLevelToXp(data.Key));
-            LocalizationService.HandleReply(ctx, $"You're level [<color=white>{data.Key}</color>] and have <color=yellow>{progress}</color> <color=#FFC0CB>proficiency</color> (<color=white>{ProfessionSystem.GetLevelProgress(steamId, professionHandler)}%</color>) in {professionHandler.GetProfessionName()}");
+            LocalizationService.Reply(ctx, $"You're level [<color=white>{data.Key}</color>] and have <color=yellow>{progress}</color> <color=#FFC0CB>proficiency</color> (<color=white>{ProfessionSystem.GetLevelProgress(steamId, professionHandler)}%</color>) in {professionHandler.GetProfessionName()}");
         }
         else
         {
-            LocalizationService.HandleReply(ctx, $"No progress in {professionHandler.GetProfessionName()} yet!");
+            LocalizationService.Reply(ctx, $"No progress in {professionHandler.GetProfessionName()} yet!");
         }
     }
 
@@ -69,33 +69,33 @@ internal static class ProfessionCommands
     {
         if (!ConfigService.ProfessionSystem)
         {
-            LocalizationService.HandleReply(ctx, "Professions are not enabled.");
+            LocalizationService.Reply(ctx, "Professions are not enabled.");
             return;
         }
 
         PlayerInfo playerInfo = GetPlayerInfo(name);
         if (!playerInfo.UserEntity.Exists())
         {
-            ctx.Reply($"Couldn't find player.");
+            LocalizationService.Reply(ctx, $"Couldn't find player.");
             return;
         }
 
         if (level < 0 || level > MAX_PROFESSION_LEVEL)
         {
-            LocalizationService.HandleReply(ctx, $"Level must be between 0 and {MAX_PROFESSION_LEVEL}.");
+            LocalizationService.Reply(ctx, $"Level must be between 0 and {MAX_PROFESSION_LEVEL}.");
             return;
         }
 
         if (!Enum.TryParse(profession, true, out ProfessionType professionType))
         {
-            LocalizationService.HandleReply(ctx, $"Valid professions: {ProfessionFactory.GetProfessionNames()}");
+            LocalizationService.Reply(ctx, $"Valid professions: {ProfessionFactory.GetProfessionNames()}");
             return;
         }
 
         IProfession professionHandler = ProfessionFactory.GetProfession(professionType);
         if (professionHandler == null)
         {
-            LocalizationService.HandleReply(ctx, "Invalid profession.");
+            LocalizationService.Reply(ctx, "Invalid profession.");
             return;
         }
 
@@ -104,7 +104,7 @@ internal static class ProfessionCommands
         float xp = ConvertLevelToXp(level);
         professionHandler.SetProfessionData(steamId, new KeyValuePair<int, float>(level, xp));
 
-        LocalizationService.HandleReply(ctx, $"{professionHandler.GetProfessionName()} set to [<color=white>{level}</color>] for <color=green>{playerInfo.User.CharacterName.Value}</color>");
+        LocalizationService.Reply(ctx, $"{professionHandler.GetProfessionName()} set to [<color=white>{level}</color>] for <color=green>{playerInfo.User.CharacterName.Value}</color>");
     }
 
     [Command(name: "list", shortHand: "l", adminOnly: false, usage: ".prof l", description: "Lists professions available.")]
@@ -112,10 +112,10 @@ internal static class ProfessionCommands
     {
         if (!ConfigService.ProfessionSystem)
         {
-            LocalizationService.HandleReply(ctx, "Professions are not enabled.");
+            LocalizationService.Reply(ctx, "Professions are not enabled.");
             return;
         }
 
-        LocalizationService.HandleReply(ctx, $"Available professions: {ProfessionFactory.GetProfessionNames()}");
+        LocalizationService.Reply(ctx, $"Available professions: {ProfessionFactory.GetProfessionNames()}");
     }
 }

--- a/Commands/QuestCommands.cs
+++ b/Commands/QuestCommands.cs
@@ -23,14 +23,14 @@ internal static class QuestCommands
     {
         if (!ConfigService.QuestSystem)
         {
-            LocalizationService.HandleReply(ctx, "Quests are not enabled.");
+            LocalizationService.Reply(ctx, "Quests are not enabled.");
             return;
         }
 
         var steamId = ctx.Event.User.PlatformId;
 
         TogglePlayerBool(steamId, QUEST_LOG_KEY);
-        LocalizationService.HandleReply(ctx, $"Quest logging is now {(GetPlayerBool(steamId, QUEST_LOG_KEY) ? "<color=green>enabled</color>" : "<color=red>disabled</color>")}.");
+        LocalizationService.Reply(ctx, $"Quest logging is now {(GetPlayerBool(steamId, QUEST_LOG_KEY) ? "<color=green>enabled</color>" : "<color=red>disabled</color>")}.");
     }
 
     [Command(name: "progress", shortHand: "p", adminOnly: false, usage: ".quest p [QuestType]", description: "Display your current quest progress.")]
@@ -38,7 +38,7 @@ internal static class QuestCommands
     {
         if (!ConfigService.QuestSystem)
         {
-            LocalizationService.HandleReply(ctx, "Quests are not enabled.");
+            LocalizationService.Reply(ctx, "Quests are not enabled.");
             return;
         }
 
@@ -55,7 +55,7 @@ internal static class QuestCommands
             }
             else
             {
-                LocalizationService.HandleReply(ctx, "Invalid quest type. (daily/weekly or d/w)");
+                LocalizationService.Reply(ctx, "Invalid quest type. (daily/weekly or d/w)");
                 return;
             }
         }
@@ -67,7 +67,7 @@ internal static class QuestCommands
         }
         else
         {
-            LocalizationService.HandleReply(ctx, "You don't have any quests yet, check back soon.");
+            LocalizationService.Reply(ctx, "You don't have any quests yet, check back soon.");
         }
     }
 
@@ -76,7 +76,7 @@ internal static class QuestCommands
     {
         if (!ConfigService.QuestSystem)
         {
-            LocalizationService.HandleReply(ctx, "Quests are not enabled.");
+            LocalizationService.Reply(ctx, "Quests are not enabled.");
             return;
         }
 
@@ -93,14 +93,14 @@ internal static class QuestCommands
             }
             else
             {
-                LocalizationService.HandleReply(ctx, "Invalid quest type. (daily/weekly or d/w)");
+                LocalizationService.Reply(ctx, "Invalid quest type. (daily/weekly or d/w)");
                 return;
             }
         }
 
         if (QuestService._lastUpdate == default)
         {
-            LocalizationService.HandleReply(ctx, "Target cache isn't ready yet, check back shortly!");
+            LocalizationService.Reply(ctx, "Target cache isn't ready yet, check back shortly!");
             return;
         }
 
@@ -111,7 +111,7 @@ internal static class QuestCommands
         }
         else
         {
-            LocalizationService.HandleReply(ctx, "You don't have any quests yet, check back soon!");
+            LocalizationService.Reply(ctx, "You don't have any quests yet, check back soon!");
         }
     }
 
@@ -120,14 +120,14 @@ internal static class QuestCommands
     {
         if (!ConfigService.QuestSystem)
         {
-            LocalizationService.HandleReply(ctx, "Quests are not enabled.");
+            LocalizationService.Reply(ctx, "Quests are not enabled.");
             return;
         }
 
         PlayerInfo playerInfo = GetPlayerInfo(name);
         if (!playerInfo.UserEntity.Exists())
         {
-            ctx.Reply($"Couldn't find player.");
+            LocalizationService.Reply(ctx, $"Couldn't find player.");
             return;
         }
 
@@ -137,7 +137,7 @@ internal static class QuestCommands
         int level = (ConfigService.LevelingSystem && steamId.TryGetPlayerExperience(out var data)) ? data.Key : Progression.GetSimulatedLevel(playerInfo.UserEntity);
         ForceRefresh(steamId, level);
 
-        LocalizationService.HandleReply(ctx, $"Quests for <color=green>{playerInfo.User.CharacterName.Value}</color> have been refreshed.");
+        LocalizationService.Reply(ctx, $"Quests for <color=green>{playerInfo.User.CharacterName.Value}</color> have been refreshed.");
     }
 
     [Command(name: "reroll", shortHand: "r", adminOnly: false, usage: ".quest r [QuestType]", description: "Reroll quest for cost (daily only currently).")]
@@ -145,7 +145,7 @@ internal static class QuestCommands
     {
         if (!ConfigService.QuestSystem)
         {
-            LocalizationService.HandleReply(ctx, "Quests are not enabled.");
+            LocalizationService.Reply(ctx, "Quests are not enabled.");
             return;
         }
 
@@ -161,7 +161,7 @@ internal static class QuestCommands
 
         if (!Enum.TryParse(questType, true, out QuestType type))
         {
-            LocalizationService.HandleReply(ctx, "Invalid quest type. (Daily/Weekly)");
+            LocalizationService.Reply(ctx, "Invalid quest type. (Daily/Weekly)");
             return;
         }
 
@@ -170,7 +170,7 @@ internal static class QuestCommands
         {
             if (steamId.TryGetPlayerQuests(out var questData) && questData[QuestType.Daily].Objective.Complete && !ConfigService.InfiniteDailies)
             {
-                LocalizationService.HandleReply(ctx, "You've already completed your <color=#00FFFF>Daily Quest</color> today. Check back tomorrow.");
+                LocalizationService.Reply(ctx, "You've already completed your <color=#00FFFF>Daily Quest</color> today. Check back tomorrow.");
                 return;
             }
             else if (!ConfigService.RerollDailyPrefab.Equals(0))
@@ -186,25 +186,25 @@ internal static class QuestCommands
                         int level = (ConfigService.LevelingSystem && steamId.TryGetPlayerExperience(out var data)) ? data.Key : Progression.GetSimulatedLevel(ctx.Event.SenderUserEntity);
                         ForceDaily(ctx.Event.User.PlatformId, level);
 
-                        LocalizationService.HandleReply(ctx, $"Your <color=#00FFFF>Daily Quest</color> has been rerolled for <color=#C0C0C0>{item.GetLocalizedName()}</color> x<color=white>{quantity}</color>!");
+                        LocalizationService.Reply(ctx, $"Your <color=#00FFFF>Daily Quest</color> has been rerolled for <color=#C0C0C0>{item.GetLocalizedName()}</color> x<color=white>{quantity}</color>!");
                         Quests.QuestObjectiveReply(ctx, questData, type);
                     }
                 }
                 else
                 {
-                    LocalizationService.HandleReply(ctx, $"You couldn't afford to reroll your daily... (<color=#C0C0C0>{item.GetLocalizedName()}</color> x<color=white>{quantity}</color>)");
+                    LocalizationService.Reply(ctx, $"You couldn't afford to reroll your daily... (<color=#C0C0C0>{item.GetLocalizedName()}</color> x<color=white>{quantity}</color>)");
                 }
             }
             else
             {
-                LocalizationService.HandleReply(ctx, "No daily reroll item configured or couldn't find daily quest entry for player.");
+                LocalizationService.Reply(ctx, "No daily reroll item configured or couldn't find daily quest entry for player.");
             }
         }
         else if (type.Equals(QuestType.Weekly))
         {
             if (steamId.TryGetPlayerQuests(out var questData) && questData[QuestType.Weekly].Objective.Complete)
             {
-                LocalizationService.HandleReply(ctx, "You've already completed your <color=#BF40BF>Weekly Quest</color>. Check back next week.");
+                LocalizationService.Reply(ctx, "You've already completed your <color=#BF40BF>Weekly Quest</color>. Check back next week.");
                 return;
             }
             else if (!ConfigService.RerollWeeklyPrefab.Equals(0))
@@ -219,18 +219,18 @@ internal static class QuestCommands
                         int level = (ConfigService.LevelingSystem && steamId.TryGetPlayerExperience(out var data)) ? data.Key : (int)ctx.Event.SenderCharacterEntity.Read<Equipment>().GetFullLevel();
                         ForceWeekly(ctx.Event.User.PlatformId, level);
 
-                        LocalizationService.HandleReply(ctx, $"Your <color=#BF40BF>Weekly Quest</color> has been rerolled for <color=#C0C0C0>{item.GetLocalizedName()}</color> x<color=white>{quantity}</color>!");
+                        LocalizationService.Reply(ctx, $"Your <color=#BF40BF>Weekly Quest</color> has been rerolled for <color=#C0C0C0>{item.GetLocalizedName()}</color> x<color=white>{quantity}</color>!");
                         Quests.QuestObjectiveReply(ctx, questData, type);
                     }
                 }
                 else
                 {
-                    LocalizationService.HandleReply(ctx, $"You couldn't afford to reroll your wekly... (<color=#C0C0C0>{item.GetLocalizedName()}</color> x<color=white>{quantity}</color>)");
+                    LocalizationService.Reply(ctx, $"You couldn't afford to reroll your wekly... (<color=#C0C0C0>{item.GetLocalizedName()}</color> x<color=white>{quantity}</color>)");
                 }
             }
             else
             {
-                LocalizationService.HandleReply(ctx, "No weekly reroll item configured or couldn't find weekly quest entry for player.");
+                LocalizationService.Reply(ctx, "No weekly reroll item configured or couldn't find weekly quest entry for player.");
             }
         }
     }
@@ -240,14 +240,14 @@ internal static class QuestCommands
     {
         if (!ConfigService.QuestSystem)
         {
-            LocalizationService.HandleReply(ctx, "Quests are not enabled.");
+            LocalizationService.Reply(ctx, "Quests are not enabled.");
             return;
         }
 
         PlayerInfo playerInfo = GetPlayerInfo(name);
         if (!playerInfo.UserEntity.Exists())
         {
-            ctx.Reply("Couldn't find player...");
+            LocalizationService.Reply(ctx, "Couldn't find player...");
             return;
         }
 
@@ -256,7 +256,7 @@ internal static class QuestCommands
 
         if (!steamId.TryGetPlayerQuests(out var questData))
         {
-            ctx.Reply("Player has no active quests!");
+            LocalizationService.Reply(ctx, "Player has no active quests!");
             return;
         }
 
@@ -272,20 +272,20 @@ internal static class QuestCommands
 
         if (!Enum.TryParse<QuestType>(questTypeName, true, out var questType))
         {
-            ctx.Reply($"Invalid quest type '{questTypeName}'. Valid values are: {string.Join(", ", Enum.GetNames(typeof(QuestType)))}");
+            LocalizationService.Reply(ctx, $"Invalid quest type '{questTypeName}'. Valid values are: {string.Join(", ", Enum.GetNames(typeof(QuestType)))}");
             return;
         }
 
         if (!questData.ContainsKey(questType))
         {
-            ctx.Reply($"Player does not have an active {questType} quest to complete.");
+            LocalizationService.Reply(ctx, $"Player does not have an active {questType} quest to complete.");
             return;
         }
 
         var quest = questData[questType];
         if (quest.Objective.Complete)
         {
-            ctx.Reply($"The {questType} quest is already complete for {playerInfo.User.CharacterName.Value}.");
+            LocalizationService.Reply(ctx, $"The {questType} quest is already complete for {playerInfo.User.CharacterName.Value}.");
             return;
         }
 
@@ -299,6 +299,6 @@ internal static class QuestCommands
 
         ProcessQuestProgress(questData, target, toAdd, user);
 
-        ctx.Reply($"Completed {Quests.QuestTypeColor[questType]} for <color=green>{playerInfo.User.CharacterName.Value}</color>!");
+        LocalizationService.Reply(ctx, $"Completed {Quests.QuestTypeColor[questType]} for <color=green>{playerInfo.User.CharacterName.Value}</color>!");
     }
 }

--- a/Commands/WeaponCommands.cs
+++ b/Commands/WeaponCommands.cs
@@ -34,7 +34,7 @@ internal static class WeaponCommands
     {
         if (!ConfigService.ExpertiseSystem)
         {
-            LocalizationService.HandleReply(ctx, "Expertise is not enabled.");
+            LocalizationService.Reply(ctx, "Expertise is not enabled.");
             return;
         }
 
@@ -44,7 +44,7 @@ internal static class WeaponCommands
         IWeaponExpertise handler = WeaponExpertiseFactory.GetExpertise(weaponType);
         if (handler == null)
         {
-            LocalizationService.HandleReply(ctx, "Expertise handler for weapon is null; this shouldn't happen and you may want to inform the developer.");
+            LocalizationService.Reply(ctx, "Expertise handler for weapon is null; this shouldn't happen and you may want to inform the developer.");
             return;
         }
 
@@ -56,7 +56,7 @@ internal static class WeaponCommands
 
         if (ExpertiseData.Key > 0 || ExpertiseData.Value > 0)
         {
-            LocalizationService.HandleReply(ctx, $"Your weapon expertise is [<color=white>{ExpertiseData.Key}</color>][<color=#90EE90>{prestigeLevel}</color>] and you have <color=yellow>{progress}</color> <color=#FFC0CB>expertise</color> (<color=white>{GetLevelProgress(steamId, handler)}%</color>) with <color=#c0c0c0>{weaponType}</color>!");
+            LocalizationService.Reply(ctx, $"Your weapon expertise is [<color=white>{ExpertiseData.Key}</color>][<color=#90EE90>{prestigeLevel}</color>] and you have <color=yellow>{progress}</color> <color=#FFC0CB>expertise</color> (<color=white>{GetLevelProgress(steamId, handler)}%</color>) with <color=#c0c0c0>{weaponType}</color>!");
 
             if (steamId.TryGetPlayerWeaponStats(out var weaponTypeStats) && weaponTypeStats.TryGetValue(weaponType, out var weaponStatTypes))
             {
@@ -74,17 +74,17 @@ internal static class WeaponCommands
                 {
                     var batch = weaponExpertiseStats.Skip(i).Take(6);
                     string bonuses = string.Join(", ", batch.Select(stat => $"<color=#00FFFF>{stat.Key}</color>: <color=white>{stat.Value}</color>"));
-                    LocalizationService.HandleReply(ctx, $"<color=#c0c0c0>{weaponType}</color> Stats: {bonuses}");
+                    LocalizationService.Reply(ctx, $"<color=#c0c0c0>{weaponType}</color> Stats: {bonuses}");
                 }
             }
             else
             {
-                LocalizationService.HandleReply(ctx, "No bonuses from currently equipped weapon.");
+                LocalizationService.Reply(ctx, "No bonuses from currently equipped weapon.");
             }
         }
         else
         {
-            LocalizationService.HandleReply(ctx, $"You haven't gained any expertise for <color=#c0c0c0>{weaponType}</color> yet!");
+            LocalizationService.Reply(ctx, $"You haven't gained any expertise for <color=#c0c0c0>{weaponType}</color> yet!");
         }
     }
 
@@ -93,14 +93,14 @@ internal static class WeaponCommands
     {
         if (!ConfigService.ExpertiseSystem)
         {
-            LocalizationService.HandleReply(ctx, "Expertise is not enabled.");
+            LocalizationService.Reply(ctx, "Expertise is not enabled.");
             return;
         }
 
         var steamId = ctx.Event.User.PlatformId;
         TogglePlayerBool(steamId, WEAPON_LOG_KEY);
 
-        LocalizationService.HandleReply(ctx, $"Expertise logging is now {(GetPlayerBool(steamId, WEAPON_LOG_KEY) ? "<color=green>enabled</color>" : "<color=red>disabled</color>")}.");
+        LocalizationService.Reply(ctx, $"Expertise logging is now {(GetPlayerBool(steamId, WEAPON_LOG_KEY) ? "<color=green>enabled</color>" : "<color=red>disabled</color>")}.");
     }
 
     [Command(name: "choosestat", shortHand: "cst", adminOnly: false, usage: ".wep cst [WeaponOrStat] [WeaponStat]", description: "Choose a weapon stat to enhance based on your expertise.")]
@@ -108,7 +108,7 @@ internal static class WeaponCommands
     {
         if (!ConfigService.ExpertiseSystem)
         {
-            LocalizationService.HandleReply(ctx, "Expertise is not enabled.");
+            LocalizationService.Reply(ctx, "Expertise is not enabled.");
             return;
         }
 
@@ -124,7 +124,7 @@ internal static class WeaponCommands
 
             if (!Enum.IsDefined(typeof(WeaponStats.WeaponStatType), numericStat))
             {
-                LocalizationService.HandleReply(ctx,
+                LocalizationService.Reply(ctx,
                     "Invalid stat, use '<color=white>.wep lst</color>' to see valid options.");
                 return;
             }
@@ -135,7 +135,7 @@ internal static class WeaponCommands
             if (ChooseStat(steamId, finalWeaponType, finalWeaponStat))
             {
                 Buffs.RefreshStats(playerCharacter);
-                LocalizationService.HandleReply(ctx,
+                LocalizationService.Reply(ctx,
                     $"<color=#00FFFF>{finalWeaponStat}</color> has been chosen for <color=#c0c0c0>{finalWeaponType}</color>!");
             }
         }
@@ -143,14 +143,14 @@ internal static class WeaponCommands
         {
             if (!Enum.TryParse(weaponOrStat, true, out finalWeaponType))
             {
-                LocalizationService.HandleReply(ctx,
+                LocalizationService.Reply(ctx,
                     "Invalid weapon choice, use '<color=white>.wep lst</color>' to see valid options.");
                 return;
             }
 
             if (statType <= 0)
             {
-                LocalizationService.HandleReply(ctx,
+                LocalizationService.Reply(ctx,
                     "Invalid stat, use '<color=white>.wep lst</color>' to see valid options.");
                 return;
             }
@@ -159,7 +159,7 @@ internal static class WeaponCommands
 
             if (!Enum.IsDefined(typeof(WeaponStats.WeaponStatType), typedStat))
             {
-                LocalizationService.HandleReply(ctx,
+                LocalizationService.Reply(ctx,
                     "Invalid stat, use '<color=white>.wep lst</color>' to see valid options.");
                 return;
             }
@@ -169,7 +169,7 @@ internal static class WeaponCommands
             if (ChooseStat(steamId, finalWeaponType, finalWeaponStat))
             {
                 Buffs.RefreshStats(playerCharacter);
-                LocalizationService.HandleReply(ctx,
+                LocalizationService.Reply(ctx,
                     $"<color=#00FFFF>{finalWeaponStat}</color> has been chosen for <color=#c0c0c0>{finalWeaponType}</color>!");
             }
         }
@@ -180,7 +180,7 @@ internal static class WeaponCommands
     {
         if (!ConfigService.ExpertiseSystem)
         {
-            LocalizationService.HandleReply(ctx, "Expertise is not enabled.");
+            LocalizationService.Reply(ctx, "Expertise is not enabled.");
             return;
         }
 
@@ -196,7 +196,7 @@ internal static class WeaponCommands
             Buffs.RefreshStats(playerCharacter);
 
             SetPlayerBool(steamId, freeKey, false);
-            LocalizationService.HandleReply(ctx, $"Your weapon stats have been reset for <color=#c0c0c0>{weaponType}</color>!");
+            LocalizationService.Reply(ctx, $"Your weapon stats have been reset for <color=#c0c0c0>{weaponType}</color>!");
             return;
         }
 
@@ -212,13 +212,13 @@ internal static class WeaponCommands
                     ResetStats(steamId, weaponType);
                     Buffs.RefreshStats(playerCharacter);
 
-                    LocalizationService.HandleReply(ctx, $"Your weapon stats have been reset for <color=#c0c0c0>{weaponType}</color>!");
+                    LocalizationService.Reply(ctx, $"Your weapon stats have been reset for <color=#c0c0c0>{weaponType}</color>!");
                     return;
                 }
             }
             else
             {
-                LocalizationService.HandleReply(ctx, $"You don't have the required item to reset your weapon stats! (<color=#ffd9eb>{item.GetLocalizedName()}</color>x<color=white>{quantity}</color>)");
+                LocalizationService.Reply(ctx, $"You don't have the required item to reset your weapon stats! (<color=#ffd9eb>{item.GetLocalizedName()}</color>x<color=white>{quantity}</color>)");
                 return;
             }
 
@@ -227,7 +227,7 @@ internal static class WeaponCommands
         ResetStats(steamId, weaponType);
         Buffs.RefreshStats(playerCharacter);
 
-        LocalizationService.HandleReply(ctx, $"Your weapon stats have been reset for <color=#c0c0c0>{weaponType}</color>!");
+        LocalizationService.Reply(ctx, $"Your weapon stats have been reset for <color=#c0c0c0>{weaponType}</color>!");
     }
 
     [Command(name: "set", adminOnly: true, usage: ".wep set [Name] [Weapon] [Level]", description: "Sets player weapon expertise level.")]
@@ -235,34 +235,34 @@ internal static class WeaponCommands
     {
         if (!ConfigService.ExpertiseSystem)
         {
-            LocalizationService.HandleReply(ctx, "Expertise is not enabled.");
+            LocalizationService.Reply(ctx, "Expertise is not enabled.");
             return;
         }
 
         PlayerInfo playerInfo = GetPlayerInfo(name);
         if (!playerInfo.UserEntity.Exists())
         {
-            ctx.Reply($"Couldn't find player.");
+            LocalizationService.Reply(ctx, $"Couldn't find player.");
             return;
         }
 
         if (level < 0 || level > ConfigService.MaxExpertiseLevel)
         {
             string message = $"Level must be between 0 and {ConfigService.MaxExpertiseLevel}.";
-            LocalizationService.HandleReply(ctx, message);
+            LocalizationService.Reply(ctx, message);
             return;
         }
 
         if (!Enum.TryParse<WeaponType>(weapon, true, out var weaponType))
         {
-            LocalizationService.HandleReply(ctx, $"Level must be between 0 and {ConfigService.MaxExpertiseLevel}.");
+            LocalizationService.Reply(ctx, $"Level must be between 0 and {ConfigService.MaxExpertiseLevel}.");
             return;
         }
 
         IWeaponExpertise expertiseHandler = WeaponExpertiseFactory.GetExpertise(weaponType);
         if (expertiseHandler == null)
         {
-            LocalizationService.HandleReply(ctx, "Invalid weapon type.");
+            LocalizationService.Reply(ctx, "Invalid weapon type.");
             return;
         }
 
@@ -274,11 +274,11 @@ internal static class WeaponCommands
             setFunc(steamId, xpData);
             Buffs.RefreshStats(playerInfo.CharEntity);
 
-            LocalizationService.HandleReply(ctx, $"<color=#c0c0c0>{expertiseHandler.GetWeaponType()}</color> expertise set to [<color=white>{level}</color>] for <color=green>{playerInfo.User.CharacterName.Value}</color>");
+            LocalizationService.Reply(ctx, $"<color=#c0c0c0>{expertiseHandler.GetWeaponType()}</color> expertise set to [<color=white>{level}</color>] for <color=green>{playerInfo.User.CharacterName.Value}</color>");
         }
         else
         {
-            LocalizationService.HandleReply(ctx, "Couldn't find matching save method for weapon type...");
+            LocalizationService.Reply(ctx, "Couldn't find matching save method for weapon type...");
         }
     }
 
@@ -287,7 +287,7 @@ internal static class WeaponCommands
     {
         if (!ConfigService.ExpertiseSystem)
         {
-            LocalizationService.HandleReply(ctx, "Expertise is not enabled.");
+            LocalizationService.Reply(ctx, "Expertise is not enabled.");
             return;
         }
 
@@ -299,7 +299,7 @@ internal static class WeaponCommands
 
         if (weaponStatsWithCaps.Count == 0)
         {
-            LocalizationService.HandleReply(ctx, "No weapon stats available at this time.");
+            LocalizationService.Reply(ctx, "No weapon stats available at this time.");
         }
         else
         {
@@ -308,7 +308,7 @@ internal static class WeaponCommands
                 var batch = weaponStatsWithCaps.Skip(i).Take(4);
                 string replyMessage = string.Join(", ", batch);
 
-                LocalizationService.HandleReply(ctx, replyMessage);
+                LocalizationService.Reply(ctx, replyMessage);
             }
         }
     }
@@ -318,12 +318,12 @@ internal static class WeaponCommands
     {
         if (!ConfigService.ExpertiseSystem)
         {
-            LocalizationService.HandleReply(ctx, "Expertise is not enabled.");
+            LocalizationService.Reply(ctx, "Expertise is not enabled.");
             return;
         }
 
         string weaponTypes = string.Join(", ", Enum.GetNames(typeof(WeaponType)));
-        LocalizationService.HandleReply(ctx, $"Available Weapon Expertises: <color=#c0c0c0>{weaponTypes}</color>");
+        LocalizationService.Reply(ctx, $"Available Weapon Expertises: <color=#c0c0c0>{weaponTypes}</color>");
     }
 
     [Command(name: "setspells", shortHand: "spell", adminOnly: true, usage: ".wep spell [Name] [Slot] [PrefabGuid] [Radius]", description: "Manually sets spells for testing (if you enter a radius it will apply to players around the entered name).")]
@@ -331,13 +331,13 @@ internal static class WeaponCommands
     {
         if (!ConfigService.UnarmedSlots)
         {
-            LocalizationService.HandleReply(ctx, "Extra spell slots are not enabled.");
+            LocalizationService.Reply(ctx, "Extra spell slots are not enabled.");
             return;
         }
 
         if (slot < 1 || slot > 7)
         {
-            LocalizationService.HandleReply(ctx, "Invalid slot (<color=white>1</color> for Q or <color=white>2</color> for E)");
+            LocalizationService.Reply(ctx, "Invalid slot (<color=white>1</color> for Q or <color=white>2</color> for E)");
             return;
         }
 
@@ -360,12 +360,12 @@ internal static class WeaponCommands
                         if (slot == 1)
                         {
                             spells.FirstUnarmed = ability;
-                            LocalizationService.HandleReply(ctx, $"First unarmed slot set to <color=white>{new PrefabGUID(ability).GetPrefabName()}</color> for <color=green>{playerInfo.User.CharacterName.Value}</color>.");
+                            LocalizationService.Reply(ctx, $"First unarmed slot set to <color=white>{new PrefabGUID(ability).GetPrefabName()}</color> for <color=green>{playerInfo.User.CharacterName.Value}</color>.");
                         }
                         else if (slot == 2)
                         {
                             spells.SecondUnarmed = ability;
-                            LocalizationService.HandleReply(ctx, $"Second unarmed slot set to <color=white>{new PrefabGUID(ability).GetPrefabName()}</color> for <color=green>{playerInfo.User.CharacterName.Value}</color>.");
+                            LocalizationService.Reply(ctx, $"Second unarmed slot set to <color=white>{new PrefabGUID(ability).GetPrefabName()}</color> for <color=green>{playerInfo.User.CharacterName.Value}</color>.");
                         }
 
                         steamId.SetPlayerSpells(spells);
@@ -377,7 +377,7 @@ internal static class WeaponCommands
         }
         else if (radius < 0f)
         {
-            LocalizationService.HandleReply(ctx, "Radius must be positive!");
+            LocalizationService.Reply(ctx, "Radius must be positive!");
             return;
         }
         else
@@ -385,7 +385,7 @@ internal static class WeaponCommands
             PlayerInfo playerInfo = GetPlayerInfo(name);
             if (!playerInfo.UserEntity.Exists())
             {
-                ctx.Reply($"Couldn't find player.");
+                LocalizationService.Reply(ctx, $"Couldn't find player.");
                 return;
             }
 
@@ -396,12 +396,12 @@ internal static class WeaponCommands
                 if (slot == 1)
                 {
                     spells.FirstUnarmed = ability;
-                    LocalizationService.HandleReply(ctx, $"First unarmed slot set to <color=white>{new PrefabGUID(ability).GetPrefabName()}</color> for <color=green>{playerInfo.User.CharacterName.Value}</color>.");
+                    LocalizationService.Reply(ctx, $"First unarmed slot set to <color=white>{new PrefabGUID(ability).GetPrefabName()}</color> for <color=green>{playerInfo.User.CharacterName.Value}</color>.");
                 }
                 else if (slot == 2)
                 {
                     spells.SecondUnarmed = ability;
-                    LocalizationService.HandleReply(ctx, $"Second unarmed slot set to <color=white>{new PrefabGUID(ability).GetPrefabName()}</color> for <color=green>{playerInfo.User.CharacterName.Value}</color>.");
+                    LocalizationService.Reply(ctx, $"Second unarmed slot set to <color=white>{new PrefabGUID(ability).GetPrefabName()}</color> for <color=green>{playerInfo.User.CharacterName.Value}</color>.");
                 }
 
                 steamId.SetPlayerSpells(spells);
@@ -414,7 +414,7 @@ internal static class WeaponCommands
     {
         if (!ConfigService.UnarmedSlots)
         {
-            LocalizationService.HandleReply(ctx, "Extra spell slots for unarmed are not enabled.");
+            LocalizationService.Reply(ctx, "Extra spell slots for unarmed are not enabled.");
             return;
         }
 
@@ -424,7 +424,7 @@ internal static class WeaponCommands
 
         if (playerCharacter.HasBuff(_exoFormBuff))
         {
-            LocalizationService.HandleReply(ctx, "Spells cannot be locked when using exoform.");
+            LocalizationService.Reply(ctx, "Spells cannot be locked when using exoform.");
             return;
         }
 
@@ -432,11 +432,11 @@ internal static class WeaponCommands
 
         if (GetPlayerBool(SteamID, SPELL_LOCK_KEY))
         {
-            LocalizationService.HandleReply(ctx, "Change spells to the ones you want in your unarmed slots. When done, toggle this again.");
+            LocalizationService.Reply(ctx, "Change spells to the ones you want in your unarmed slots. When done, toggle this again.");
         }
         else
         {
-            LocalizationService.HandleReply(ctx, "Spells locked.");
+            LocalizationService.Reply(ctx, "Spells locked.");
         }
     }
 }

--- a/Services/DataService.cs
+++ b/Services/DataService.cs
@@ -1154,7 +1154,7 @@ internal static class DataService
 
                 if (battleGroup.Familiars.Contains(ActiveFamiliarManager.GetActiveFamiliarData(steamId).FamiliarId))
                 {
-                    LocalizationService.HandleReply(ctx, "Active familiar already present in battle group!");
+                    LocalizationService.Reply(ctx, "Active familiar already present in battle group!");
                     return false;
                 }
 
@@ -1189,7 +1189,7 @@ internal static class DataService
                 var data = LoadFamiliarBattleGroupsData(steamId);
                 if (data.BattleGroups.Count >= MAX_BATTLE_GROUPS)
                 {
-                    LocalizationService.HandleReply(ctx, $"Can't have more than <color=white>{MAX_BATTLE_GROUPS}</color> battle groups!");
+                    LocalizationService.Reply(ctx, $"Can't have more than <color=white>{MAX_BATTLE_GROUPS}</color> battle groups!");
                     return false;
                 }
 
@@ -1207,7 +1207,7 @@ internal static class DataService
 
                 data.BattleGroups.Remove(group);
                 SaveFamiliarBattleGroupsData(steamId, data);
-                LocalizationService.HandleReply(ctx, $"Deleted battle group <color=white>{groupName}</color>!");
+                LocalizationService.Reply(ctx, $"Deleted battle group <color=white>{groupName}</color>!");
                 return true;
             }
             public static bool SetActiveBattleGroup(ChatCommandContext ctx, ulong steamId, string groupName)
@@ -1234,11 +1234,11 @@ internal static class DataService
                     BuildBattleGroupDetailsReply(steamId, buffsData, prestigeData, battleGroup, ref familiars);
 
                     string familiarReply = string.Join(", ", familiars);
-                    LocalizationService.HandleReply(ctx, $"Battle Group - {familiarReply}");
+                    LocalizationService.Reply(ctx, $"Battle Group - {familiarReply}");
                 }
                 else
                 {
-                    LocalizationService.HandleReply(ctx, "No familiars in battle group!");
+                    LocalizationService.Reply(ctx, "No familiars in battle group!");
                 }
             }
             static void BuildBattleGroupDetailsReply(ulong steamId, FamiliarBuffsData buffsData, FamiliarPrestigeData prestigeData, FamiliarBattleGroup battleGroup, ref List<string> familiars)


### PR DESCRIPTION
## Summary
- search Commands and Services for direct `ctx.Reply` and `LocalizationService.HandleReply`
- replace these with `LocalizationService.Reply`

## Testing
- `dotnet build -c Release` *(fails: invalid expression term due to missing preview features)*

------
https://chatgpt.com/codex/tasks/task_e_6885c520ea3c832d9e6a2223511e0891