### PR TITLE
Fix box label translation across languages

### DIFF
--- a/Resources/Localization/Messages/French.json
+++ b/Resources/Localization/Messages/French.json
@@ -131,7 +131,7 @@
     "2196432591": "[<color=red>][{BloodHandler.GetBloodType()}][</color>] legs mis à [[<color=white>[{level}][</color>]] pour [<color=green>][{foundUser.CharacterName}][</color>]",
     "85537047": "Legs sanguins disponibles: [<color=red>][{bloodTypesList}[</color>]",
     "1381058165": "Les familiers ne sont pas activés.",
-    "1716911803": "[<color=white>][{box}[</color>]:",
+    "1716911803": "<color=white>{box}</color>:",
     "863911874": "[<color=yellow>][{count}][</color>] [<color=green>][{famName}][</color>]{(familiarBuffsData.FamiliarBuffs.ContientKey(familiarKey) ? $",
     "1066178325": "Pas de boîte active ! Essayez d'utiliser [<color=white>'.fam sb [Nom]'[</color>] si vous connaissez le familier que vous recherchez. (utiliser des citations pour les noms avec un espace)",
     "2462277004": "Je n'ai pas trouvé de boîte active !",

--- a/Resources/Localization/Messages/German.json
+++ b/Resources/Localization/Messages/German.json
@@ -106,7 +106,7 @@
     "1108347105": "Die Ebene muss zwischen 0 und [{ConfigService.MaxBloodLevel}] liegen.",
     "85537047": "Verfügbare Blutgesetze: [<color=red>][{bloodTypesList}][</color>]]",
     "1381058165": "Vertraute sind nicht aktiviert.",
-    "1716911803": "[<color=white>[[{box}][[</color>]]]:",
+    "1716911803": "<color=white>{box}</color>:",
     "863911874": "[<color=yellow>][[{count}][</color>]]] [<color=green>[[{famName}][[</color>]]{(familiarBuffsData.FamiliarBuffs.ContainsKey(famKey) ? $",
     "1066178325": "Keine aktive Box! Versuchen Sie, [<color=white>]]'.fam sb [Name]'[</color>]] zu verwenden, wenn Sie das vertraute wissen, nach dem Sie suchen. (Zitate für Namen mit einem Raum verwenden)",
     "2462277004": "Ich konnte keine aktive Box finden!",

--- a/Resources/Localization/Messages/Japanese.json
+++ b/Resources/Localization/Messages/Japanese.json
@@ -131,7 +131,7 @@
     "2196432591": "[[<color=red>][{BloodHandler.GetBloodType()}][</color>]のレガシーセット[[[<color=white>][{level}][</color>]]]]]] [<color=green>][{foundUser.CharacterName}][</color>]]",
     "85537047": "[<color=red>][{bloodTypesList}][</color>]]]",
     "1381058165": "ファミリアーズは有効ではありません。",
-    "1716911803": "[<color=white>][{box}][</color>]]:",
+    "1716911803": "<color=white>{box}</color>：",
     "863911874": "[<color=yellow>][{count}][</color>]]]| [<color=green>][{famName}][</color>]{(familiarBuffsData.FamiliarBuffs.ContainsKey(famKey)] ? ドル",
     "1066178325": "アクティブな箱無し! [[<color=white>]]'.fam sb [Name]'[[</color>] を使ってみてください。 (スペースで名前の引用)",
     "2462277004": "アクティブなボックスが見つからなかった!",

--- a/Resources/Localization/Messages/Korean.json
+++ b/Resources/Localization/Messages/Korean.json
@@ -113,7 +113,7 @@
     "1108347105": "레벨은 0과 [{ConfigService.MaxBloodLevel}] 사이에 있어야 합니다.",
     "85537047": "[<color=red>] [{bloodTypesList}] </color>]",
     "1381058165": "Familiars는 사용할 수 없습니다.",
-    "1716911803": "[<color=white>] [{box}] </color>]:",
+    "1716911803": "<color=white>{box}</color>:",
     "863911874": "[<color=yellow>] [{count}] </color>]| [<color=green>][{famName}][</color>]]{(familiarBuffsData.FamiliarBuffs.ContainsKey(famKey) ? $ 6,000 원",
     "1066178325": "활동 상자 없음! [<color=white>]'.fam sb [Name]'</color>]를 사용해보십시오. (공간의 이름을 인용함)",
     "2462277004": "활성 상자를 찾을 수 없습니다!",

--- a/Resources/Localization/Messages/Latam.json
+++ b/Resources/Localization/Messages/Latam.json
@@ -135,7 +135,7 @@
     "2196432591": "Legado de <color=red>{BloodHandler.GetBloodType()}</color> establecido en [<color=white>{level}</color>] para <color=green>{foundUser.CharacterName}</color>",
     "85537047": "Legacías de sangre disponibles: [<color=red> [{bloodTypesList} [</color>]]",
     "1381058165": "Los familiares no están habilitados.",
-    "1716911803": "[<color=white> [{box}] [</color>]:",
+    "1716911803": "<color=white>{box}</color>:",
     "863911874": "<color=yellow> [{count} [</color> [<color=green> [{famName}]</color>{(familiarBuffsData.FamiliarBuffs.ContainsKey(famKey) ? $",
     "1066178325": "¡No hay caja activa! Trate de usar [<color=white>'.fam sb [Name]'</color>] si sabe lo familiar que está buscando. (usar citas para nombres con un espacio)",
     "2462277004": "¡No pude encontrar una caja activa!",

--- a/Resources/Localization/Messages/Spanish.json
+++ b/Resources/Localization/Messages/Spanish.json
@@ -125,7 +125,7 @@
     "1108347105": "El nivel debe ser entre 0 y [{ConfigService.MaxBloodLevel}].",
     "85537047": "Legacías de sangre disponibles: [<color=red> [{bloodTypesList} [</color>]]",
     "1381058165": "Los familiares no están habilitados.",
-    "1716911803": "[<color=white> [{box}] [</color>]:",
+    "1716911803": "<color=white>{box}</color>:",
     "863911874": "<color=yellow> [{count} [</color> [<color=green> [{famName}]</color>{(familiarBuffsData.FamiliarBuffs.ContainsKey(famKey) ? $",
     "1066178325": "¡No hay caja activa! Trate de usar [<color=white>'.fam sb [Name]'</color>] si sabe lo familiar que está buscando. (usar citas para nombres con un espacio)",
     "2462277004": "¡No pude encontrar una caja activa!",


### PR DESCRIPTION
## Summary
- fix skipped translation for box label message in multiple language files

## Testing
- `DOTNET_ROLL_FORWARD=Major dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations --show-text`

------
https://chatgpt.com/codex/tasks/task_e_689275442328832db1ee2446e2484d6d