### PR TITLE
Fix batch_translate and ensure newline

### DIFF
--- a/Resources/Localization/Messages/Spanish.json
+++ b/Resources/Localization/Messages/Spanish.json
@@ -3,3 +3,4 @@
     "3439613370": "Bienvenido a Bloodcraft"
   }
 }
+

--- a/Tools/batch_translate.py
+++ b/Tools/batch_translate.py
@@ -5,6 +5,7 @@ import os
 import re
 import subprocess
 from typing import List
+from argostranslate import translate as argos_translate
 
 MAX_ATTEMPTS = 3
 
@@ -41,16 +42,11 @@ def contains_english(text: str) -> bool:
 
 
 def translate_batch(src: str, dst: str, lines: List[str]) -> List[str]:
-    joined = "\n".join(lines)
-    result = subprocess.run(
-        ["argos-translate", "-f", src, "-t", dst],
-        input=joined,
-        text=True,
-        capture_output=True,
-    )
-    if result.returncode != 0:
-        raise RuntimeError(result.stderr)
-    return result.stdout.strip().splitlines()
+    languages = {l.code: l for l in argos_translate.get_installed_languages()}
+    if src not in languages or dst not in languages:
+        raise RuntimeError(f"Languages {src}->{dst} not installed")
+    translator = languages[src].get_translation(languages[dst])
+    return [translator.translate(line) for line in lines]
 
 
 def main():


### PR DESCRIPTION
## Summary
- use Argos Translate library directly in `Tools/batch_translate.py`
- ensure `Spanish.json` ends with a newline

## Testing
- `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations` *(fails: untranslated hashes remain)*

------
https://chatgpt.com/codex/tasks/task_e_688a6e2e86cc832db1563b7da7d95321