### PR TITLE
Refactor localization replies

### DIFF
--- a/Systems/Leveling/PrestigeManager.cs
+++ b/Systems/Leveling/PrestigeManager.cs
@@ -424,11 +424,11 @@ internal static class PrestigeManager
 
             string totalEffectString = (combinedFactor >= 0 ? "+" : "-") + (combinedFactor * 100).ToString("F2") + "%";
 
-            LocalizationService.HandleReply(ctx, $"<color=#90EE90>{parsedPrestigeType}</color> Prestige Info:");
-            LocalizationService.HandleReply(ctx, $"Current Prestige Level: <color=yellow>{prestigeLevel}</color>/{maxPrestigeLevel}");
-            LocalizationService.HandleReply(ctx, $"Growth rate reduction from <color=#90EE90>{parsedPrestigeType}</color> prestige level: <color=yellow>-{percentageReductionString}</color>");
-            LocalizationService.HandleReply(ctx, $"Stat bonuses improvement: <color=green>{statGainString}</color>");
-            LocalizationService.HandleReply(ctx, $"Total change in growth rate including leveling prestige bonus: <color=yellow>{totalEffectString}</color>");
+            LocalizationService.Reply(ctx, $"<color=#90EE90>{parsedPrestigeType}</color> Prestige Info:");
+            LocalizationService.Reply(ctx, $"Current Prestige Level: <color=yellow>{prestigeLevel}</color>/{maxPrestigeLevel}");
+            LocalizationService.Reply(ctx, $"Growth rate reduction from <color=#90EE90>{parsedPrestigeType}</color> prestige level: <color=yellow>-{percentageReductionString}</color>");
+            LocalizationService.Reply(ctx, $"Stat bonuses improvement: <color=green>{statGainString}</color>");
+            LocalizationService.Reply(ctx, $"Total change in growth rate including leveling prestige bonus: <color=yellow>{totalEffectString}</color>");
         }
     }
     public static bool CanPrestige(ulong steamId, PrestigeType parsedPrestigeType, int xpKey)
@@ -490,7 +490,7 @@ internal static class PrestigeManager
         }
         */
 
-        LocalizationService.HandleReply(ctx, $"You have prestiged in <color=#90EE90>Experience</color>[<color=white>{prestigeLevel}</color>]! Growth rates for all expertise/legacies increased by <color=green>{gainPercentage}</color>, experience from unit kills reduced by <color=red>{reductionPercentage}</color>.");
+        LocalizationService.Reply(ctx, $"You have prestiged in <color=#90EE90>Experience</color>[<color=white>{prestigeLevel}</color>]! Growth rates for all expertise/legacies increased by <color=green>{gainPercentage}</color>, experience from unit kills reduced by <color=red>{reductionPercentage}</color>.");
     }
     static void HandleOtherPrestige(ChatCommandContext ctx, ulong steamId, PrestigeType parsedPrestigeType, int prestigeLevel)
     {
@@ -528,7 +528,7 @@ internal static class PrestigeManager
         }
         */
 
-        LocalizationService.HandleReply(ctx, $"<color=#90EE90>{parsedPrestigeType}</color>[<color=white>{prestigeLevel}</color>] prestiged successfully! Growth rate reduced by <color=red>{percentageReductionString}</color> and stat bonuses improved by <color=green>{statGainString}</color>. The total change in growth rate with leveling prestige bonus is <color=yellow>{totalEffectString}</color>.");
+        LocalizationService.Reply(ctx, $"<color=#90EE90>{parsedPrestigeType}</color>[<color=white>{prestigeLevel}</color>] prestiged successfully! Growth rate reduced by <color=red>{percentageReductionString}</color> and stat bonuses improved by <color=green>{statGainString}</color>. The total change in growth rate with leveling prestige bonus is <color=yellow>{totalEffectString}</color>.");
     }
     public static void RemovePrestigeBuffs(Entity character)
     {

--- a/Tools/GenerateMessageTranslations.cs
+++ b/Tools/GenerateMessageTranslations.cs
@@ -6,7 +6,7 @@ namespace Bloodcraft.Tools;
 internal static class GenerateMessageTranslations
 {
     static readonly Regex _serviceRegex = new(
-        "LocalizationService\\.(?:Reply|HandleReply)\\s*\\([^,]*,\\s*(?<lit>@?\\$?\"(?:[^\"\\]|\\.)*\")",
+        "LocalizationService\\.Reply\\s*\\([^,]*,\\s*(?<lit>@?\\$?\"(?:[^\"\\]|\\.)*\")",
         RegexOptions.Compiled | RegexOptions.Singleline);
 
     static readonly Regex _ctxRegex = new(

--- a/Utilities/Battles.cs
+++ b/Utilities/Battles.cs
@@ -180,7 +180,7 @@ internal static class Battles
             prestiges = prestigeData.FamiliarPrestige[familiarId].Key;
         }
 
-        LocalizationService.HandleReply(ctx, $"<color=green>{famName}</color>{(buffsData.FamiliarBuffs.ContainsKey(familiarId) ? $"{colorCode}*</color>" : "")} [<color=white>{level}</color>][<color=#90EE90>{prestiges}</color>] added to <color=white>{groupName}</color>! (<color=yellow>{slotIndex}</color>)");
+        LocalizationService.Reply(ctx, $"<color=green>{famName}</color>{(buffsData.FamiliarBuffs.ContainsKey(familiarId) ? $"{colorCode}*</color>" : "")} [<color=white>{level}</color>][<color=#90EE90>{prestiges}</color>] added to <color=white>{groupName}</color>! (<color=yellow>{slotIndex}</color>)");
     }
     */
     public static void HandleBattleGroupDetailsReply(ChatCommandContext ctx, ulong steamId, FamiliarBattleGroupsManager.FamiliarBattleGroup battleGroup)
@@ -194,12 +194,12 @@ internal static class Battles
             BuildBattleGroupDetailsReply(steamId, buffsData, prestigeData, battleGroup.Familiars, ref familiars);
 
             string familiarReply = string.Join(", ", familiars);
-            LocalizationService.HandleReply(ctx, $"Battle Group - {familiarReply}");
+            LocalizationService.Reply(ctx, $"Battle Group - {familiarReply}");
             return;
         }
         else
         {
-            LocalizationService.HandleReply(ctx, "No familiars in battle group!");
+            LocalizationService.Reply(ctx, "No familiars in battle group!");
             return;
         }
     }

--- a/Utilities/Classes.cs
+++ b/Utilities/Classes.cs
@@ -345,13 +345,13 @@ internal static class Classes
         if (!InventoryUtilities.TryGetInventoryEntity(EntityManager, ctx.User.LocalCharacter._Entity, out var inventoryEntity) ||
             ServerGameManager.GetInventoryItemCount(inventoryEntity, item) < quantity)
         {
-            LocalizationService.HandleReply(ctx, $"You do not have enough of the required item to change classes (<color=#ffd9eb>{item.GetLocalizedName()}</color>x<color=white>{quantity}</color>)");
+            LocalizationService.Reply(ctx, $"You do not have enough of the required item to change classes (<color=#ffd9eb>{item.GetLocalizedName()}</color>x<color=white>{quantity}</color>)");
             return false;
         }
 
         if (!ServerGameManager.TryRemoveInventoryItem(inventoryEntity, item, quantity))
         {
-            LocalizationService.HandleReply(ctx, $"Failed to remove enough of the item required (<color=#ffd9eb>{item.GetLocalizedName()}</color>x<color=white>{quantity}</color>)");
+            LocalizationService.Reply(ctx, $"Failed to remove enough of the item required (<color=#ffd9eb>{item.GetLocalizedName()}</color>x<color=white>{quantity}</color>)");
             return false;
         }
 
@@ -397,7 +397,7 @@ internal static class Classes
 
         if (passiveBuffs.Count == 0)
         {
-            LocalizationService.HandleReply(ctx, $"{FormatClassName(playerClass)} passives not found!");
+            LocalizationService.Reply(ctx, $"{FormatClassName(playerClass)} passives not found!");
             return;
         }
 
@@ -419,13 +419,13 @@ internal static class Classes
             return $"<color=yellow>{index + 1}</color>| {(prefabEntity.Has<ModifyUnitStatBuff_DOTS>() ? FormatModifyUnitStatBuffer(prefabEntity) : prefabName)} at level <color=green>{level}</color>";
         }).ToList();
 
-        LocalizationService.HandleReply(ctx, $"{FormatClassName(playerClass)} passives:");
+        LocalizationService.Reply(ctx, $"{FormatClassName(playerClass)} passives:");
 
         for (int i = 0; i < classBuffs.Count; i += 3) // Using batches of 4 for better readability
         {
             var batch = classBuffs.Skip(i).Take(3);
             string replyMessage = string.Join(", ", batch);
-            LocalizationService.HandleReply(ctx, $"{replyMessage}");
+            LocalizationService.Reply(ctx, $"{replyMessage}");
         }
     }
 
@@ -436,7 +436,7 @@ internal static class Classes
 
         if (!hasWeaponStats && !hasBloodStats)
         {
-            LocalizationService.HandleReply(ctx, $"Couldn't find stat synergies for {FormatClassName(playerClass)}...");
+            LocalizationService.Reply(ctx, $"Couldn't find stat synergies for {FormatClassName(playerClass)}...");
             return;
         }
 
@@ -454,17 +454,17 @@ internal static class Classes
 
         if (allStats.Count == 0)
         {
-            LocalizationService.HandleReply(ctx, $"No stat synergies found for {FormatClassName(playerClass)}.");
+            LocalizationService.Reply(ctx, $"No stat synergies found for {FormatClassName(playerClass)}.");
             return;
         }
 
-        LocalizationService.HandleReply(ctx, $"{FormatClassName(playerClass)} stat synergies [x<color=white>{ConfigService.SynergyMultiplier}</color>]:");
+        LocalizationService.Reply(ctx, $"{FormatClassName(playerClass)} stat synergies [x<color=white>{ConfigService.SynergyMultiplier}</color>]:");
 
         for (int i = 0; i < allStats.Count; i += 6)
         {
             var batch = allStats.Skip(i).Take(6);
             string replyMessage = string.Join(", ", batch);
-            LocalizationService.HandleReply(ctx, $"{replyMessage}");
+            LocalizationService.Reply(ctx, $"{replyMessage}");
         }
     }
 
@@ -478,7 +478,7 @@ internal static class Classes
 
             if (weaponStats.Count == 0 && bloodStats.Count == 0)
             {
-                LocalizationService.HandleReply(ctx, $"No stat synergies found for {FormatClassName(playerClass)}.");
+                LocalizationService.Reply(ctx, $"No stat synergies found for {FormatClassName(playerClass)}.");
                 return;
             }
 
@@ -486,18 +486,18 @@ internal static class Classes
             allStats.AddRange(weaponStats.Select(stat => $"<color=white>{stat}</color> (<color=#00FFFF>Weapon</color>)"));
             allStats.AddRange(bloodStats.Select(stat => $"<color=white>{stat}</color> (<color=red>Blood</color>)"));
 
-            LocalizationService.HandleReply(ctx, $"{FormatClassName(playerClass)} stat synergies[x<color=white>{ConfigService.SynergyMultiplier}</color>]:");
+            LocalizationService.Reply(ctx, $"{FormatClassName(playerClass)} stat synergies[x<color=white>{ConfigService.SynergyMultiplier}</color>]:");
 
             for (int i = 0; i < allStats.Count; i += 6)
             {
                 var batch = allStats.Skip(i).Take(6);
                 string replyMessage = string.Join(", ", batch);
-                LocalizationService.HandleReply(ctx, $"{replyMessage}");
+                LocalizationService.Reply(ctx, $"{replyMessage}");
             }
         }
         else
         {
-            LocalizationService.HandleReply(ctx, $"Couldn't find stat synergies for {FormatClassName(playerClass)}...");
+            LocalizationService.Reply(ctx, $"Couldn't find stat synergies for {FormatClassName(playerClass)}...");
         }
     }
     */
@@ -507,7 +507,7 @@ internal static class Classes
 
         if (spells.Count == 0)
         {
-            LocalizationService.HandleReply(ctx, $"{FormatClassName(playerClass)} has no spells configured...");
+            LocalizationService.Reply(ctx, $"{FormatClassName(playerClass)} has no spells configured...");
             return;
         }
 
@@ -527,13 +527,13 @@ internal static class Classes
             classSpells.Insert(0, $"<color=yellow>{0}</color>| <color=white>{spellName}</color>");
         }
 
-        LocalizationService.HandleReply(ctx, $"{FormatClassName(playerClass)} spells:");
+        LocalizationService.Reply(ctx, $"{FormatClassName(playerClass)} spells:");
 
         for (int i = 0; i < classSpells.Count; i += 4)
         {
             var batch = classSpells.Skip(i).Take(4);
             string replyMessage = string.Join(", ", batch);
-            LocalizationService.HandleReply(ctx, $"{replyMessage}");
+            LocalizationService.Reply(ctx, $"{replyMessage}");
         }
     }
     public static bool TryParseClass(string classType, out PlayerClass parsedClassType)
@@ -652,7 +652,7 @@ internal static class Classes
 
                 if (spellPrefabGUID.Equals(oldAbility))
                 {
-                    LocalizationService.HandleReply(ctx, $"Shift spell: <color=#CBC3E3>{spellName}</color>");
+                    LocalizationService.Reply(ctx, $"Shift spell: <color=#CBC3E3>{spellName}</color>");
                     return;
                 }
                 for (int i = 0; i < firstBuffer.Length; i++)
@@ -717,7 +717,7 @@ internal static class Classes
                 JewelEquipUtilitiesServer.TryEquipJewel(ref _entityManagerRef, ref _prefabLookupMap, character, slot);
             }
 
-            LocalizationService.HandleReply(ctx, $"Shift spell: <color=#CBC3E3>{spellName}</color>");
+            LocalizationService.Reply(ctx, $"Shift spell: <color=#CBC3E3>{spellName}</color>");
         }
         else if (spellPrefabGUID.HasValue())
         {
@@ -736,7 +736,7 @@ internal static class Classes
 
                 if (spellPrefabGUID.Equals(oldAbility))
                 {
-                    LocalizationService.HandleReply(ctx, $"Shift spell: <color=#CBC3E3>{spellName}</color>");
+                    LocalizationService.Reply(ctx, $"Shift spell: <color=#CBC3E3>{spellName}</color>");
                     return;
                 }
                 for (int i = 0; i < firstBuffer.Length; i++)
@@ -781,12 +781,12 @@ internal static class Classes
                     JewelEquipUtilitiesServer.TryEquipJewel(ref _entityManagerRef, ref _prefabLookupMap, character, slot);
                 }
 
-                LocalizationService.HandleReply(ctx, $"Shift spell: <color=#CBC3E3>{spellName}</color>");
+                LocalizationService.Reply(ctx, $"Shift spell: <color=#CBC3E3>{spellName}</color>");
             }
             else
             {
                 HandleNPCSpell(character, spellPrefabGUID);
-                LocalizationService.HandleReply(ctx, $"Shift spell: <color=#CBC3E3>{spellName}</color>");
+                LocalizationService.Reply(ctx, $"Shift spell: <color=#CBC3E3>{spellName}</color>");
             }
         }
     }
@@ -884,7 +884,7 @@ internal static class Classes
 
             if (!Enum.IsDefined(typeof(PlayerClass), value))
             {
-                LocalizationService.HandleReply(ctx,
+                LocalizationService.Reply(ctx,
                     "Invalid class, use '<color=white>.class l</color>' to see options.");
                 return null;
             }
@@ -892,7 +892,7 @@ internal static class Classes
             /*
             if (value < 1 || value > 6)
             {
-                LocalizationService.HandleReply(ctx, "Invalid class, use <color=white>'.class l'</color> to see options.");
+                LocalizationService.Reply(ctx, "Invalid class, use <color=white>'.class l'</color> to see options.");
                 return null;
             }
             */
@@ -904,7 +904,7 @@ internal static class Classes
         {
             if (!TryParseClassName(input, out PlayerClass playerClass))
             {
-                LocalizationService.HandleReply(ctx, "Invalid class, use <color=white>'.class l'</color> to see options.");
+                LocalizationService.Reply(ctx, "Invalid class, use <color=white>'.class l'</color> to see options.");
                 return null;
             }
 

--- a/Utilities/Familiars.cs
+++ b/Utilities/Familiars.cs
@@ -352,14 +352,14 @@ internal static class Familiars
             // Add to set if valid
             if (!prefabEntity.Read<PrefabGUID>().GetPrefabName().StartsWith("CHAR"))
             {
-                LocalizationService.HandleReply(ctx, "Invalid unit prefab (match found but does not start with CHAR/char).");
+                LocalizationService.Reply(ctx, "Invalid unit prefab (match found but does not start with CHAR/char).");
                 return;
             }
 
             data.FamiliarUnlocks[activeBox].Add(prefabHash);
             SaveFamiliarUnlocksData(steamId, data);
 
-            LocalizationService.HandleReply(ctx, $"<color=green>{new PrefabGUID(prefabHash).GetLocalizedName()}</color> added to <color=white>{activeBox}</color>.");
+            LocalizationService.Reply(ctx, $"<color=green>{new PrefabGUID(prefabHash).GetLocalizedName()}</color> added to <color=white>{activeBox}</color>.");
         }
         else if (unit.ToLower().StartsWith("char")) // search for full and/or partial name match
         {
@@ -383,23 +383,23 @@ internal static class Familiars
             {
                 if (!prefabEntity.Read<PrefabGUID>().GetPrefabName().StartsWith("CHAR"))
                 {
-                    LocalizationService.HandleReply(ctx, "Invalid unit name (match found but does not start with CHAR/char).");
+                    LocalizationService.Reply(ctx, "Invalid unit name (match found but does not start with CHAR/char).");
                     return;
                 }
 
                 data.FamiliarUnlocks[activeBox].Add(match.GuidHash);
                 SaveFamiliarUnlocksData(steamId, data);
 
-                LocalizationService.HandleReply(ctx, $"<color=green>{match.GetLocalizedName()}</color> (<color=yellow>{match.GuidHash}</color>) added to <color=white>{activeBox}</color>.");
+                LocalizationService.Reply(ctx, $"<color=green>{match.GetLocalizedName()}</color> (<color=yellow>{match.GuidHash}</color>) added to <color=white>{activeBox}</color>.");
             }
             else
             {
-                LocalizationService.HandleReply(ctx, "Invalid unit name (no full or partial matches).");
+                LocalizationService.Reply(ctx, "Invalid unit name (no full or partial matches).");
             }
         }
         else
         {
-            LocalizationService.HandleReply(ctx, "Invalid prefab (not an integer) or name (does not start with CHAR/char).");
+            LocalizationService.Reply(ctx, "Invalid prefab (not an integer) or name (does not start with CHAR/char).");
         }
     }
     public static void TryReturnFamiliar(Entity playerCharacter, Entity familiar)
@@ -475,12 +475,12 @@ internal static class Familiars
     public static void ToggleShinies(ChatCommandContext ctx, ulong steamId)
     {
         TogglePlayerBool(steamId, SHINY_FAMILIARS_KEY);
-        LocalizationService.HandleReply(ctx, GetPlayerBool(steamId, SHINY_FAMILIARS_KEY) ? "Shiny familiars <color=green>enabled</color>." : "Shiny familiars <color=red>disabled</color>.");
+        LocalizationService.Reply(ctx, GetPlayerBool(steamId, SHINY_FAMILIARS_KEY) ? "Shiny familiars <color=green>enabled</color>." : "Shiny familiars <color=red>disabled</color>.");
     }
     public static void ToggleVBloodEmotes(ChatCommandContext ctx, ulong steamId)
     {
         TogglePlayerBool(steamId, VBLOOD_EMOTES_KEY);
-        LocalizationService.HandleReply(ctx, GetPlayerBool(steamId, VBLOOD_EMOTES_KEY) ? "VBlood emotes <color=green>enabled</color>." : "VBlood emotes <color=red>disabled</color>.");
+        LocalizationService.Reply(ctx, GetPlayerBool(steamId, VBLOOD_EMOTES_KEY) ? "VBlood emotes <color=green>enabled</color>." : "VBlood emotes <color=red>disabled</color>.");
     }
     public static void CallFamiliar(Entity playerCharacter, Entity familiar, User user, ulong steamId)
     {
@@ -885,7 +885,7 @@ internal static class Familiars
 
         if (!steamId.HasActiveFamiliar())
         {
-            LocalizationService.HandleReply(ctx, "Couldn't find active familiar!");
+            LocalizationService.Reply(ctx, "Couldn't find active familiar!");
             return;
         }
 
@@ -905,7 +905,7 @@ internal static class Familiars
 
         if (prestigeData.FamiliarPrestige[familiarId] >= ConfigService.MaxFamiliarPrestiges)
         {
-            LocalizationService.HandleReply(ctx, $"Your familiar has already prestiged the maximum number of times! (<color=white>{ConfigService.MaxFamiliarPrestiges}</color>)");
+            LocalizationService.Reply(ctx, $"Your familiar has already prestiged the maximum number of times! (<color=white>{ConfigService.MaxFamiliarPrestiges}</color>)");
             return;
         }
 
@@ -920,7 +920,7 @@ internal static class Familiars
 
                 if (value < 1 || value > length)
                 {
-                    LocalizationService.HandleReply(ctx, $"Invalid familiar prestige stat type, use '<color=white>.fam lst</color>' to see options.");
+                    LocalizationService.Reply(ctx, $"Invalid familiar prestige stat type, use '<color=white>.fam lst</color>' to see options.");
                     return;
                 }
 
@@ -932,19 +932,19 @@ internal static class Familiars
                 }
                 else
                 {
-                    LocalizationService.HandleReply(ctx, $"Familiar already has <color=#00FFFF>{FamiliarPrestigeStats[value]}</color> (<color=yellow>{value + 1}</color>) from prestiging, use '<color=white>.fam lst</color>' to see options.");
+                    LocalizationService.Reply(ctx, $"Familiar already has <color=#00FFFF>{FamiliarPrestigeStats[value]}</color> (<color=yellow>{value + 1}</color>) from prestiging, use '<color=white>.fam lst</color>' to see options.");
                     return;
                 }
             }
             else
             {
-                LocalizationService.HandleReply(ctx, $"Invalid familiar prestige stat, use '<color=white>.fam lst</color>' to see options.");
+                LocalizationService.Reply(ctx, $"Invalid familiar prestige stat, use '<color=white>.fam lst</color>' to see options.");
                 return;
             }
         }
         else if (stats.Count >= FamiliarPrestigeStats.Count && !string.IsNullOrEmpty(statType))
         {
-            LocalizationService.HandleReply(ctx, "Familiar already has all prestige stats! ('<color=white>.fam pr</color>' instead of '<color=white>.fam pr [PrestigeStat]</color>')");
+            LocalizationService.Reply(ctx, "Familiar already has all prestige stats! ('<color=white>.fam pr</color>' instead of '<color=white>.fam pr [PrestigeStat]</color>')");
             return;
         }
         */
@@ -958,22 +958,22 @@ internal static class Familiars
             Entity familiar = GetActiveFamiliar(playerCharacter);
             ModifyUnitStats(familiar, xpData.FamiliarExperience[familiarId].Key, steamId, familiarId);
 
-            LocalizationService.HandleReply(ctx, $"Your familiar has prestiged [<color=#90EE90>{prestigeLevel}</color>]; the accumulated knowledge allowed them to retain their level!");
+            LocalizationService.Reply(ctx, $"Your familiar has prestiged [<color=#90EE90>{prestigeLevel}</color>]; the accumulated knowledge allowed them to retain their level!");
 
             /*
             if (value == -1)
             {
-                LocalizationService.HandleReply(ctx, $"Your familiar has prestiged [<color=#90EE90>{prestigeLevel}</color>]; the accumulated knowledge allowed them to retain their level!");
+                LocalizationService.Reply(ctx, $"Your familiar has prestiged [<color=#90EE90>{prestigeLevel}</color>]; the accumulated knowledge allowed them to retain their level!");
             }
             else
             {
-                LocalizationService.HandleReply(ctx, $"Your familiar has prestiged [<color=#90EE90>{prestigeLevel}</color>]; the accumulated knowledge allowed them to retain their level! (+<color=#00FFFF>{FamiliarPrestigeStats[value]}</color>)");
+                LocalizationService.Reply(ctx, $"Your familiar has prestiged [<color=#90EE90>{prestigeLevel}</color>]; the accumulated knowledge allowed them to retain their level! (+<color=#00FFFF>{FamiliarPrestigeStats[value]}</color>)");
             }
             */
         }
         else
         {
-            LocalizationService.HandleReply(ctx, "Failed to remove schematics from your inventory!");
+            LocalizationService.Reply(ctx, "Failed to remove schematics from your inventory!");
         }
     }
     public static IEnumerator HandleFamiliarShapeshiftRoutine(User user, Entity playerCharacter, Entity familiar)

--- a/Utilities/Misc.cs
+++ b/Utilities/Misc.cs
@@ -500,7 +500,7 @@ internal static class Misc
             }
         }
 
-        LocalizationService.HandleReply(ctx, sb.ToString());
+        LocalizationService.Reply(ctx, sb.ToString());
     }
     public static void GiveOrDropItem(User user, Entity playerCharacter, PrefabGUID itemType, int amount)
     {

--- a/Utilities/Quests.cs
+++ b/Utilities/Quests.cs
@@ -41,7 +41,7 @@ internal static class Quests
         {
             if (!QuestService.TargetCache.TryGetValue(questObjective.Objective.Target, out HashSet<Entity> entities))
             {
-                LocalizationService.HandleReply(ctx, $"Targets have all been killed, give them a chance to respawn! If this doesn't seem right consider rerolling your {QuestTypeColor[questType]}.");
+                LocalizationService.Reply(ctx, $"Targets have all been killed, give them a chance to respawn! If this doesn't seem right consider rerolling your {QuestTypeColor[questType]}.");
             }
             else if (entities.Count > 0)
             {
@@ -63,12 +63,12 @@ internal static class Quests
 
                 if (!closest.Exists())
                 {
-                    LocalizationService.HandleReply(ctx, "Targets have all been killed, give them a chance to respawn!");
+                    LocalizationService.Reply(ctx, "Targets have all been killed, give them a chance to respawn!");
                     return;
                 }
                 else if (closest.IsVBloodOrGateBoss())
                 {
-                    LocalizationService.HandleReply(ctx, "Use the VBlood menu to track bosses!");
+                    LocalizationService.Reply(ctx, "Use the VBlood menu to track bosses!");
                     return;
                 }
 
@@ -79,16 +79,16 @@ internal static class Quests
                 string cardinalDirection = $"<color=yellow>{GetCardinalDirection(direction)}</color>";
                 double seconds = (DateTime.UtcNow - QuestService._lastUpdate).TotalSeconds;
 
-                LocalizationService.HandleReply(ctx, $"Nearest <color=white>{questObjective.Objective.Target.GetLocalizedName()}</color> was <color=#00FFFF>{(int)distance}</color>f away to the {cardinalDirection} <color=#F88380>{(int)seconds}</color>s ago.");
+                LocalizationService.Reply(ctx, $"Nearest <color=white>{questObjective.Objective.Target.GetLocalizedName()}</color> was <color=#00FFFF>{(int)distance}</color>f away to the {cardinalDirection} <color=#F88380>{(int)seconds}</color>s ago.");
             }
             else if (entities.Count == 0)
             {
-                LocalizationService.HandleReply(ctx, "Targets have all been killed, give them a chance to respawn!");
+                LocalizationService.Reply(ctx, "Targets have all been killed, give them a chance to respawn!");
             }
         }
         else
         {
-            LocalizationService.HandleReply(ctx, "Tracking is only available for incomplete kill quests.");
+            LocalizationService.Reply(ctx, "Tracking is only available for incomplete kill quests.");
         }
     }
     */
@@ -106,7 +106,7 @@ internal static class Quests
 
             if (!targetCache.IsCreated || !targetCache.ContainsKey(questObjective.Objective.Target))
             {
-                LocalizationService.HandleReply(ctx, $"Targets have all been killed, give them a chance to respawn! If this doesn't seem right consider rerolling your {QuestTypeColor[questType]}.");
+                LocalizationService.Reply(ctx, $"Targets have all been killed, give them a chance to respawn! If this doesn't seem right consider rerolling your {QuestTypeColor[questType]}.");
                 return;
             }
 
@@ -139,13 +139,13 @@ internal static class Quests
 
             if (!closest.Exists())
             {
-                LocalizationService.HandleReply(ctx, "Targets have all been killed, give them a chance to respawn!");
+                LocalizationService.Reply(ctx, "Targets have all been killed, give them a chance to respawn!");
                 return;
             }
 
             if (closest.IsVBloodOrGateBoss())
             {
-                LocalizationService.HandleReply(ctx, "Use the VBlood menu to track bosses!");
+                LocalizationService.Reply(ctx, "Use the VBlood menu to track bosses!");
                 return;
             }
 
@@ -156,11 +156,11 @@ internal static class Quests
             double seconds = (DateTime.UtcNow - QuestService._lastUpdate).TotalSeconds;
 
             // LocalizationService.HandleReply(ctx, $"Nearest <color=white>{questObjective.Objective.Target.GetLocalizedName()}</color> was <color=#00FFFF>{(int)distance}</color>f away to the {cardinalDirection} <color=#F88380>{(int)seconds}</color>s ago.");
-            LocalizationService.HandleReply(ctx, $"Nearest <color=white>{questObjective.Objective.Target.GetLocalizedName()}</color> was <color=#00FFFF>{(int)distance}</color>f away to the {cardinalDirection}!");
+            LocalizationService.Reply(ctx, $"Nearest <color=white>{questObjective.Objective.Target.GetLocalizedName()}</color> was <color=#00FFFF>{(int)distance}</color>f away to the {cardinalDirection}!");
         }
         else
         {
-            LocalizationService.HandleReply(ctx, "Tracking is only available for incomplete kill quests.");
+            LocalizationService.Reply(ctx, "Tracking is only available for incomplete kill quests.");
         }
     }
     public static void QuestObjectiveReply(ChatCommandContext ctx, Dictionary<QuestType, (QuestObjective Objective, int Progress, DateTime LastReset)> questData, QuestType questType)
@@ -168,17 +168,17 @@ internal static class Quests
         if (questData.TryGetValue(questType, out var questObjective) && !questObjective.Objective.Complete)
         {
             string timeLeft = GetTimeUntilReset(questObjective, questType);
-            LocalizationService.HandleReply(ctx, $"{QuestTypeColor[questType]}: <color=green>{questObjective.Objective.Goal}</color> <color=white>{questObjective.Objective.Target.GetLocalizedName()}</color>x<color=#FFC0CB>{questObjective.Objective.RequiredAmount}</color> [<color=white>{questObjective.Progress}</color>/<color=yellow>{questObjective.Objective.RequiredAmount}</color>]");
-            LocalizationService.HandleReply(ctx, $"Time until {questType} reset - <color=yellow>{timeLeft}</color> | {_questTargetType[questObjective.Objective.Goal]} Prefab: <color=white>{questObjective.Objective.Target.GetPrefabName()}</color>");
+            LocalizationService.Reply(ctx, $"{QuestTypeColor[questType]}: <color=green>{questObjective.Objective.Goal}</color> <color=white>{questObjective.Objective.Target.GetLocalizedName()}</color>x<color=#FFC0CB>{questObjective.Objective.RequiredAmount}</color> [<color=white>{questObjective.Progress}</color>/<color=yellow>{questObjective.Objective.RequiredAmount}</color>]");
+            LocalizationService.Reply(ctx, $"Time until {questType} reset - <color=yellow>{timeLeft}</color> | {_questTargetType[questObjective.Objective.Goal]} Prefab: <color=white>{questObjective.Objective.Target.GetPrefabName()}</color>");
         }
         else if (questObjective.Objective.Complete)
         {
             string timeLeft = GetTimeUntilReset(questObjective, questType);
-            LocalizationService.HandleReply(ctx, $"You've already completed your {QuestTypeColor[questType]}! Time until {questType} reset - <color=yellow>{timeLeft}</color>");
+            LocalizationService.Reply(ctx, $"You've already completed your {QuestTypeColor[questType]}! Time until {questType} reset - <color=yellow>{timeLeft}</color>");
         }
         else
         {
-            LocalizationService.HandleReply(ctx, $"You don't have a {QuestTypeColor[questType]}.");
+            LocalizationService.Reply(ctx, $"You don't have a {QuestTypeColor[questType]}.");
         }
     }
     static string GetTimeUntilReset((QuestObjective Objective, int Progress, DateTime LastReset) questObjective, QuestType questType)


### PR DESCRIPTION
## Summary
- swap out `LocalizationService.HandleReply` calls for `LocalizationService.Reply`
- update message translation regex

## Testing
- `dotnet build --no-restore` *(fails: operator `?` cannot be applied to operand of type `LocalizationService.MessageFile`)*

------
https://chatgpt.com/codex/tasks/task_e_68865c2a1a70832db55486f8c69ccb53