### PR TITLE
Automate secrets generation in install script

### DIFF
--- a/.codex/install.sh
+++ b/.codex/install.sh
@@ -7,11 +7,23 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 DOTNET_VERSION="6.0"
 
+
 if ! command -v dotnet >/dev/null; then
     echo "Installing .NET $DOTNET_VERSION SDK..."
     curl -sSL https://dot.net/v1/dotnet-install.sh -o "$SCRIPT_DIR/dotnet-install.sh"
     bash "$SCRIPT_DIR/dotnet-install.sh" --channel "$DOTNET_VERSION"
     export PATH="$HOME/.dotnet:$PATH"
+fi
+
+# Ensure embedded secrets exist before restoring
+SECRETS_FILE="$ROOT_DIR/Resources/secrets.json"
+if [ ! -f "$SECRETS_FILE" ]; then
+    mkdir -p "$(dirname "$SECRETS_FILE")"
+    cat >"$SECRETS_FILE" <<'EOF'
+{
+  "NEW_SHARED_KEY": "3xUjC8aOZ9+RlWoCphxH5MvFOPkvIf2P/8b89GiQjbE="
+}
+EOF
 fi
 
 dotnet restore "$ROOT_DIR/Bloodcraft.csproj"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,8 @@ The Codex system uses the following keywords:
 * **ClosePrd** – finalize and archive completed PRDs.
 
 0. Codex-related workflow items belong in `AGENTS.md`, NOT `README.md`!
-1. Run `.codex/install.sh` once to install dependencies
+1. Run `.codex/install.sh` once to install dependencies. This will also generate
+   `Resources/secrets.json` with default development secrets.
 2. Build and deploy locally with `./dev_init.sh`
 3. Update message hashes when needed using `Tools/GenerateMessageTranslations`:
    `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- generate-messages`


### PR DESCRIPTION
## Summary
- create `Resources/secrets.json` automatically from `.codex/install.sh`
- mention the generated secrets file in `AGENTS.md`

## Testing
- `bash .codex/install.sh`
- `dotnet test Bloodcraft.Tests/Bloodcraft.Tests.csproj --no-build --logger trx`

------
https://chatgpt.com/codex/tasks/task_e_688afeedd9d0832d93a20915f74a530e