### PR TITLE
Install Argos Translate during setup

### DIFF
--- a/.codex/install.sh
+++ b/.codex/install.sh
@@ -21,13 +21,22 @@ if ! dotnet --list-sdks 2>/dev/null | grep -q '^6\.'; then
 fi
 
 export DOTNET_ROOT="$HOME/.dotnet"
-export PATH="$DOTNET_ROOT:$PATH"
+export PATH="$DOTNET_ROOT:$PATH:$HOME/.local/bin"
 
 # Persist environment variables for future sessions
 if ! grep -q "DOTNET_ROOT" "$HOME/.bashrc"; then
     echo "export DOTNET_ROOT=$DOTNET_ROOT" >> "$HOME/.bashrc"
-    echo "export PATH=\$DOTNET_ROOT:\$PATH" >> "$HOME/.bashrc"
+    echo "export PATH=\$DOTNET_ROOT:\$PATH:\$HOME/.local/bin" >> "$HOME/.bashrc"
 fi
+
+# Install Argos Translate and expose CLI
+python3 -m pip install --user --no-cache-dir argostranslate==1.8.0
+mkdir -p "$HOME/.local/bin"
+cat >"$HOME/.local/bin/argos-translate" <<'EOF'
+#!/usr/bin/env bash
+python3 -m argostranslate.cli "$@"
+EOF
+chmod +x "$HOME/.local/bin/argos-translate"
 
 # Ensure embedded secrets exist before restoring
 SECRETS_FILE="$ROOT_DIR/Resources/secrets.json"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - [BleedingEdge](#bleedingedge)
 - [Configuration](#configuration)
 - [Recommended Mods](#recommended-mods)
+- [Development Setup](#development-setup)
 - [Codex Workflow](#codex-workflow)
 - [Workflow Source](#workflow-source)
 - [Credits](#credits)
@@ -772,6 +773,11 @@ Jairon O.; Odjit; Jera; Kokuren TCG and Gaming Shop; Rexxn; Eduardo G.; DirtyMik
   Create custom portals and waygates for your server! Pairs great with KindredSchematics for making new areas.
 - [XPRising](https://thunderstore.io/c/v-rising/p/XPRising/XPRising/)
   If you like the idea of a mod with RPG features but Bloodcraft doesn't float your boat maybe this will!
+
+## Development Setup
+
+Run `.codex/install.sh` once to install the .NET SDK and Argos Translate. The script adds
+`~/.local/bin` to your `PATH` so the `argos-translate` CLI is available in future sessions.
 
 ## Localization (WIP)
 


### PR DESCRIPTION
## Summary
- install Argos Translate from the setup script
- add `~/.local/bin` to PATH and persist in `.bashrc`
- create a wrapper for the `argos-translate` CLI
- document the new setup step in the README

## Testing
- `./.codex/install.sh`
- `dotnet test Bloodcraft.Tests/Bloodcraft.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_688d1edb02e0832daf6e6b193900e55e