### PR TITLE
Add translation checker CLI

### DIFF
--- a/GenerateREADME.cs
+++ b/GenerateREADME.cs
@@ -41,6 +41,13 @@ internal static class GenerateREADME
             return;
         }
 
+        if (args.Length >= 1 && args[0].Equals("check-translations", StringComparison.OrdinalIgnoreCase))
+        {
+            string root = args.Length > 1 ? args[1] : Directory.GetCurrentDirectory();
+            Tools.CheckTranslations.Run(root);
+            return;
+        }
+
         if (args.Length < 2)
         {
             Console.WriteLine("Usage: GenerateREADME <CommandsPath> <ReadMePath>");

--- a/README.md
+++ b/README.md
@@ -793,7 +793,9 @@ dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- generate-me
    ```bash
    dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations .
    ```
-   Missing hashes will be printed for further translation.
+   Missing hashes will be printed for further translation. The command now defaults
+   to the current directory when no path is specified, so the example above
+   continues to work as written.
 4. Rebuild and deploy the plugin with `./dev_init.sh` to load the new messages.
 
 ## Workflow Source


### PR DESCRIPTION
## Summary
- support `check-translations` in `GenerateREADME`
- clarify Translation Workflow section in the README

## Testing
- `bash .codex/install.sh`
- `dotnet build`
- `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations .`

------
https://chatgpt.com/codex/tasks/task_e_6887b1711660832d8251c48f1fd8f415