### PR TITLE
Add batch size to translation tool

### DIFF
--- a/.project-management/current-prd/translation-support-tasks.md
+++ b/.project-management/current-prd/translation-support-tasks.md
@@ -2,7 +2,7 @@
 
 These tasks break down the work described in `translation-support-prd.md`.
 
-* `Tools/batch_translate.py` retries each missing entry up to three times. Hashes that still fail are listed at the end and require manual translation.
+* `Tools/batch_translate.py` retries each missing entry up to three times. Hashes that still fail are listed at the end and require manual translation. Use `--batch-size` to reduce the number of lines per request if Argos stalls.
 
 - [x] Create placeholder message files for all languages  
   Copy English.json to new files for each language (Brazilian, French, etc.), ensure structure/hashes match, and add as <EmbeddedResource> in Bloodcraft.csproj.  

--- a/README.md
+++ b/README.md
@@ -786,6 +786,8 @@ dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- generate-me
 
 Use `Tools/batch_translate.py` to generate missing strings. The script protects `<...>` tags and `{...}` variables by replacing them with `[[TOKEN_n]]`. Lines made entirely of tokens receive a `TRANSLATE` suffix so Argos does not skip them. After translating, run `check-translations` to ensure no English text remains. See `AGENTS.md` for the full workflow.
 
+`batch_translate.py` accepts `--batch-size` to control how many strings are sent to Argos in a single request (default `20`). Lower values may help if large batches stall or fail.
+
 ### Protecting Tags During Translation
 
 When translating strings manually, use `LocalizationHelpers.Protect` to temporarily replace rich-text tags and placeholders with numbered markers. After translating, call `LocalizationHelpers.Unprotect` to restore the original tokens.

--- a/Tools/batch_translate.py
+++ b/Tools/batch_translate.py
@@ -58,6 +58,12 @@ def main():
     ap.add_argument("target_file", help="Path to the target language JSON file")
     ap.add_argument("--from", dest="src", default="en", help="Source language code (default: en)")
     ap.add_argument("--to", dest="dst", required=True, help="Target language code")
+    ap.add_argument(
+        "--batch-size",
+        type=int,
+        default=20,
+        help="Number of strings to translate per request (default: 20)",
+    )
     ap.add_argument("--root", default=os.path.dirname(os.path.dirname(__file__)), help="Repo root")
     args = ap.parse_args()
 
@@ -80,11 +86,12 @@ def main():
     to_translate = [(k, v) for k, v in english.items() if k not in messages]
 
     queue = [(k, v, 0) for k, v in to_translate]
+    batch_size = max(1, args.batch_size)
     translated = {}
     skipped: List[str] = []
     while queue:
-        batch = queue[:20]
-        queue = queue[20:]
+        batch = queue[:batch_size]
+        queue = queue[batch_size:]
         safe_lines = []
         tokens_list = []
         keys = []


### PR DESCRIPTION
## Summary
- extend `batch_translate.py` with `--batch-size` parameter
- mention smaller batch size usage in translation-support-tasks
- document new option in README

## Testing
- `bash .codex/install.sh`
- `dotnet test Bloodcraft.Tests/Bloodcraft.Tests.csproj`
- `dotnet build -c Release -p:RunGenerateREADME=false Bloodcraft.csproj`


------
https://chatgpt.com/codex/tasks/task_e_6889710a7800832d8b074e706c7214e0