### PR TITLE
Update translation task

### DIFF
--- a/.project-management/current-prd/translation-support-tasks.md
+++ b/.project-management/current-prd/translation-support-tasks.md
@@ -16,7 +16,8 @@ These tasks break down the work described in `translation-support-prd.md`.
   Provide Spanish translations for all entries in Spanish.json and verify with Tools/CheckTranslations.
   (Owner: @dev, Due: 2025-08-12)
 
-:::task{title="Translate Spanish", owner="@dev", due="2025-08-12", status="in_progress"}
+:::task{title="Translate Spanish", owner="@dev", due="2025-08-12", status="blocked"}
+Argos Translate language data missing; cannot run translation command.
 Run `python Tools/translate.py Resources/Localization/Messages/Spanish.json --to es`
 :::
 

--- a/Resources/Localization/Messages/English.json
+++ b/Resources/Localization/Messages/English.json
@@ -300,6 +300,7 @@
     "562341898": "Total change in growth rate including leveling prestige bonus: \u003Ccolor=yellow\u003E{totalEffectString}\u003C/color\u003E",
     "1812818458": "You have prestiged in \u003Ccolor=#90EE90\u003EExperience\u003C/color\u003E[\u003Ccolor=white\u003E{prestigeLevel}\u003C/color\u003E]! Growth rates for all expertise/legacies increased by \u003Ccolor=green\u003E{gainPercentage}\u003C/color\u003E, experience from unit kills reduced by \u003Ccolor=red\u003E{reductionPercentage}\u003C/color\u003E.",
     "709298301": "\u003Ccolor=#90EE90\u003E{parsedPrestigeType}\u003C/color\u003E[\u003Ccolor=white\u003E{prestigeLevel}\u003C/color\u003E] prestiged successfully! Growth rate reduced by \u003Ccolor=red\u003E{percentageReductionString}\u003C/color\u003E and stat bonuses improved by \u003Ccolor=green\u003E{statGainString}\u003C/color\u003E. The total change in growth rate with leveling prestige bonus is \u003Ccolor=yellow\u003E{totalEffectString}\u003C/color\u003E.",
-    "1443941563": "Removed prestige buffs from all players."
+    "1443941563": "Removed prestige buffs from all players.",
+    "1286090332": "You\u0027re level [\u003Ccolor=white\u003E{data.Key}\u003C/color\u003E][\u003Ccolor=#90EE90\u003E{prestigeLevel}\u003C/color\u003E] with \u003Ccolor=yellow\u003E{progress}\u003C/color\u003E \u003Ccolor=#FFC0CB\u003Eessence\u003C/color\u003E (\u003Ccolor=white\u003E{BloodSystem.GetLevelProgress(ctx.Event.User.PlatformId, handler)}%\u003C/color\u003E) in \u003Ccolor=red\u003E{handler.GetBloodType()}\u003C/color\u003E!"
   }
 }


### PR DESCRIPTION
## Summary
- mark Spanish translation task blocked
- update English.json message hashes

## Testing
- `./dev_init.sh`
- `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- generate-messages`
- `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations`
- `dotnet test Bloodcraft.Tests/Bloodcraft.Tests.csproj -v m --no-build`


------
https://chatgpt.com/codex/tasks/task_e_688bb9001688832db3493c731b7d982d