### PR TITLE
Align English word regex across tools

### DIFF
--- a/Tools/CheckTranslations.cs
+++ b/Tools/CheckTranslations.cs
@@ -58,7 +58,7 @@ internal static class CheckTranslations
     }
 
     static readonly Regex EnglishWords = new(
-        @"\b(the|and|of|to|with|you|your|for|a|an)\b",
+        @"\b(the|and|of|with|you|your|for|an)\b",
         RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
     static bool LooksEnglish(string txt)

--- a/Tools/translate.py
+++ b/Tools/translate.py
@@ -11,7 +11,7 @@ PLACEHOLDER = re.compile(r'\{[^{}]+\}')
 CSINTERP = re.compile(r'\$\{[^{}]+\}')
 TOKEN_RE = re.compile(r'\[\[TOKEN_(\d+)\]\]')
 
-ENGLISH_WORDS = re.compile(r'\b(the|and|of|to|with|you|your|for|a|an)\b', re.I)
+ENGLISH_WORDS = re.compile(r'\b(the|and|of|with|you|your|for|an)\b', re.I)
 
 
 def protect(text: str):


### PR DESCRIPTION
## Summary
- update regex to remove `a` and `to` from English detection
- keep `CheckTranslations` in sync with `translate.py`

## Testing
- `dotnet test Bloodcraft.Tests/Bloodcraft.Tests.csproj -v minimal`
- `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations`

------
https://chatgpt.com/codex/tasks/task_e_688cdb3cc4e8832daf89a5c77db6c608