### PR TITLE
Fix message extraction and update translations

### DIFF
--- a/Resources/Localization/Messages/English.json
+++ b/Resources/Localization/Messages/English.json
@@ -1,7 +1,6 @@
 {
   "Messages": {
     "welcome": "Welcome to Bloodcraft",
-    "3004207253": "\u003Ccolor=green\u003E{famName}\u003C/color\u003E{(buffsData.FamiliarBuffs.ContainsKey(familiarId) ? $",
     "2761093386": "Battle Group - {familiarReply}",
     "3158650477": "No familiars in battle group!",
     "4165788499": "Targets have all been killed, give them a chance to respawn! If this doesn\u0027t seem right consider rerolling your {QuestTypeColor[questType]}.",
@@ -301,6 +300,19 @@
     "1812818458": "You have prestiged in \u003Ccolor=#90EE90\u003EExperience\u003C/color\u003E[\u003Ccolor=white\u003E{prestigeLevel}\u003C/color\u003E]! Growth rates for all expertise/legacies increased by \u003Ccolor=green\u003E{gainPercentage}\u003C/color\u003E, experience from unit kills reduced by \u003Ccolor=red\u003E{reductionPercentage}\u003C/color\u003E.",
     "709298301": "\u003Ccolor=#90EE90\u003E{parsedPrestigeType}\u003C/color\u003E[\u003Ccolor=white\u003E{prestigeLevel}\u003C/color\u003E] prestiged successfully! Growth rate reduced by \u003Ccolor=red\u003E{percentageReductionString}\u003C/color\u003E and stat bonuses improved by \u003Ccolor=green\u003E{statGainString}\u003C/color\u003E. The total change in growth rate with leveling prestige bonus is \u003Ccolor=yellow\u003E{totalEffectString}\u003C/color\u003E.",
     "1443941563": "Removed prestige buffs from all players.",
-    "1286090332": "You\u0027re level [\u003Ccolor=white\u003E{data.Key}\u003C/color\u003E][\u003Ccolor=#90EE90\u003E{prestigeLevel}\u003C/color\u003E] with \u003Ccolor=yellow\u003E{progress}\u003C/color\u003E \u003Ccolor=#FFC0CB\u003Eessence\u003C/color\u003E (\u003Ccolor=white\u003E{BloodSystem.GetLevelProgress(ctx.Event.User.PlatformId, handler)}%\u003C/color\u003E) in \u003Ccolor=red\u003E{handler.GetBloodType()}\u003C/color\u003E!"
+    "1286090332": "You\u0027re level [\u003Ccolor=white\u003E{data.Key}\u003C/color\u003E][\u003Ccolor=#90EE90\u003E{prestigeLevel}\u003C/color\u003E] with \u003Ccolor=yellow\u003E{progress}\u003C/color\u003E \u003Ccolor=#FFC0CB\u003Eessence\u003C/color\u003E (\u003Ccolor=white\u003E{BloodSystem.GetLevelProgress(ctx.Event.User.PlatformId, handler)}%\u003C/color\u003E) in \u003Ccolor=red\u003E{handler.GetBloodType()}\u003C/color\u003E!",
+    "3066749917": "\u003Ccolor=green\u003E{famName}\u003C/color\u003E{(buffsData.FamiliarBuffs.ContainsKey(familiarId) ? $\u0022{colorCode}*\u003C/color\u003E\u0022 : \u0022\u0022)} [\u003Ccolor=white\u003E{level}\u003C/color\u003E][\u003Ccolor=#90EE90\u003E{prestiges}\u003C/color\u003E] added to \u003Ccolor=white\u003E{groupName}\u003C/color\u003E! (\u003Ccolor=yellow\u003E{slotIndex}\u003C/color\u003E)",
+    "1465975319": "Reminders {(GetPlayerBool(steamId, REMINDERS_KEY) ? \u0022\u003Ccolor=green\u003Eenabled\u003C/color\u003E\u0022 : \u0022\u003Ccolor=red\u003Edisabled\u003C/color\u003E\u0022)}.",
+    "1945389717": "\u003Ccolor=white\u003E{sctType}\u003C/color\u003E scrolling text {(currentState ? \u0022\u003Ccolor=green\u003Eenabled\u003C/color\u003E\u0022 : \u0022\u003Ccolor=red\u003Edisabled\u003C/color\u003E\u0022)}.",
+    "2511919794": "\u003Ccolor=yellow\u003E{count}\u003C/color\u003E| \u003Ccolor=green\u003E{famName}\u003C/color\u003E{(familiarBuffsData.FamiliarBuffs.ContainsKey(famKey) ? $\u0022{colorCode}*\u003C/color\u003E {levelAndPrestiges}\u0022 : $\u0022 {levelAndPrestiges}\u0022)}",
+    "508045935": "Emote actions {(GetPlayerBool(steamId, EMOTE_ACTIONS_KEY) ? \u0022\u003Ccolor=green\u003Eenabled\u003C/color\u003E\u0022 : \u0022\u003Ccolor=red\u003Edisabled\u003C/color\u003E\u0022)}!",
+    "52573990": "Expertise logging is now {(GetPlayerBool(steamId, WEAPON_LOG_KEY) ? \u0022\u003Ccolor=green\u003Eenabled\u003C/color\u003E\u0022 : \u0022\u003Ccolor=red\u003Edisabled\u003C/color\u003E\u0022)}.",
+    "1904876515": "Quest logging is now {(GetPlayerBool(steamId, QUEST_LOG_KEY) ? \u0022\u003Ccolor=green\u003Eenabled\u003C/color\u003E\u0022 : \u0022\u003Ccolor=red\u003Edisabled\u003C/color\u003E\u0022)}.",
+    "3706417587": "Invalid quest type \u0027{questTypeName}\u0027. Valid values are: {string.Join(\u0022, \u0022, Enum.GetNames(typeof(QuestType)))}",
+    "1095669519": "Level logging {(GetPlayerBool(SteamID, EXPERIENCE_LOG_KEY) ? \u0022\u003Ccolor=green\u003Eenabled\u003C/color\u003E\u0022 : \u0022\u003Ccolor=red\u003Edisabled\u003C/color\u003E\u0022)}.",
+    "3112026815": "Profession logging is now {(GetPlayerBool(steamId, PROFESSION_LOG_KEY) ? \u0022\u003Ccolor=green\u003Eenabled\u003C/color\u003E\u0022 : \u0022\u003Ccolor=red\u003Edisabled\u003C/color\u003E\u0022)}.",
+    "542066310": "Blood Legacy logging {(GetPlayerBool(steamId, BLOOD_LOG_KEY) ? \u0022\u003Ccolor=green\u003Eenabled\u003C/color\u003E\u0022 : \u0022\u003Ccolor=red\u003Edisabled\u003C/color\u003E\u0022)}.",
+    "881612152": "Exo form emote action (\u003Ccolor=white\u003Etaunt\u003C/color\u003E) {(GetPlayerBool(steamId, SHAPESHIFT_KEY) ? \u0022\u003Ccolor=green\u003Eenabled\u003C/color\u003E\u0022 : \u0022\u003Ccolor=red\u003Edisabled\u003C/color\u003E\u0022)}",
+    "2978826451": "\u003Ccolor=green\u003E{famName}\u003C/color\u003E{(buffsData.FamiliarBuffs.ContainsKey(familiarId) ? \u0022{colorCode}*\u003C/color\u003E\u0022 : \u0022\u0022)} [\u003Ccolor=white\u003E{level}\u003C/color\u003E][\u003Ccolor=#90EE90\u003E{prestiges}\u003C/color\u003E] added to \u003Ccolor=white\u003E{groupName}\u003C/color\u003E! (\u003Ccolor=yellow\u003E{slotIndex}\u003C/color\u003E)"
   }
 }

--- a/Resources/Localization/Messages/French.json
+++ b/Resources/Localization/Messages/French.json
@@ -1,7 +1,7 @@
 {
   "Messages": {
-    "welcome": "Bienvenue à Bloodcraft",
-    "3004207253": "[<color=green>][{famName}[</color>]{(buffsData.FamiliarBuffs.Contient une clé(familiar Id) ? $",
+  "welcome": "Bienvenue à Bloodcraft",
+    "2978826451": "<color=green>{famName}</color>{(buffsData.FamiliarBuffs.ContainsKey(familiarId) ? \"{colorCode}*</color>\" : \"\")} [<color=white>{level}</color>][<color=#90EE90>{prestiges}</color>] added to <color=white>{groupName}</color>! (<color=yellow>{slotIndex}</color>)",
     "2761093386": "Groupe tactique - [{familiarReply}]",
     "3158650477": "Pas de familiers dans le groupe de combat !",
     "4165788499": "Les cibles ont toutes été tuées, donnez-leur une chance de se reproduire ! Si cela ne semble pas juste envisager de reroller votre [{QuestTypeColor[questType]}].",

--- a/Resources/Localization/Messages/German.json
+++ b/Resources/Localization/Messages/German.json
@@ -1,7 +1,7 @@
 {
   "Messages": {
-    "welcome": "Willkommen bei Bloodcraft",
-    "3004207253": "[<color=green>[[{famName}][[</color>]]{(buffsData.FamiliarBuffs.ContainsKey(familiar Id? $",
+  "welcome": "Willkommen bei Bloodcraft",
+    "2978826451": "<color=green>{famName}</color>{(buffsData.FamiliarBuffs.ContainsKey(familiarId) ? \"{colorCode}*</color>\" : \"\")} [<color=white>{level}</color>][<color=#90EE90>{prestiges}</color>] added to <color=white>{groupName}</color>! (<color=yellow>{slotIndex}</color>)",
     "2761093386": "Battle Group - [{familiarReply}",
     "3158650477": "Keine Vertrauten in der Kampfgruppe!",
     "4165788499": "Ziele wurden alle getötet, geben Sie ihnen die Chance, sich anzusprechen! Wenn dies nicht richtig erscheint, betrachten Sie es, Ihre [{QuestTypeColor[questType]}].",

--- a/Resources/Localization/Messages/Italian.json
+++ b/Resources/Localization/Messages/Italian.json
@@ -1,6 +1,7 @@
 {
   "Messages": {
-    "welcome": "Benvenuti a Bloodcraft",
+  "welcome": "Benvenuti a Bloodcraft",
+    "2978826451": "<color=green>{famName}</color>{(buffsData.FamiliarBuffs.ContainsKey(familiarId) ? \"{colorCode}*</color>\" : \"\")} [<color=white>{level}</color>][<color=#90EE90>{prestiges}</color>] added to <color=white>{groupName}</color>! (<color=yellow>{slotIndex}</color>)",
     "2761093386": "Gruppo di battaglia - [{familiarReply}",
     "3158650477": "Nessun familiare nel gruppo di battaglia!",
     "4165788499": "I bersagli sono stati tutti uccisi, dando loro la possibilità di reagire! Se questo non sembra giusto considerare di riscrivere il [{QuestTypeColor[questType]}.",

--- a/Resources/Localization/Messages/Japanese.json
+++ b/Resources/Localization/Messages/Japanese.json
@@ -1,7 +1,7 @@
 {
   "Messages": {
-    "welcome": "ブラッドクラフトへようこそ",
-    "3004207253": "[<color=green>][{famName}][</color>]{(buffsData.FamiliarBuffs.ContainsKey(familiar) お問い合わせ ドル",
+  "welcome": "ブラッドクラフトへようこそ",
+    "2978826451": "<color=green>{famName}</color>{(buffsData.FamiliarBuffs.ContainsKey(familiarId) ? \"{colorCode}*</color>\" : \"\")} [<color=white>{level}</color>][<color=#90EE90>{prestiges}</color>] added to <color=white>{groupName}</color>! (<color=yellow>{slotIndex}</color>)",
     "2761093386": "バトルグループ - [{familiarReply}",
     "3158650477": "バトルグループに馴染みのない!",
     "4165788499": "ターゲットは、すべて殺され、それらを再発するチャンスを与えます! もしそうでなければ、あなたの[[[{QuestTypeColor[questType]}]]をリロールするのは正しい考えではありません。",

--- a/Resources/Localization/Messages/Korean.json
+++ b/Resources/Localization/Messages/Korean.json
@@ -1,7 +1,7 @@
 {
   "Messages": {
-    "welcome": "환영합니다 Bloodcraft",
-    "3004207253": "[<color=green>][{famName}][</color>]{(buffsData.FamiliarBuffs.ContainsKey(familiar) 아이)? $ 6,000 원",
+  "welcome": "환영합니다 Bloodcraft",
+    "2978826451": "<color=green>{famName}</color>{(buffsData.FamiliarBuffs.ContainsKey(familiarId) ? \"{colorCode}*</color>\" : \"\")} [<color=white>{level}</color>][<color=#90EE90>{prestiges}</color>] added to <color=white>{groupName}</color>! (<color=yellow>{slotIndex}</color>)",
     "2761093386": "배틀 그룹 - {familiarReply}",
     "3158650477": "전투 그룹에 익숙하지!",
     "4165788499": "대상은 모두 죽어, 그들을 respawn 할 수있는 기회를 제공합니다! [{QuestTypeColor[questType]}]]를 다시 불러야 합니다.",

--- a/Resources/Localization/Messages/Spanish.json
+++ b/Resources/Localization/Messages/Spanish.json
@@ -1,7 +1,7 @@
 {
   "Messages": {
-    "welcome": "Bienvenido a Bloodcraft",
-    "3004207253": "[<color=green> [{famName}]</color>{(buffsData.FamiliarBuffs.ContainsKey(familiar) ¿Id? $",
+  "welcome": "Bienvenido a Bloodcraft",
+    "2978826451": "<color=green>{famName}</color>{(buffsData.FamiliarBuffs.ContainsKey(familiarId) ? \"{colorCode}*</color>\" : \"\")} [<color=white>{level}</color>][<color=#90EE90>{prestiges}</color>] added to <color=white>{groupName}</color>! (<color=yellow>{slotIndex}</color>)",
     "2761093386": "Grupo de batalla - [{familiarReply}",
     "3158650477": "¡Ningún familiar en el grupo de batalla!",
     "4165788499": "¡Todos los blancos han sido asesinados, darles la oportunidad de reaparecer! Si esto no parece correcto considerar rerollar su [{QuestTypeColor[questType]}].",


### PR DESCRIPTION
## Summary
- improve message extraction to handle nested string interpolation
- add full familiar battle group message to localization files

## Testing
- `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- generate-messages`
- `python Tools/translate_argos.py Resources/Localization/Messages/Spanish.json --to es --batch-size 100 --max-retries 3 --verbose --log-file translate.log` *(fails: 'NoneType' object has no attribute 'get_translation')*
- `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations` *(fails: missing hashes in Spanish.json)*

------
https://chatgpt.com/codex/tasks/task_e_68922c91bd2c832db280612897838ee9