### PR TITLE
docs: explain unlocking vblood familiars

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Jairon O.; Odjit; Jera; Kokuren TCG and Gaming Shop; Rexxn; Eduardo G.; DirtyMik
   - 20% chance for random shiny effect on first unit unlock, 100% chance on repeated unit unlock
   - Chance when dealing damage to apply respective spell school debuff, same proc chance as configured for class onhit effects
   - `.fam shiny [SpellSchool]` (apply or change shiny, requires vampiric dust)
+- Spend exo prestige rewards to unlock VBlood familiars with `.fam echoes [VBloodName]`. Costs scale by unit level and tier and depend on the `PrimalEchoes` configuration and `EchoesFactor` multiplier.
 
 ### Quests
 - Players can complete daily and weekly quests for XP and rewards.


### PR DESCRIPTION
## Summary
- document how exo prestige rewards can unlock VBlood familiars via `.fam echoes [VBloodName]`

## Testing
- `dotnet build` *(fails: WarEvent_StartEvent, FromCharacter, NetworkEventType types missing)*
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688f9f119280832db18ecd79faba4fb0