### PR TITLE
Add translation token protection utilities

### DIFF
--- a/.project-management/current-prd/translation-support-tasks.md
+++ b/.project-management/current-prd/translation-support-tasks.md
@@ -98,3 +98,8 @@ These tasks implement the requirements from `translation-support-prd.md`.
 2. Document how to add new translations and reload messages.
 :::
 
+:::task{title="Add token protection helpers", owner="@dev", due="2025-08-25", status="open"}
+1. Implement `LocalizationHelpers.ProtectTokens` and `LocalizationHelpers.UnprotectTokens` in the codebase.
+2. Extend the README with an example showing how to use them during translation.
+:::
+

--- a/README.md
+++ b/README.md
@@ -798,6 +798,22 @@ dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- generate-me
    continues to work as written.
 4. Rebuild and deploy the plugin with `./dev_init.sh` to load the new messages.
 
+### Protecting Tags During Translation
+
+Some strings contain Unity rich-text tags or runtime placeholders like `{player}`.
+These must remain byte-for-byte identical in every language. Use the
+`LocalizationHelpers` utility to temporarily hide these tokens before translating:
+
+```csharp
+string protectedText = LocalizationHelpers.ProtectTokens(originalText);
+// Translate protectedText here
+string finalText = LocalizationHelpers.UnprotectTokens(translatedText);
+```
+
+Tags and placeholders are replaced with markers such as `[[TAG_...]]` so that
+human or automated translators do not alter them. After translation, the helpers
+restore the original tokens, preventing broken color codes or variables.
+
 ## Workflow Source
 
 - Repo: https://github.com/knavillus1/codex_bootstrap/tree/dev_chat_with_tasks

--- a/Utilities/LocalizationHelpers.cs
+++ b/Utilities/LocalizationHelpers.cs
@@ -1,0 +1,41 @@
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Bloodcraft.Utilities;
+
+/// <summary>
+/// Utility methods to protect Unity rich-text tags and placeholders during translation.
+/// </summary>
+internal static class LocalizationHelpers
+{
+    static readonly Regex _tagPattern = new(
+        @"</?color=[^>]+>|</?b>|</?size=[^>]+>",
+        RegexOptions.Compiled);
+
+    static readonly Regex _varPattern = new(
+        @"\{[^}]+\}",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// Replaces tags and variable placeholders with base64 markers
+    /// so translation services do not alter them.
+    /// </summary>
+    public static string ProtectTokens(string message)
+    {
+        message = _tagPattern.Replace(message, m => $"[[TAG_{Convert.ToBase64String(Encoding.UTF8.GetBytes(m.Value))}]]");
+        message = _varPattern.Replace(message, m => $"[[VAR_{Convert.ToBase64String(Encoding.UTF8.GetBytes(m.Value))}]]");
+        return message;
+    }
+
+    /// <summary>
+    /// Restores tags and variables from base64 markers.
+    /// </summary>
+    public static string UnprotectTokens(string message)
+    {
+        return Regex.Replace(message, @"\[\[TAG_(.*?)\]\]|\[\[VAR_(.*?)\]\]", m =>
+        {
+            string data = m.Groups[1].Value.Length > 0 ? m.Groups[1].Value : m.Groups[2].Value;
+            return Encoding.UTF8.GetString(Convert.FromBase64String(data));
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- document how to preserve tags during translation
- implement `LocalizationHelpers` class with `ProtectTokens` and `UnprotectTokens`
- add open task for token protection helpers

## Testing
- `dotnet build --no-restore -c Release`
- `./dev_init.sh` *(fails: cannot copy to `/path/to/BepInEx/plugins`)*

------
https://chatgpt.com/codex/tasks/task_e_6887d2fd1aec832dbabc4738aaec331e