### PR TITLE
Add translation retry and timeout options

### DIFF
--- a/README.md
+++ b/README.md
@@ -786,7 +786,7 @@ dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- generate-me
 
 Use `Tools/translate.py` to generate missing strings. The script protects `<...>` tags and `{...}` variables by replacing them with `[[TOKEN_n]]`. Lines made entirely of tokens receive a `TRANSLATE` suffix so Argos does not skip them. After translating, run `check-translations` to ensure no English text remains. See `AGENTS.md` for the full workflow.
 
-`translate.py` accepts a `--batch-size` option to split work across multiple requests and retries failed lines up to `--max-retries` times. Re-run it on a clean copy of `Spanish.json` to restart translations from scratch.
+`translate.py` accepts `--batch-size`, `--max-retries`, and `--timeout` options. It splits work across batches and retries each batch up to the specified limit, waiting at most `--timeout` seconds for Argos to respond. Re-run it on a clean copy of `Spanish.json` to restart translations from scratch.
 
 ### Protecting Tags During Translation
 


### PR DESCRIPTION
## Summary
- add `--max-retries` and `--timeout` options to `translate.py`
- retry translation batches and handle timeouts
- document new options in README

## Testing
- `dotnet build --no-restore -p:RunGenerateREADME=false`
- `dotnet test Bloodcraft.Tests/Bloodcraft.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_688cd41c9168832d96831d0f12b18604