### PR TITLE
Add Argos Python API translation tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,8 +21,8 @@ The Codex system uses the following keywords:
    `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- generate-messages`
 2. Copy `English.json` to `<Language>.json` and translate each value while keeping numeric hashes.
 3. Automatically translate missing strings with Argos:
-   `python Tools/translate.py Resources/Localization/Messages/<Language>.json --to <iso-code> --batch-size 100 --max-retries 3 --verbose --log-file translate.log`
-   `--verbose` and `--log-file` help pinpoint skipped or untranslated strings.
+   `python Tools/translate_argos.py Resources/Localization/Messages/<Language>.json --to <iso-code> --batch-size 100 --max-retries 3 --verbose --log-file translate.log`
+   `--verbose` and `--log-file` help pinpoint skipped or untranslated strings. `translate.py` still exists but prints a deprecation warning.
 4. The script hides `<...>` tags and `{...}` placeholders as `[[TOKEN_n]]` tokens. Lines consisting only of tokens are given a dummy `TRANSLATE` suffix so Argos will process them.
    **DO NOT** edit text inside these tokens, tags, or variables.
 5. After translation, run the checker to ensure nothing remains in English:

--- a/README.md
+++ b/README.md
@@ -784,8 +784,8 @@ dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- generate-me
 
 ### Translation Workflow
 
-Use `Tools/translate.py` to generate missing strings. The script protects `<...>` tags and `{...}` variables by replacing them with `[[TOKEN_n]]`. Lines made entirely of tokens receive a `TRANSLATE` suffix so Argos does not skip them. Pass `--verbose` to display each entry as it is processed and `--log-file` to keep a record. After translating, run `check-translations --show-text` to pinpoint any skipped or untranslated strings. See `AGENTS.md` for the full workflow.
-`translate.py` accepts `--batch-size`, `--max-retries`, and `--timeout` options. It splits work across batches and retries each batch up to the specified limit, waiting at most `--timeout` seconds for Argos to respond. Re-run it on a clean copy of `Spanish.json` to restart translations from scratch.
+Use `Tools/translate_argos.py` to generate missing strings. The script uses the `argostranslate` Python API and protects `<...>` tags and `{...}` variables by replacing them with `[[TOKEN_n]]`. Lines made entirely of tokens receive a `TRANSLATE` suffix so Argos does not skip them. Pass `--verbose` to display each entry as it is processed and `--log-file` to keep a record. After translating, run `check-translations --show-text` to pinpoint any skipped or untranslated strings. See `AGENTS.md` for the full workflow.
+`translate_argos.py` accepts `--batch-size`, `--max-retries`, and `--timeout` options. It processes strings in batches and retries failures up to the specified limit. Re-run it on a clean copy of `Spanish.json` to restart translations from scratch. `Tools/translate.py` remains for backward compatibility but will print a deprecation warning.
 
 ### Protecting Tags During Translation
 


### PR DESCRIPTION
## Summary
- add `Tools/translate_argos.py` using the argostranslate Python API
- deprecate `Tools/translate.py` with a warning
- update translation workflow docs and instructions

## Testing
- `~/.dotnet/dotnet test Bloodcraft.Tests/Bloodcraft.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_688d1f20dea8832d9edb2be56c5217f4