### PR TITLE
Update translation tag protection docs

### DIFF
--- a/.project-management/current-prd/translation-support-prd.md
+++ b/.project-management/current-prd/translation-support-prd.md
@@ -28,7 +28,7 @@ While hashed-message localization and configuration for plugin language selectio
    - Document and regularly run `Tools/GenerateMessageTranslations` and `Tools/CheckTranslations` as part of the development workflow.
    - Acceptance: README includes clear instructions and the tools run without errors in CI or local development.
 6. **Token Protection**
-   - Use `LocalizationHelpers.ProtectTokens` before sending strings to translators and call `LocalizationHelpers.UnprotectTokens` on the returned text.
+   - Use `LocalizationHelpers.Protect` before sending strings to translators and call `LocalizationHelpers.Unprotect` on the returned text.
    - Keep `English.json` unchanged; apply the helpers only when creating other language files so rich-text tags and placeholders remain intact.
    - Acceptance: README and tasks describe this workflow and translated JSON files preserve tokens exactly.
 

--- a/.project-management/current-prd/translation-support-tasks.md
+++ b/.project-management/current-prd/translation-support-tasks.md
@@ -91,11 +91,11 @@ These tasks break down the work described in `translation-support-prd.md`.
   (Owner: @dev, Due: 2025-08-24)
 
 - [x] Add token protection helpers  
-  Implement ProtectTokens/UnprotectTokens helpers and document usage.  
+  Implement Protect/Unprotect helpers and document usage.
   (Owner: @dev, Due: 2025-08-25)
 
 :::task{title="Add token protection helpers", owner="@dev", due="2025-08-25", status="done"}
-1. Implement `LocalizationHelpers.ProtectTokens` and `LocalizationHelpers.UnprotectTokens` with indexed markers and a token map.
+1. Implement `LocalizationHelpers.Protect` and `LocalizationHelpers.Unprotect` with indexed markers and a token map.
 2. Extend the README with an example showing how to use them during translation.
 :::
 

--- a/README.md
+++ b/README.md
@@ -786,6 +786,17 @@ dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- generate-me
 
 Use `Tools/batch_translate.py` to generate missing strings. The script protects `<...>` tags and `{...}` variables by replacing them with `[[TOKEN_n]]`. Lines made entirely of tokens receive a `TRANSLATE` suffix so Argos does not skip them. After translating, run `check-translations` to ensure no English text remains. See `AGENTS.md` for the full workflow.
 
+### Protecting Tags During Translation
+
+When translating strings manually, use `LocalizationHelpers.Protect` to temporarily replace rich-text tags and placeholders with numbered markers. After translating, call `LocalizationHelpers.Unprotect` to restore the original tokens.
+
+```csharp
+var (safe, tokens) = LocalizationHelpers.Protect(original);
+// send `safe` to a translation service
+string translated = Translate(safe);
+string final = LocalizationHelpers.Unprotect(translated, tokens);
+```
+
 ## Workflow Source
 
 - Repo: https://github.com/knavillus1/codex_bootstrap/tree/dev_chat_with_tasks


### PR DESCRIPTION
## Summary
- document how to protect tags during translation with the `LocalizationHelpers.Protect` API
- update translation PRD and task references to new helper names

## Testing
- `.codex/install.sh`
- `./dev_init.sh` *(fails: Build failed: ./bin/Release/net6.0/Bloodcraft.dll not found.)*
- `dotnet test Bloodcraft.Tests/Bloodcraft.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68896492e220832d994faa481331e4cf