### PR TITLE
Fix MessageFile type and init

### DIFF
--- a/Services/LocalizationService.cs
+++ b/Services/LocalizationService.cs
@@ -36,9 +36,9 @@ internal class LocalizationService // the bones are from KindredCommands, ty Odj
         public Node[] Nodes { get; set; }
         public Word[] Words { get; set; }
     }
-    struct MessageFile
+    class MessageFile
     {
-        public Dictionary<string, string> Messages { get; set; }
+        public Dictionary<string, string> Messages { get; set; } = new();
     }
 
     static readonly string _language = ConfigService.LanguageLocalization;


### PR DESCRIPTION
## Summary
- change `MessageFile` from struct to class
- initialize `Messages` dictionary to avoid null refs

## Testing
- `dotnet build --no-restore -p:RunGenerateREADME=false`

------
https://chatgpt.com/codex/tasks/task_e_688661fef3f8832dba29b4f10a199e31