### PR TITLE
Create hashed localization tasks

### DIFF
--- a/.project-management/current-prd/hashed-localization-prd.md
+++ b/.project-management/current-prd/hashed-localization-prd.md
@@ -1,0 +1,40 @@
+# Hashed Localization PRD
+
+## Problem Statement
+Current message localization requires manually managing keys for every string, which is error-prone and difficult to maintain. The goal is to introduce a deterministic hashing approach to map English text to localized translations and streamline configuration and tooling around it.
+
+## Objectives
+- Derive localization keys automatically from message text
+- Allow configurable language selection for plugin messages
+- Provide tools to generate/update translation files and check for missing entries
+- Begin migrating command replies to the new localization API
+
+## Features & Acceptance Criteria
+1. **Hashed-message localization**
+   - `LocalizationService` computes a hash for each English message and uses JSON dictionaries under `Resources/Localization/Messages/<language>.json`.
+   - `Reply(ChatCommandContext, string, params object[])` looks up the hash and falls back to English when missing.
+   - Dictionary files are embedded in the project.
+   - Acceptance: Replies display translated text when provided, otherwise English.
+2. **PluginLanguage configuration**
+   - New config entry `PluginLanguage` accessible via `ConfigService.PluginLanguage`.
+   - `LocalizationService` loads dictionaries based on this setting.
+   - Acceptance: Changing `PluginLanguage` reloads messages in the selected language.
+3. **Automated translation file generator**
+   - Tool scans project for reply strings, computes hashes, and updates `Messages/English.json` plus placeholders for other languages.
+   - Documented usage in README.
+   - Acceptance: Running the tool populates or updates translation files without removing existing translations.
+4. **Command migration**
+   - Representative commands refactored to use `LocalizationService.Reply`.
+   - Acceptance: Commands still produce replies correctly with fallback behavior.
+5. **Translation completeness checker**
+   - Console utility lists missing translations across languages.
+   - Acceptance: Running the checker highlights hashes without translations for each language.
+
+## Timeline Estimate
+- Implementation and initial migration: ~1 week
+- Tooling and README updates: ~2 days
+
+## Stakeholders
+- Project Maintainers
+- Community Translators
+

--- a/.project-management/current-prd/hashed-localization-tasks.md
+++ b/.project-management/current-prd/hashed-localization-tasks.md
@@ -1,0 +1,34 @@
+# Hashed Localization Tasks
+
+These tasks implement the requirements outlined in `hashed-localization-prd.md`.
+
+:::task{title="Add hashed-message localization support", owner="@dev", due="2025-08-03"}
+1. Create `Resources/Localization/Messages` with `English.json` and placeholders for other languages.
+2. Embed these JSON files in `Bloodcraft.csproj`.
+3. Update `LocalizationService` around lines 244-284 to load translations keyed by a deterministic hash and add a `Reply(ctx, string, params object[])` method.
+:::
+
+:::task{title="Add PluginLanguage configuration", owner="@dev", due="2025-08-03"}
+1. Add a `PluginLanguage` entry alongside the existing `LanguageLocalization` config.
+2. Provide `ConfigService.PluginLanguage` (lazy-loaded).
+3. Use this value when loading dictionaries in `LocalizationService`.
+4. Document the new option in the README.
+:::
+
+:::task{title="Automated translation file generator", owner="@dev", due="2025-08-05"}
+1. Create `Tools/GenerateMessageTranslations.cs`.
+2. Scan for calls to `LocalizationService.HandleReply` or `ctx.Reply`.
+3. Compute hashes for all discovered strings and update `Resources/Localization/Messages/English.json`.
+4. Ensure placeholder entries are produced for other languages.
+:::
+
+:::task{title="Begin migrating commands to LocalizationService.Reply", owner="@dev", due="2025-08-05"}
+1. Refactor commands such as `Commands/WeaponCommands.cs` to call `LocalizationService.Reply` with the original English text.
+2. Confirm that missing translations fall back to English.
+:::
+
+:::task{title="Translation completeness checker", owner="@dev", due="2025-08-05"}
+1. Implement `Tools/CheckTranslations.cs` that loads all language files and reports hashes present in English but missing elsewhere.
+2. Mention this tool in the README under the Localization section.
+:::
+


### PR DESCRIPTION
## Summary
- add hashed localization tasks

## Testing
- `dotnet build --no-restore` *(fails: Microsoft.NETCore.App 6.0 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688690cf13f8832d9b70a00cf001c5af