### PR TITLE
Enable automatic primal rift events

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,8 @@ Jairon O.; Odjit; Jera; Kokuren TCG and Gaming Shop; Rexxn; Eduardo G.; DirtyMik
   Enable or disable elite shard bearers.
 - **Shard Bearer Level**: `ShardBearerLevel` (int, default: 0)
   Sets level of shard bearers if elite shard bearers is enabled. Leave at 0 for no effect.
+- **Primal Rift Frequency**: `PrimalRiftFrequency` (int, default: 0)
+  Number of primal rifts automatically triggered per day. Set to 0 to disable.
 - **Potion Stacking**: `PotionStacking` (bool, default: False)
   Enable or disable potion stacking (can have t01/t02 effects at the same time).
 - **Bear Form Dash**: `BearFormDash` (bool, default: False)

--- a/Services/ConfigService.cs
+++ b/Services/ConfigService.cs
@@ -23,6 +23,9 @@ internal static class ConfigService
     static readonly Lazy<int> _shardBearerLevel = new(() => GetConfigValue<int>("ShardBearerLevel"));
     public static int ShardBearerLevel => _shardBearerLevel.Value;
 
+    static readonly Lazy<int> _primalRiftFrequency = new(() => GetConfigValue<int>("PrimalRiftFrequency"));
+    public static int PrimalRiftFrequency => _primalRiftFrequency.Value;
+
     static readonly Lazy<bool> _potionStacking = new(() => GetConfigValue<bool>("PotionStacking"));
     public static bool PotionStacking => _potionStacking.Value;
 
@@ -519,6 +522,7 @@ internal static class ConfigService
             new ConfigEntryDefinition("General", "ElitePrimalRifts", false, "Enable or disable elite primal rifts. (WIP!)"),
             new ConfigEntryDefinition("General", "EliteShardBearers", false, "Enable or disable elite shard bearers."),
             new ConfigEntryDefinition("General", "ShardBearerLevel", 0, "Sets level of shard bearers if elite shard bearers is enabled. Leave at 0 for no effect."),
+            new ConfigEntryDefinition("General", "PrimalRiftFrequency", 0, "Number of primal rifts to start per day automatically. 0 to disable."),
             new ConfigEntryDefinition("General", "PotionStacking", false, "Enable or disable potion stacking (can have t01/t02 effects at the same time)."),
             new ConfigEntryDefinition("General", "BearFormDash", false, "Enable or disable bear form dash."),
             new ConfigEntryDefinition("General", "BleedingEdge", "", "Enable various weapon-specific changes; some are more experimental than others, see README for details. (Slashers, Crossbow, Pistols, TwinBlades, Daggers)"),

--- a/Systems/PrimalWarEventSystemBase.cs
+++ b/Systems/PrimalWarEventSystemBase.cs
@@ -1,5 +1,8 @@
-﻿using Bloodcraft.Resources;
+using Bloodcraft.Resources;
 using Bloodcraft.Utilities;
+using Bloodcraft.Services;
+using System;
+using System.Linq;
 using Il2CppInterop.Runtime;
 using ProjectM;
 using ProjectM.Scripting;
@@ -39,6 +42,18 @@ public class PrimalWarEventSystem : SystemBase
         PrefabGUIDs.AB_CastleMan_HolyBeam_PowerBuff_01,
         PrefabGUIDs.AB_Chaos_PowerSurge_Buff
     ];
+
+    static readonly ComponentType[] _eventComponents =
+    [
+        ComponentType.ReadOnly(Il2CppType.Of<WarEvent_StartEvent>()),
+        ComponentType.ReadOnly(Il2CppType.Of<FromCharacter>()),
+        ComponentType.ReadOnly(Il2CppType.Of<NetworkEventType>())
+    ];
+
+    static readonly int _primalRiftFrequency = ConfigService.PrimalRiftFrequency;
+
+    double _nextRiftTime;
+    double _riftInterval;
 
     static bool _isEdited;
 
@@ -99,6 +114,12 @@ public class PrimalWarEventSystem : SystemBase
     public override void OnStartRunning()
     {
         if (!_isEdited) _isEdited = TryModifyPrimalUnitCompositions(); // OnCreate too soon
+
+        if (_primalRiftFrequency > 0)
+        {
+            _riftInterval = 86400.0 / _primalRiftFrequency;
+            _nextRiftTime = Core.ServerTime + _riftInterval;
+        }
     }
     bool TryModifyPrimalUnitCompositions()
     {
@@ -177,6 +198,12 @@ public class PrimalWarEventSystem : SystemBase
 
         _entityHandle.Update(this);
         _entityStorageInfoLookup.Update(this);
+
+        if (_primalRiftFrequency > 0 && Core.ServerTime >= _nextRiftTime)
+        {
+            StartPrimalWarEvent();
+            _nextRiftTime = Core.ServerTime + _riftInterval;
+        }
 
         SweepHandled();
         HandleActiveGates(_gateQuery);
@@ -411,5 +438,41 @@ public class PrimalWarEventSystem : SystemBase
             aiMoveSpeeds.Run._Value *= MID_AMP;
             aiMoveSpeeds.Circle._Value *= MID_AMP;
         });
+    }
+
+    public static void StartPrimalWarEvent()
+    {
+        if (PlayerService.SteamIdOnlinePlayerInfoCache.Count == 0)
+        {
+            Core.Log.LogWarning("[PrimalWarEventSystem] No online players to start event.");
+            return;
+        }
+
+        var player = PlayerService.SteamIdOnlinePlayerInfoCache.Values.First();
+        if (!player.UserEntity.Exists() || !player.CharEntity.Exists()) return;
+
+        NetworkEventType networkEventType = new()
+        {
+            EventId = NetworkEvents.EventId_WarEvent_StartEvent,
+            IsAdminEvent = true,
+            IsDebugEvent = true
+        };
+
+        WarEvent_StartEvent warEvent = new()
+        {
+            EventType = WarEventType.Primal,
+            EnableAllGates = true
+        };
+
+        FromCharacter fromCharacter = new()
+        {
+            Character = player.CharEntity,
+            User = player.UserEntity
+        };
+
+        Entity entity = Core.EntityManager.CreateEntity(_eventComponents);
+        entity.Write(warEvent);
+        entity.Write(fromCharacter);
+        entity.Write(networkEventType);
     }
 }


### PR DESCRIPTION
## Summary
- introduce `PrimalRiftFrequency` config
- document the new setting
- schedule primal rift events in `PrimalWarEventSystem`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ba0507384832d8612fed7bf0b0fe6