### PR TITLE
Add localization token fixer utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -809,6 +809,8 @@ rm translate-en_es-1_0.zip translate-en_es-1_0.argosmodel
 Use `Tools/translate_argos.py` to generate missing strings. The script uses the `argostranslate` Python API and protects `<...>` tags and `{...}` variables by replacing them with `[[TOKEN_n]]`. Lines made entirely of tokens receive a `TRANSLATE` suffix so Argos does not skip them. Pass `--verbose` to display each entry as it is processed and `--log-file` to keep a record. After translating, run `check-translations --show-text` to pinpoint any skipped or untranslated strings. See `AGENTS.md` for the full workflow.
 `translate_argos.py` accepts `--batch-size`, `--max-retries`, and `--timeout` options. It processes strings in batches and retries failures up to the specified limit. Re-run it on a clean copy of `Spanish.json` to restart translations from scratch. `Tools/translate.py` remains for backward compatibility but will print a deprecation warning.
 
+Run `Tools/fix_tokens.py` after translating to restore `<...>` tags and `{...}` placeholders if any `[[TOKEN_n]]` markers remain. Use `--check-only` to report discrepancies without modifying files.
+
 The `.codex/install.sh` setup script also supports downloading Argos language models automatically. Set `FROM_LANG` and `TO_LANG` (or `ARGOS_LANGUAGE_PAIR` as `from:to`) before invoking the script. Example:
 
 ```bash

--- a/Tools/fix_tokens.py
+++ b/Tools/fix_tokens.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Replace placeholder tokens in localization files with English originals."""
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+TOKEN_PLACEHOLDER = re.compile(r"\[\[[^\]]+\]\]")
+TOKEN_PATTERN = re.compile(r"<[^>]+>|\{[^{}]+\}|\$\{[^{}]+\}")
+
+
+def extract_tokens(text: str) -> List[str]:
+    return TOKEN_PATTERN.findall(text or "")
+
+
+def replace_placeholders(value: str, tokens: List[str]) -> Tuple[str, bool, bool]:
+    placeholders = TOKEN_PLACEHOLDER.findall(value)
+    if not placeholders:
+        return value, False, False
+    mismatch = len(placeholders) != len(tokens)
+    for ph, token in zip(placeholders, tokens):
+        value = value.replace(ph, token, 1)
+    return value, True, mismatch
+
+
+def load_english_messages(root: Path) -> Dict[str, List[str]]:
+    path = root / "Resources" / "Localization" / "Messages" / "English.json"
+    with open(path, "r", encoding="utf-8") as f:
+        english = json.load(f)["Messages"]
+    return {k: extract_tokens(v) for k, v in english.items()}
+
+
+def load_english_nodes(root: Path) -> Dict[str, List[str]]:
+    path = root / "Resources" / "Localization" / "English.json"
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    nodes = data.get("nodes") or data.get("Nodes") or []
+    mapping: Dict[str, List[str]] = {}
+    for node in nodes:
+        guid = node.get("guid") or node.get("Guid")
+        text = node.get("text") or node.get("Text")
+        if guid and isinstance(text, str):
+            mapping[guid] = extract_tokens(text)
+    return mapping
+
+
+def process_messages_file(path: Path, baseline: Dict[str, List[str]], check_only: bool) -> bool:
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    messages = data.get("Messages", {})
+    changed = False
+    mismatch = False
+    for key, text in list(messages.items()):
+        new_text, replaced, bad = replace_placeholders(text, baseline.get(key, []))
+        if replaced:
+            if bad:
+                print(f"{path}: {key} token count mismatch")
+            else:
+                print(f"{path}: {key} tokens restored")
+            if not check_only:
+                messages[key] = new_text
+            changed = True
+            mismatch = mismatch or bad
+    if changed and not check_only:
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, ensure_ascii=False)
+    return changed or mismatch
+
+
+def process_root_file(path: Path, baseline: Dict[str, List[str]], check_only: bool) -> bool:
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    nodes = data.get("nodes") or data.get("Nodes") or []
+    changed = False
+    mismatch = False
+    for node in nodes:
+        guid = node.get("guid") or node.get("Guid")
+        text_key = "text" if "text" in node else "Text" if "Text" in node else None
+        if not guid or not text_key:
+            continue
+        text = node[text_key]
+        if not isinstance(text, str):
+            continue
+        new_text, replaced, bad = replace_placeholders(text, baseline.get(guid, []))
+        if replaced:
+            if bad:
+                print(f"{path}: {guid} token count mismatch")
+            else:
+                print(f"{path}: {guid} tokens restored")
+            if not check_only:
+                node[text_key] = new_text
+            changed = True
+            mismatch = mismatch or bad
+    if changed and not check_only:
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, ensure_ascii=False)
+    return changed or mismatch
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Fix token placeholders in localization JSON files")
+    ap.add_argument("--root", default=Path(__file__).resolve().parents[1], help="Repo root")
+    ap.add_argument("--check-only", action="store_true", help="Report issues without modifying files")
+    args = ap.parse_args()
+
+    root = Path(args.root).resolve()
+    messages_tokens = load_english_messages(root)
+    node_tokens = load_english_nodes(root)
+
+    files = list((root / "Resources" / "Localization" / "Messages").glob("*.json"))
+    files = [p for p in files if p.name != "English.json"]
+    files += [p for p in (root / "Resources" / "Localization").glob("*.json") if p.name != "English.json"]
+
+    issues = False
+    for path in files:
+        if path.parent.name == "Messages":
+            issues |= process_messages_file(path, messages_tokens, args.check_only)
+        else:
+            issues |= process_root_file(path, node_tokens, args.check_only)
+
+    if args.check_only and issues:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `Tools/fix_tokens.py` to restore `<...>` and `{...}` tokens using English baselines
- document token fixer usage in translation workflow

## Testing
- `python Tools/fix_tokens.py --check-only`
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-6.0` *(fails: no installation candidate)*

------
https://chatgpt.com/codex/tasks/task_e_6892544fa68c832db64aba1e5b854bc3