### PR TITLE
Rename translation script

### DIFF
--- a/.project-management/current-prd/translation-support-tasks.md
+++ b/.project-management/current-prd/translation-support-tasks.md
@@ -2,7 +2,7 @@
 
 These tasks break down the work described in `translation-support-prd.md`.
 
-* `Tools/batch_translate.py` retries each missing entry up to three times. Hashes that still fail are listed at the end and require manual translation. The script now processes all lines in a single request by default.
+* `Tools/translate.py` processes all missing entries in a single request. Hashes that fail validation are listed at the end and require manual translation.
 
 - [x] Create placeholder message files for all languages  
   Copy English.json to new files for each language (Brazilian, French, etc.), ensure structure/hashes match, and add as <EmbeddedResource> in Bloodcraft.csproj.  
@@ -17,119 +17,119 @@ These tasks break down the work described in `translation-support-prd.md`.
   (Owner: @dev, Due: 2025-08-12)
 
 :::task{title="Translate Spanish", owner="@dev", due="2025-08-12", status="open"}
-Run `python Tools/batch_translate.py Resources/Localization/Messages/Spanish.json --to es`
+Run `python Tools/translate.py Resources/Localization/Messages/Spanish.json --to es`
 :::
 
 - [ ] Translate Brazilian Portuguese messages
   Populate Brazilian.json with Portuguese, validate using the checker tool.
   (Owner: @dev, Due: 2025-08-13)
 :::task{title="Translate Brazilian Portuguese", owner="@dev", due="2025-08-13", status="open"}
-Run `python Tools/batch_translate.py Resources/Localization/Messages/Brazilian.json --to pt`
+Run `python Tools/translate.py Resources/Localization/Messages/Brazilian.json --to pt`
 :::
 
 - [ ] Translate French messages
   Fill French.json and verify hashes/structure.
   (Owner: @dev, Due: 2025-08-13)
 :::task{title="Translate French", owner="@dev", due="2025-08-13", status="open"}
-Run `python Tools/batch_translate.py Resources/Localization/Messages/French.json --to fr`
+Run `python Tools/translate.py Resources/Localization/Messages/French.json --to fr`
 :::
 
 - [ ] Translate German messages
   Translate German.json and confirm with checker.
   (Owner: @dev, Due: 2025-08-14)
 :::task{title="Translate German", owner="@dev", due="2025-08-14", status="open"}
-Run `python Tools/batch_translate.py Resources/Localization/Messages/German.json --to de`
+Run `python Tools/translate.py Resources/Localization/Messages/German.json --to de`
 :::
 
 - [ ] Translate Hungarian messages
   Translate Hungarian.json and run the checker tool.
   (Owner: @dev, Due: 2025-08-14)
 :::task{title="Translate Hungarian", owner="@dev", due="2025-08-14", status="open"}
-Run `python Tools/batch_translate.py Resources/Localization/Messages/Hungarian.json --to hu`
+Run `python Tools/translate.py Resources/Localization/Messages/Hungarian.json --to hu`
 :::
 
 - [ ] Translate Italian messages
   Provide Italian text in Italian.json and verify.
   (Owner: @dev, Due: 2025-08-15)
 :::task{title="Translate Italian", owner="@dev", due="2025-08-15", status="open"}
-Run `python Tools/batch_translate.py Resources/Localization/Messages/Italian.json --to it`
+Run `python Tools/translate.py Resources/Localization/Messages/Italian.json --to it`
 :::
 
 - [ ] Translate Japanese messages
   Update Japanese.json and run the checker.
   (Owner: @dev, Due: 2025-08-15)
 :::task{title="Translate Japanese", owner="@dev", due="2025-08-15", status="open"}
-Run `python Tools/batch_translate.py Resources/Localization/Messages/Japanese.json --to ja`
+Run `python Tools/translate.py Resources/Localization/Messages/Japanese.json --to ja`
 :::
 
 - [ ] Translate Korean messages
   Use Koreana.json for Korean, validate hashes/structure.
   (Owner: @dev, Due: 2025-08-16)
 :::task{title="Translate Korean", owner="@dev", due="2025-08-16", status="open"}
-Run `python Tools/batch_translate.py Resources/Localization/Messages/Koreana.json --to ko`
+Run `python Tools/translate.py Resources/Localization/Messages/Koreana.json --to ko`
 :::
 
 - [ ] Translate Latin American Spanish messages
   Translate Latam.json fully and check for missing entries.
   (Owner: @dev, Due: 2025-08-16)
 :::task{title="Translate Latin American Spanish", owner="@dev", due="2025-08-16", status="open"}
-Run `python Tools/batch_translate.py Resources/Localization/Messages/Latam.json --to es`
+Run `python Tools/translate.py Resources/Localization/Messages/Latam.json --to es`
 :::
 
 - [ ] Translate Polish messages
   Fill Polish.json and verify with checker tool.
   (Owner: @dev, Due: 2025-08-17)
 :::task{title="Translate Polish", owner="@dev", due="2025-08-17", status="open"}
-Run `python Tools/batch_translate.py Resources/Localization/Messages/Polish.json --to pl`
+Run `python Tools/translate.py Resources/Localization/Messages/Polish.json --to pl`
 :::
 
 - [ ] Translate Russian messages
   Provide Russian in Russian.json and verify.
   (Owner: @dev, Due: 2025-08-17)
 :::task{title="Translate Russian", owner="@dev", due="2025-08-17", status="open"}
-Run `python Tools/batch_translate.py Resources/Localization/Messages/Russian.json --to ru`
+Run `python Tools/translate.py Resources/Localization/Messages/Russian.json --to ru`
 :::
 
 - [ ] Translate Simplified Chinese messages
   Populate SChinese.json and run checker tool.
   (Owner: @dev, Due: 2025-08-18)
 :::task{title="Translate Simplified Chinese", owner="@dev", due="2025-08-18", status="open"}
-Run `python Tools/batch_translate.py Resources/Localization/Messages/SChinese.json --to zh`
+Run `python Tools/translate.py Resources/Localization/Messages/SChinese.json --to zh`
 :::
 
 - [ ] Translate Traditional Chinese messages
   Translate TChinese.json and verify completeness.
   (Owner: @dev, Due: 2025-08-18)
 :::task{title="Translate Traditional Chinese", owner="@dev", due="2025-08-18", status="open"}
-Run `python Tools/batch_translate.py Resources/Localization/Messages/TChinese.json --to zh`
+Run `python Tools/translate.py Resources/Localization/Messages/TChinese.json --to zh`
 :::
 
 - [ ] Translate Thai messages
   Provide Thai in Thai.json and run checker.
   (Owner: @dev, Due: 2025-08-19)
 :::task{title="Translate Thai", owner="@dev", due="2025-08-19", status="open"}
-Run `python Tools/batch_translate.py Resources/Localization/Messages/Thai.json --to th`
+Run `python Tools/translate.py Resources/Localization/Messages/Thai.json --to th`
 :::
 
 - [ ] Translate Turkish messages
   Translate Turkish.json fully and validate.
   (Owner: @dev, Due: 2025-08-19)
 :::task{title="Translate Turkish", owner="@dev", due="2025-08-19", status="open"}
-Run `python Tools/batch_translate.py Resources/Localization/Messages/Turkish.json --to tr`
+Run `python Tools/translate.py Resources/Localization/Messages/Turkish.json --to tr`
 :::
 
 - [ ] Translate Ukrainian messages
   Update Ukrainian.json and run checker tool.
   (Owner: @dev, Due: 2025-08-20)
 :::task{title="Translate Ukrainian", owner="@dev", due="2025-08-20", status="open"}
-Run `python Tools/batch_translate.py Resources/Localization/Messages/Ukrainian.json --to uk`
+Run `python Tools/translate.py Resources/Localization/Messages/Ukrainian.json --to uk`
 :::
 
 - [ ] Translate Vietnamese messages
   Fill Vietnamese.json and verify structure/hashes.
   (Owner: @dev, Due: 2025-08-20)
 :::task{title="Translate Vietnamese", owner="@dev", due="2025-08-20", status="open"}
-Run `python Tools/batch_translate.py Resources/Localization/Messages/Vietnamese.json --to vi`
+Run `python Tools/translate.py Resources/Localization/Messages/Vietnamese.json --to vi`
 :::
 
 - [ ] Migrate remaining HandleServerReply calls  

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ The Codex system uses the following keywords:
    `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- generate-messages .`
 2. Copy `English.json` to `<Language>.json` and translate each value while keeping numeric hashes.
 3. Automatically translate missing strings with Argos:
-   `python Tools/batch_translate.py Resources/Localization/Messages/<Language>.json --to <iso-code>`
+   `python Tools/translate.py Resources/Localization/Messages/<Language>.json --to <iso-code>`
 4. The script hides `<...>` tags and `{...}` placeholders as `[[TOKEN_n]]` tokens. Lines consisting only of tokens are given a dummy `TRANSLATE` suffix so Argos will process them.
    **DO NOT** edit text inside these tokens, tags, or variables.
 5. After translation, run the checker to ensure nothing remains in English:

--- a/README.md
+++ b/README.md
@@ -784,9 +784,9 @@ dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- generate-me
 
 ### Translation Workflow
 
-Use `Tools/batch_translate.py` to generate missing strings. The script protects `<...>` tags and `{...}` variables by replacing them with `[[TOKEN_n]]`. Lines made entirely of tokens receive a `TRANSLATE` suffix so Argos does not skip them. After translating, run `check-translations` to ensure no English text remains. See `AGENTS.md` for the full workflow.
+Use `Tools/translate.py` to generate missing strings. The script protects `<...>` tags and `{...}` variables by replacing them with `[[TOKEN_n]]`. Lines made entirely of tokens receive a `TRANSLATE` suffix so Argos does not skip them. After translating, run `check-translations` to ensure no English text remains. See `AGENTS.md` for the full workflow.
 
-`batch_translate.py` now processes all messages in a single request. Batching is not supported.
+`translate.py` sends all messages in a single request without retries or batching.
 
 ### Protecting Tags During Translation
 

--- a/Tools/translate.py
+++ b/Tools/translate.py
@@ -6,8 +6,6 @@ import re
 import subprocess
 from typing import List
 
-MAX_ATTEMPTS = 3
-
 RICHTEXT = re.compile(r'<[^>]+>')
 PLACEHOLDER = re.compile(r'\{[^{}]+\}')
 CSINTERP = re.compile(r'\$\{[^{}]+\}')
@@ -79,53 +77,46 @@ def main():
     messages = target.get("Messages", {})
     to_translate = [(k, v) for k, v in english.items() if k not in messages]
 
-    queue = [(k, v, 0) for k, v in to_translate]
-    translated = {}
+    if not to_translate:
+        print("No messages need translation.")
+        return
+
+    safe_lines: List[str] = []
+    tokens_list: List[tuple[List[str], bool]] = []
+    keys: List[str] = []
+
+    for key, text in to_translate:
+        safe, tokens = protect(text)
+        token_only = TOKEN_RE.sub("", safe).strip() == ""
+        if token_only:
+            safe += " TRANSLATE"
+        safe_lines.append(safe)
+        tokens_list.append((tokens, token_only))
+        keys.append(key)
+
+    try:
+        results = translate_batch(args.src, args.dst, safe_lines)
+    except Exception as e:
+        print("Translation error:", e)
+        return
+
+    translated: dict[str, str] = {}
     skipped: List[str] = []
-    while queue:
-        batch = queue
-        queue = []
-        safe_lines = []
-        tokens_list = []
-        for key, text, tries in batch:
-            safe, tokens = protect(text)
-            token_only = TOKEN_RE.sub("", safe).strip() == ""
-            if token_only:
-                safe += " TRANSLATE"
-            safe_lines.append(safe)
-            tokens_list.append((tokens, token_only, tries))
-        try:
-            results = translate_batch(args.src, args.dst, safe_lines)
-        except Exception as e:
-            print("Translation error", e)
-            for key, text, tries in batch:
-                if tries + 1 >= MAX_ATTEMPTS:
-                    print(f"Skipping {key} after {MAX_ATTEMPTS} attempts")
-                    skipped.append(key)
-                else:
-                    queue.append((key, text, tries + 1))
+
+    for key, result, (tokens, token_only) in zip(keys, results, tokens_list):
+        if token_only:
+            result = result.replace(" TRANSLATE", "")
+        if len(TOKEN_RE.findall(result)) != len(tokens):
+            print(f"Skipping {key}: token mismatch")
+            skipped.append(key)
             continue
-        for (key, text, tries), result, (tokens, token_only, _) in zip(batch, results, tokens_list):
-            if token_only:
-                result = result.replace(" TRANSLATE", "")
-            if len(TOKEN_RE.findall(result)) != len(tokens):
-                # translator mangled tokens
-                if tries + 1 >= MAX_ATTEMPTS:
-                    print(f"Skipping {key} after {MAX_ATTEMPTS} attempts")
-                    skipped.append(key)
-                else:
-                    queue.append((key, text, tries + 1))
-                continue
-            un = unprotect(result, tokens)
-            un = un.replace("\\u003C", "<").replace("\\u003E", ">")
-            if un == text or contains_english(un):
-                if tries + 1 >= MAX_ATTEMPTS:
-                    print(f"Skipping {key} after {MAX_ATTEMPTS} attempts")
-                    skipped.append(key)
-                else:
-                    queue.append((key, text, tries + 1))
-                continue
-            translated[key] = un
+        un = unprotect(result, tokens)
+        un = un.replace("\\u003C", "<").replace("\\u003E", ">")
+        if un == english[key] or contains_english(un):
+            print(f"Skipping {key}: looks untranslated")
+            skipped.append(key)
+            continue
+        translated[key] = un
 
     messages.update(translated)
     target["Messages"] = messages


### PR DESCRIPTION
## Summary
- rename batch_translate.py to translate.py
- simplify translate.py logic to send all messages at once
- update docs and translation tasks

## Testing
- `dotnet --version`
- `dotnet test --no-build` *(no output, likely zero tests)*
- `./dev_init.sh` *(fails: Build failed: ./bin/Release/net6.0/Bloodcraft.dll not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a6e175e04832d8fd130984e4559ae