### PR TITLE
Handle missing Argos translation models

### DIFF
--- a/Tools/translate.py
+++ b/Tools/translate.py
@@ -7,6 +7,8 @@ import subprocess
 import sys
 from typing import List
 
+from argostranslate import translate as argos_translate
+
 print(
     "WARNING: Tools/translate.py is deprecated. Use Tools/translate_argos.py instead.",
     file=sys.stderr,
@@ -52,6 +54,13 @@ def translate_batch(
     max_retries: int,
     timeout: int,
 ) -> List[str]:
+    argos_translate.load_installed_languages()
+    translator = argos_translate.get_translation_from_codes(src, dst)
+    if translator is None:
+        raise RuntimeError(
+            f"No Argos translation model for {src}->{dst}. "
+            "Assemble or install the model, or run `.codex/install.sh`."
+        )
     joined = "\n".join(lines)
     for attempt in range(1, max_retries + 1):
         try:

--- a/Tools/translate_argos.py
+++ b/Tools/translate_argos.py
@@ -58,6 +58,11 @@ def translate_batch(
     """Translate a list of lines using argostranslate."""
     argos_translate.load_installed_languages()
     translator = argos_translate.get_translation_from_codes(src, dst)
+    if translator is None:
+        raise RuntimeError(
+            f"No Argos translation model for {src}->{dst}. "
+            "Assemble or install the model, or run `.codex/install.sh`."
+        )
     results: List[str] = []
     for line in lines:
         for attempt in range(1, max_retries + 1):


### PR DESCRIPTION
## Summary
- check for available Argos translation models before translating
- surface helpful error when models are absent

## Testing
- `python -m py_compile Tools/translate_argos.py Tools/translate.py`
- `dotnet test Bloodcraft.Tests/Bloodcraft.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_688fc2c86afc832db7ed661b03661e9a