### PR TITLE
Fix alchemy gating for buffs

### DIFF
--- a/Patches/BuffSpawnServerPatches.cs
+++ b/Patches/BuffSpawnServerPatches.cs
@@ -219,9 +219,7 @@ internal static class BuffSystemSpawnPatches
                                 if (buffEntity.Has<RemoveBuffOnGameplayEventEntry>()) buffEntity.Remove<RemoveBuffOnGameplayEventEntry>();
                             }
 
-                            if (!_alchemy) continue;
-
-                            if (_professions)
+                            if (_professions && _alchemy)
                             {
                                 IProfession handler = ProfessionFactory.GetProfession(buffPrefabGuid);
 
@@ -636,7 +634,7 @@ internal static class BuffSystemSpawnPatches
             buffEntity.Remove<RemoveBuffOnGameplayEventEntry>();
         }
 
-        if (_professions)
+        if (_professions && _alchemy)
         {
             IProfession alchemyHandler = ProfessionFactory.GetProfession(buffGuid);
             int level = alchemyHandler.GetProfessionLevel(steamId);


### PR DESCRIPTION
## Summary
- apply profession bonuses only when alchemy is enabled
- ensure familiar buffs trigger even if alchemy is disabled

## Testing
- `dotnet build --no-restore -p:RunGenerateREADME=false`
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6889086b6784832d8fc5260a746a42e5