### PR TITLE
Document Argos model assembly for translations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,12 +20,20 @@ The Codex system uses the following keywords:
 1. Run the generator to refresh `English.json`:
    `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- generate-messages`
 2. Copy `English.json` to `<Language>.json` and translate each value while keeping numeric hashes.
-3. Automatically translate missing strings with Argos:
+3. Reassemble and install the Argos model before running translation scripts. The split files `translate-en_es-1_0.z01`–`translate-en_es-1_0.z04` live in `Resources/Localization/Messages/Models`:
+   ```bash
+   cd Resources/Localization/Messages/Models
+   cat translate-en_es-1_0.z* > translate-en_es-1_0.zip
+   unzip translate-en_es-1_0.zip
+   argos-translate install translate-en_es-1_0.argosmodel
+   ```
+   Translation scripts require the model to be installed beforehand.
+4. Automatically translate missing strings with Argos:
    `python Tools/translate_argos.py Resources/Localization/Messages/<Language>.json --to <iso-code> --batch-size 100 --max-retries 3 --verbose --log-file translate.log`
    `--verbose` and `--log-file` help pinpoint skipped or untranslated strings. `translate.py` still exists but prints a deprecation warning.
-4. The script hides `<...>` tags and `{...}` placeholders as `[[TOKEN_n]]` tokens. Lines consisting only of tokens are given a dummy `TRANSLATE` suffix so Argos will process them.
+5. The script hides `<...>` tags and `{...}` placeholders as `[[TOKEN_n]]` tokens. Lines consisting only of tokens are given a dummy `TRANSLATE` suffix so Argos will process them.
    **DO NOT** edit text inside these tokens, tags, or variables.
-5. After translation, run the checker to ensure nothing remains in English:
+6. After translation, run the checker to ensure nothing remains in English:
    `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations`
    Use `--show-text` to also print the English string and existing translation alongside each hash.
 

--- a/README.md
+++ b/README.md
@@ -796,6 +796,15 @@ dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- generate-me
 
 ### Translation Workflow
 
+`Resources/Localization/Messages/Models` contains a split Argos English→Spanish model (`translate-en_es-1_0.z01`–`translate-en_es-1_0.z04`). Combine the parts and install the model before running any translation scripts:
+
+```bash
+cd Resources/Localization/Messages/Models
+cat translate-en_es-1_0.z* > translate-en_es-1_0.zip
+unzip translate-en_es-1_0.zip
+argos-translate install translate-en_es-1_0.argosmodel
+```
+
 Use `Tools/translate_argos.py` to generate missing strings. The script uses the `argostranslate` Python API and protects `<...>` tags and `{...}` variables by replacing them with `[[TOKEN_n]]`. Lines made entirely of tokens receive a `TRANSLATE` suffix so Argos does not skip them. Pass `--verbose` to display each entry as it is processed and `--log-file` to keep a record. After translating, run `check-translations --show-text` to pinpoint any skipped or untranslated strings. See `AGENTS.md` for the full workflow.
 `translate_argos.py` accepts `--batch-size`, `--max-retries`, and `--timeout` options. It processes strings in batches and retries failures up to the specified limit. Re-run it on a clean copy of `Spanish.json` to restart translations from scratch. `Tools/translate.py` remains for backward compatibility but will print a deprecation warning.
 


### PR DESCRIPTION
## Summary
- document split Argos model files and installation steps in translation workflow docs
- note that translation scripts require the model installed first

## Testing
- `~/.dotnet/dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688fc2772bc8832dbc1665126e79c4a8