### PR TITLE
Improve Argos translation protection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,18 @@ The Codex system uses the following keywords:
    `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- generate-messages`
 4. Use the keywords (**CreatePrd**, **CreateTasks**, **TaskMaster**, **ClosePrd**) to manage PRDs and tasks
 
+### Translation Workflow
+
+1. Run the generator to refresh `English.json`:
+   `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- generate-messages .`
+2. Copy `English.json` to `<Language>.json` and translate each value while keeping numeric hashes.
+3. Automatically translate missing strings with Argos:
+   `python Tools/batch_translate.py Resources/Localization/Messages/<Language>.json --to <iso-code>`
+4. The script hides `<...>` tags and `{...}` placeholders as `[[TOKEN_n]]` tokens. Lines consisting only of tokens are given a dummy `TRANSLATE` suffix so Argos will process them.
+   **DO NOT** edit text inside these tokens, tags, or variables.
+5. After translation, run the checker to ensure nothing remains in English:
+   `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations .`
+
 Current PRDs and task lists are stored in `.project-management/current-prd/`, while completed items are moved to `.project-management/closed-prd/`. Codex is expected to own as much as it feels capable of doing so in terms of completion, furthering goals, and being generally proactive with managing tasks to completion of state project goals. Compile with .NET 8 to build with preview features, though do note VRising runs on the .NET 6 runtime as the .csproj implies; be mindful to stay within the .NET 6 API surface to avoid surprises.
 
 ---

--- a/README.md
+++ b/README.md
@@ -784,42 +784,7 @@ dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- generate-me
 
 ### Translation Workflow
 
-1. Run the generator to refresh `English.json` with any new messages:
-   ```bash
-   dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- generate-messages .
-   ```
-2. Copy this file to a new `<Language>.json` and translate each value while keeping the numeric hashes intact.
-3. Automatically translate any missing entries using Argos Translate:
-   ```bash
-   python Tools/batch_translate.py Resources/Localization/Messages/<Language>.json --to <iso-code>
-   ```
-4. Verify completeness using the translation checker:
-   ```bash
-   dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations .
-   ```
-   Missing hashes will be printed for further translation. The command now defaults
-   to the current directory when no path is specified, so the example above
-   continues to work as written.
-   The command warns if translated strings still look English so you can catch untranslated text early.
-5. Rebuild and deploy the plugin with `./dev_init.sh` to load the new messages.
-
-### Protecting Tags During Translation
-
-Some strings contain Unity rich-text tags or runtime placeholders like `{player}`.
-These must remain byte-for-byte identical in every language. Use the
-`LocalizationHelpers` utility to temporarily hide these tokens before translating.
-The `Protect` method returns a safe string and the list of tokens to restore:
-
-```csharp
-// Protect returns a tuple with the sanitized text and token list
-var (safe, tokens) = LocalizationHelpers.Protect(originalText);
-// Translate 'safe' here
-string finalText = LocalizationHelpers.Unprotect(translatedText, tokens);
-```
-
-Tags and placeholders are replaced with markers such as `[[TAG_...]]` so that
-human or automated translators do not alter them. After translation, the helpers
-restore the original tokens, preventing broken color codes or variables.
+Use `Tools/batch_translate.py` to generate missing strings. The script protects `<...>` tags and `{...}` variables by replacing them with `[[TOKEN_n]]`. Lines made entirely of tokens receive a `TRANSLATE` suffix so Argos does not skip them. After translating, run `check-translations` to ensure no English text remains. See `AGENTS.md` for the full workflow.
 
 ## Workflow Source
 


### PR DESCRIPTION
## Summary
- enhance `batch_translate.py` with full tag protection, retries and translator note
- document translation workflow for maintainers in `AGENTS.md`
- simplify README translation section to highlight new safeguards

## Testing
- `./dev_init.sh` *(fails: Build failed due to missing BepInEx path)*
- `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations .`

------
https://chatgpt.com/codex/tasks/task_e_688908a886fc832da12b3f6d460d9d88