### PR TITLE
Disable batch mode for Argos translation

### DIFF
--- a/.project-management/current-prd/translation-support-tasks.md
+++ b/.project-management/current-prd/translation-support-tasks.md
@@ -2,7 +2,7 @@
 
 These tasks break down the work described in `translation-support-prd.md`.
 
-* `Tools/batch_translate.py` retries each missing entry up to three times. Hashes that still fail are listed at the end and require manual translation. Use `--batch-size` to reduce the number of lines per request if Argos stalls.
+* `Tools/batch_translate.py` retries each missing entry up to three times. Hashes that still fail are listed at the end and require manual translation. The script now processes all lines in a single request by default; use `--batch-size` only if Argos stalls.
 
 - [x] Create placeholder message files for all languages  
   Copy English.json to new files for each language (Brazilian, French, etc.), ensure structure/hashes match, and add as <EmbeddedResource> in Bloodcraft.csproj.  
@@ -12,73 +12,125 @@ These tasks break down the work described in `translation-support-prd.md`.
   Confirm all language files are embedded and build loads resources without errors.  
   (Owner: @dev, Due: 2025-08-10)
 
-- [ ] Translate Spanish message file  
-  Provide Spanish translations for all entries in Spanish.json and verify with Tools/CheckTranslations.  
+- [ ] Translate Spanish message file
+  Provide Spanish translations for all entries in Spanish.json and verify with Tools/CheckTranslations.
   (Owner: @dev, Due: 2025-08-12)
 
-- [ ] Translate Brazilian Portuguese messages  
-  Populate Brazilian.json with Portuguese, validate using the checker tool.  
+:::task{title="Translate Spanish", owner="@dev", due="2025-08-12", status="open"}
+Run `python Tools/batch_translate.py Resources/Localization/Messages/Spanish.json --to es` to translate all missing entries at once. Add `--batch-size` only if Argos stalls.
+:::
+
+- [ ] Translate Brazilian Portuguese messages
+  Populate Brazilian.json with Portuguese, validate using the checker tool.
   (Owner: @dev, Due: 2025-08-13)
+:::task{title="Translate Brazilian Portuguese", owner="@dev", due="2025-08-13", status="open"}
+Run `python Tools/batch_translate.py Resources/Localization/Messages/Brazilian.json --to pt` to translate all missing entries at once. Add `--batch-size` only if Argos stalls.
+:::
 
-- [ ] Translate French messages  
-  Fill French.json and verify hashes/structure.  
+- [ ] Translate French messages
+  Fill French.json and verify hashes/structure.
   (Owner: @dev, Due: 2025-08-13)
+:::task{title="Translate French", owner="@dev", due="2025-08-13", status="open"}
+Run `python Tools/batch_translate.py Resources/Localization/Messages/French.json --to fr` to translate all missing entries at once. Add `--batch-size` only if Argos stalls.
+:::
 
-- [ ] Translate German messages  
-  Translate German.json and confirm with checker.  
+- [ ] Translate German messages
+  Translate German.json and confirm with checker.
   (Owner: @dev, Due: 2025-08-14)
+:::task{title="Translate German", owner="@dev", due="2025-08-14", status="open"}
+Run `python Tools/batch_translate.py Resources/Localization/Messages/German.json --to de` to translate all missing entries at once. Add `--batch-size` only if Argos stalls.
+:::
 
-- [ ] Translate Hungarian messages  
-  Translate Hungarian.json and run the checker tool.  
+- [ ] Translate Hungarian messages
+  Translate Hungarian.json and run the checker tool.
   (Owner: @dev, Due: 2025-08-14)
+:::task{title="Translate Hungarian", owner="@dev", due="2025-08-14", status="open"}
+Run `python Tools/batch_translate.py Resources/Localization/Messages/Hungarian.json --to hu` to translate all missing entries at once. Add `--batch-size` only if Argos stalls.
+:::
 
-- [ ] Translate Italian messages  
-  Provide Italian text in Italian.json and verify.  
+- [ ] Translate Italian messages
+  Provide Italian text in Italian.json and verify.
   (Owner: @dev, Due: 2025-08-15)
+:::task{title="Translate Italian", owner="@dev", due="2025-08-15", status="open"}
+Run `python Tools/batch_translate.py Resources/Localization/Messages/Italian.json --to it` to translate all missing entries at once. Add `--batch-size` only if Argos stalls.
+:::
 
-- [ ] Translate Japanese messages  
-  Update Japanese.json and run the checker.  
+- [ ] Translate Japanese messages
+  Update Japanese.json and run the checker.
   (Owner: @dev, Due: 2025-08-15)
+:::task{title="Translate Japanese", owner="@dev", due="2025-08-15", status="open"}
+Run `python Tools/batch_translate.py Resources/Localization/Messages/Japanese.json --to ja` to translate all missing entries at once. Add `--batch-size` only if Argos stalls.
+:::
 
-- [ ] Translate Korean messages  
-  Use Koreana.json for Korean, validate hashes/structure.  
+- [ ] Translate Korean messages
+  Use Koreana.json for Korean, validate hashes/structure.
   (Owner: @dev, Due: 2025-08-16)
+:::task{title="Translate Korean", owner="@dev", due="2025-08-16", status="open"}
+Run `python Tools/batch_translate.py Resources/Localization/Messages/Koreana.json --to ko` to translate all missing entries at once. Add `--batch-size` only if Argos stalls.
+:::
 
-- [ ] Translate Latin American Spanish messages  
-  Translate Latam.json fully and check for missing entries.  
+- [ ] Translate Latin American Spanish messages
+  Translate Latam.json fully and check for missing entries.
   (Owner: @dev, Due: 2025-08-16)
+:::task{title="Translate Latin American Spanish", owner="@dev", due="2025-08-16", status="open"}
+Run `python Tools/batch_translate.py Resources/Localization/Messages/Latam.json --to es` to translate all missing entries at once. Add `--batch-size` only if Argos stalls.
+:::
 
-- [ ] Translate Polish messages  
-  Fill Polish.json and verify with checker tool.  
+- [ ] Translate Polish messages
+  Fill Polish.json and verify with checker tool.
   (Owner: @dev, Due: 2025-08-17)
+:::task{title="Translate Polish", owner="@dev", due="2025-08-17", status="open"}
+Run `python Tools/batch_translate.py Resources/Localization/Messages/Polish.json --to pl` to translate all missing entries at once. Add `--batch-size` only if Argos stalls.
+:::
 
-- [ ] Translate Russian messages  
-  Provide Russian in Russian.json and verify.  
+- [ ] Translate Russian messages
+  Provide Russian in Russian.json and verify.
   (Owner: @dev, Due: 2025-08-17)
+:::task{title="Translate Russian", owner="@dev", due="2025-08-17", status="open"}
+Run `python Tools/batch_translate.py Resources/Localization/Messages/Russian.json --to ru` to translate all missing entries at once. Add `--batch-size` only if Argos stalls.
+:::
 
-- [ ] Translate Simplified Chinese messages  
-  Populate SChinese.json and run checker tool.  
+- [ ] Translate Simplified Chinese messages
+  Populate SChinese.json and run checker tool.
   (Owner: @dev, Due: 2025-08-18)
+:::task{title="Translate Simplified Chinese", owner="@dev", due="2025-08-18", status="open"}
+Run `python Tools/batch_translate.py Resources/Localization/Messages/SChinese.json --to zh` to translate all missing entries at once. Add `--batch-size` only if Argos stalls.
+:::
 
-- [ ] Translate Traditional Chinese messages  
-  Translate TChinese.json and verify completeness.  
+- [ ] Translate Traditional Chinese messages
+  Translate TChinese.json and verify completeness.
   (Owner: @dev, Due: 2025-08-18)
+:::task{title="Translate Traditional Chinese", owner="@dev", due="2025-08-18", status="open"}
+Run `python Tools/batch_translate.py Resources/Localization/Messages/TChinese.json --to zh` to translate all missing entries at once. Add `--batch-size` only if Argos stalls.
+:::
 
-- [ ] Translate Thai messages  
-  Provide Thai in Thai.json and run checker.  
+- [ ] Translate Thai messages
+  Provide Thai in Thai.json and run checker.
   (Owner: @dev, Due: 2025-08-19)
+:::task{title="Translate Thai", owner="@dev", due="2025-08-19", status="open"}
+Run `python Tools/batch_translate.py Resources/Localization/Messages/Thai.json --to th` to translate all missing entries at once. Add `--batch-size` only if Argos stalls.
+:::
 
-- [ ] Translate Turkish messages  
-  Translate Turkish.json fully and validate.  
+- [ ] Translate Turkish messages
+  Translate Turkish.json fully and validate.
   (Owner: @dev, Due: 2025-08-19)
+:::task{title="Translate Turkish", owner="@dev", due="2025-08-19", status="open"}
+Run `python Tools/batch_translate.py Resources/Localization/Messages/Turkish.json --to tr` to translate all missing entries at once. Add `--batch-size` only if Argos stalls.
+:::
 
-- [ ] Translate Ukrainian messages  
-  Update Ukrainian.json and run checker tool.  
+- [ ] Translate Ukrainian messages
+  Update Ukrainian.json and run checker tool.
   (Owner: @dev, Due: 2025-08-20)
+:::task{title="Translate Ukrainian", owner="@dev", due="2025-08-20", status="open"}
+Run `python Tools/batch_translate.py Resources/Localization/Messages/Ukrainian.json --to uk` to translate all missing entries at once. Add `--batch-size` only if Argos stalls.
+:::
 
-- [ ] Translate Vietnamese messages  
-  Fill Vietnamese.json and verify structure/hashes.  
+- [ ] Translate Vietnamese messages
+  Fill Vietnamese.json and verify structure/hashes.
   (Owner: @dev, Due: 2025-08-20)
+:::task{title="Translate Vietnamese", owner="@dev", due="2025-08-20", status="open"}
+Run `python Tools/batch_translate.py Resources/Localization/Messages/Vietnamese.json --to vi` to translate all missing entries at once. Add `--batch-size` only if Argos stalls.
+:::
 
 - [ ] Migrate remaining HandleServerReply calls  
   Replace LocalizationService.HandleServerReply with Reply, re-generate and check translations.  

--- a/README.md
+++ b/README.md
@@ -786,7 +786,7 @@ dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- generate-me
 
 Use `Tools/batch_translate.py` to generate missing strings. The script protects `<...>` tags and `{...}` variables by replacing them with `[[TOKEN_n]]`. Lines made entirely of tokens receive a `TRANSLATE` suffix so Argos does not skip them. After translating, run `check-translations` to ensure no English text remains. See `AGENTS.md` for the full workflow.
 
-`batch_translate.py` accepts `--batch-size` to control how many strings are sent to Argos in a single request (default `20`). Lower values may help if large batches stall or fail.
+`batch_translate.py` now processes all lines in one request by default. Use `--batch-size` only if Argos stalls and you need to split the translation into smaller chunks.
 
 ### Protecting Tags During Translation
 

--- a/Tools/batch_translate.py
+++ b/Tools/batch_translate.py
@@ -61,8 +61,8 @@ def main():
     ap.add_argument(
         "--batch-size",
         type=int,
-        default=20,
-        help="Number of strings to translate per request (default: 20)",
+        default=0,
+        help="Optional limit on strings per request; defaults to one batch",
     )
     ap.add_argument("--root", default=os.path.dirname(os.path.dirname(__file__)), help="Repo root")
     args = ap.parse_args()
@@ -86,7 +86,7 @@ def main():
     to_translate = [(k, v) for k, v in english.items() if k not in messages]
 
     queue = [(k, v, 0) for k, v in to_translate]
-    batch_size = max(1, args.batch_size)
+    batch_size = args.batch_size or len(queue)
     translated = {}
     skipped: List[str] = []
     while queue:


### PR DESCRIPTION
## Summary
- translate all messages in one pass by default
- document using batch_translate with no batching
- add single-batch tasks for all languages

## Testing
- `dotnet test --no-build` *(fails: command not found)*
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6889b90cacd0832da7ab9b303f98927d