### PR TITLE
Fix token count check in batch translation script

### DIFF
--- a/Tools/batch_translate.py
+++ b/Tools/batch_translate.py
@@ -108,7 +108,8 @@ def main():
         for (key, text, tries), result, (tokens, token_only, _) in zip(batch, results, tokens_list):
             if token_only:
                 result = result.replace(" TRANSLATE", "")
-            if len(TOKEN_RE.findall(result)) != len(tokens):
+            found_tokens = TOKEN_RE.findall(result)
+            if len(found_tokens) != len(tokens):
                 # translator mangled tokens
                 if tries + 1 >= MAX_ATTEMPTS:
                     print(f"Skipping {key} after {MAX_ATTEMPTS} attempts")


### PR DESCRIPTION
## Summary
- store tokens found in translation results and check the count with `len()`

## Testing
- `python3 -m py_compile Tools/batch_translate.py`


------
https://chatgpt.com/codex/tasks/task_e_688a6e28ac24832daa37cc8000f0bcd3