### PR TITLE
Add verbose output option for translation checker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ The Codex system uses the following keywords:
    **DO NOT** edit text inside these tokens, tags, or variables.
 5. After translation, run the checker to ensure nothing remains in English:
    `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations`
+   Use `--show-text` to also print the English string and existing translation alongside each hash.
 
 Current PRDs and task lists are stored in `.project-management/current-prd/`, while completed items are moved to `.project-management/closed-prd/`. Codex is expected to own as much as it feels capable of doing so in terms of completion, furthering goals, and being generally proactive with managing tasks to completion of state project goals. Compile with .NET 8 to build with preview features, though do note VRising runs on the .NET 6 runtime as the .csproj implies; be mindful to stay within the .NET 6 API surface to avoid surprises.
 

--- a/GenerateREADME.cs
+++ b/GenerateREADME.cs
@@ -43,8 +43,18 @@ internal static class GenerateREADME
 
         if (args.Length >= 1 && args[0].Equals("check-translations", StringComparison.OrdinalIgnoreCase))
         {
-            string root = args.Length > 1 ? args[1] : Directory.GetCurrentDirectory();
-            Tools.CheckTranslations.Run(root);
+            string root = Directory.GetCurrentDirectory();
+            bool showText = false;
+            for (int i = 1; i < args.Length; i++)
+            {
+                string arg = args[i];
+                if (arg.Equals("--show-text", StringComparison.OrdinalIgnoreCase) || arg.Equals("--verbose", StringComparison.OrdinalIgnoreCase))
+                    showText = true;
+                else if (!arg.StartsWith("-"))
+                    root = arg;
+            }
+
+            Tools.CheckTranslations.Run(root, showText);
             return;
         }
 

--- a/README.md
+++ b/README.md
@@ -784,7 +784,7 @@ dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- generate-me
 
 ### Translation Workflow
 
-Use `Tools/translate.py` to generate missing strings. The script protects `<...>` tags and `{...}` variables by replacing them with `[[TOKEN_n]]`. Lines made entirely of tokens receive a `TRANSLATE` suffix so Argos does not skip them. After translating, run `check-translations` to ensure no English text remains. See `AGENTS.md` for the full workflow.
+Use `Tools/translate.py` to generate missing strings. The script protects `<...>` tags and `{...}` variables by replacing them with `[[TOKEN_n]]`. Lines made entirely of tokens receive a `TRANSLATE` suffix so Argos does not skip them. After translating, run `check-translations` to ensure no English text remains. Pass `--show-text` (or `--verbose`) to also display the English source and current translation for each reported hash. See `AGENTS.md` for the full workflow.
 
 `translate.py` accepts `--batch-size`, `--max-retries`, and `--timeout` options. It splits work across batches and retries each batch up to the specified limit, waiting at most `--timeout` seconds for Argos to respond. Use `--verbose` to display the key, original text, and translated text for each entry, with skipped reasons; provide `--log-file` to write the same information to a file. Re-run it on a clean copy of `Spanish.json` to restart translations from scratch.
 

--- a/Tools/CheckTranslations.cs
+++ b/Tools/CheckTranslations.cs
@@ -4,7 +4,7 @@ using System.Text.RegularExpressions;
 namespace Bloodcraft.Tools;
 internal static class CheckTranslations
 {
-    public static void Run(string rootPath)
+    public static void Run(string rootPath, bool showText = false)
     {
         string messagesDir = Path.Combine(rootPath, "Resources", "Localization", "Messages");
         string engPath = Path.Combine(messagesDir, "English.json");
@@ -40,14 +40,35 @@ internal static class CheckTranslations
             {
                 Console.WriteLine($"Missing hashes in {Path.GetFileName(path)}:");
                 foreach (string h in missing)
-                    Console.WriteLine($"  {h}");
+                {
+                    if (showText)
+                    {
+                        string eng = englishFile.Messages.GetValueOrDefault(h, string.Empty);
+                        Console.WriteLine($"  {h}: {eng}");
+                    }
+                    else
+                    {
+                        Console.WriteLine($"  {h}");
+                    }
+                }
             }
 
             if (englishLike.Count > 0)
             {
                 Console.WriteLine($"Potential untranslated strings in {Path.GetFileName(path)}:");
                 foreach (string h in englishLike)
-                    Console.WriteLine($"  {h}");
+                {
+                    if (showText)
+                    {
+                        string eng = englishFile.Messages.GetValueOrDefault(h, string.Empty);
+                        string current = langFile.Messages[h];
+                        Console.WriteLine($"  {h}: {eng} -> {current}");
+                    }
+                    else
+                    {
+                        Console.WriteLine($"  {h}");
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- enhance `CheckTranslations` to optionally print English text and translations
- support `--show-text`/`--verbose` flag in GenerateREADME CLI
- document new flag in README and AGENTS

## Testing
- `dotnet test Bloodcraft.Tests/Bloodcraft.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_688cedc7c334832dbd2542b884522751