### PR TITLE
chore: add missing localization entries

### DIFF
--- a/Resources/Localization/Messages/Brazilian.json
+++ b/Resources/Localization/Messages/Brazilian.json
@@ -292,6 +292,27 @@
     "1443941563": "Aficionados prestígio removido de todos os jogadores.",
     "1286090332": "Você está no nível [<color=white>{data.Key}</color>][<color=#90EE90>{prestigeLevel}</color>]<color=yellow>{progress}</color> <color=#FFC0CB>essência</color> <color=white>{BloodSystem.GetLevelProgress(ctx.Event.User.PlatformId, handler)}%</color><color=red>{handler.GetBloodType()}</color>!",
     "2511919794": "<color=yellow> {count} </color> <color=green>{famName}</color>{(familiarBuffsData.FamiliarBuffs.ContémKey(famKey) ? $\"{colorCode}*</color> {levelAndPrestiges}\" : $\" {levelAndPrestiges})}",
-    "2978826451": "<color=green>{famName}</color>{(buffsData.FamiliarBuffs.ContémChave(familiarId) ? \"{colorCode}*</color>\" : \"} [<color=white>{level}</color>][<color=#90EE90>{prestiges}</color>]<color=white>{groupName}</color>! <color=yellow>{slotIndex}</color>"
+    "2978826451": "<color=green>{famName}</color>{(buffsData.FamiliarBuffs.ContémChave(familiarId) ? \"{colorCode}*</color>\" : \"} [<color=white>{level}</color>][<color=#90EE90>{prestiges}</color>]<color=white>{groupName}</color>! <color=yellow>{slotIndex}</color>",
+    "2761093386": "Grupo de Batalha - {familiarReply}",
+    "460602473": "{FormatClassName(playerClass)} não tem feitiços configurados...",
+    "11642316": "Nível de Prestígio <color=#90EE90>Exo</color> Atual: <color=yellow>{exoLevel}</color>/{PrestigeTypeToMaxPrestiges[parsedPrestigeType]} | Duração Máxima da Forma: <color=green>{(int)Shapeshifts.CalculateFormDuration(exoLevel)}</color>s",
+    "2461283441": "Prestígios:",
+    "1716911803": "<color=white>{box}</color>:",
+    "1469754031": "Parece que seu familiar ainda pode ser encontrado; desvincule-o normalmente após chamá-lo se for dispensado.",
+    "563018011": "Tipo de missão inválido '{questTypeName}'. Valores válidos: {string.Join(\", \", Enum.GetNames(typeof(QuestType)))}",
+    "3938051122": "Classes: {classTypes}",
+    "2320898349": "Feitiço de Shift <color=red>desativado</color>!",
+    "3399068440": "<color=white>VBloods Abatidos</color>: <color=#FF5733>{VBloodKills}</color> | <color=white>Unidades Mortas</color>: <color=#FFD700>{UnitKills}</color> | <color=white>Mortes</color>: <color=#808080>{Deaths}</color> | <color=white>Tempo Online</color>: <color=#1E90FF>{OnlineTime}</color>h | <color=white>Distância Percorrida</color>: <color=#32CD32>{DistanceTraveled}</color>kf | <color=white>Sangue Consumido</color>: <color=red>{LitresBloodConsumed}</color>L",
+    "3066749917": "<color=green>{famName}</color>{(buffsData.FamiliarBuffs.ContainsKey(familiarId) ? \"{colorCode}*</color>\" : \"\")} [<color=white>{level}</color>][<color=#90EE90>{prestiges}</color>] adicionado a <color=white>{groupName}</color>! (<color=yellow>{slotIndex}</color>)",
+    "1465975319": "Lembretes {(GetPlayerBool(steamId, REMINDERS_KEY) ? \"<color=green>ativados</color>\" : \"<color=red>desativados</color>\")}.",
+    "1945389717": "<color=white>{sctType}</color> texto rolante {(currentState ? \"<color=green>ativado</color>\" : \"<color=red>desativado</color>\")}.",
+    "508045935": "Ações de emote {(GetPlayerBool(steamId, EMOTE_ACTIONS_KEY) ? \"<color=green>ativadas</color>\" : \"<color=red>desativadas</color>\")}!",
+    "52573990": "O registro de perícia agora está {(GetPlayerBool(steamId, WEAPON_LOG_KEY) ? \"<color=green>ativado</color>\" : \"<color=red>desativado</color>\")}.",
+    "1904876515": "O registro de missões agora está {(GetPlayerBool(steamId, QUEST_LOG_KEY) ? \"<color=green>ativado</color>\" : \"<color=red>desativado</color>\")}.",
+    "3706417587": "Tipo de missão inválido '{questTypeName}'. Valores válidos: {string.Join(\", \", Enum.GetNames(typeof(QuestType)))}",
+    "1095669519": "O registro de nível {(GetPlayerBool(SteamID, EXPERIENCE_LOG_KEY) ? \"<color=green>ativado</color>\" : \"<color=red>desativado</color>\")}.",
+    "3112026815": "O registro de profissão agora está {(GetPlayerBool(steamId, PROFESSION_LOG_KEY) ? \"<color=green>ativado</color>\" : \"<color=red>desativado</color>\")}.",
+    "542066310": "O registro de Legado de Sangue {(GetPlayerBool(steamId, BLOOD_LOG_KEY) ? \"<color=green>ativado</color>\" : \"<color=red>desativado</color>\")}.",
+    "881612152": "Ação de emote da forma Exo (<color=white>provocar</color>) {(GetPlayerBool(steamId, SHAPESHIFT_KEY) ? \"<color=green>ativada</color>\" : \"<color=red>desativada</color>\")}"
   }
 }

--- a/Resources/Localization/Messages/SChinese.json
+++ b/Resources/Localization/Messages/SChinese.json
@@ -297,6 +297,22 @@
     "2978826451": "<color=green>{famName}</color>{(buken_5{prestiges}</color><color=white>{groupName}</color> 添加到<color=white>{groupName}</color> 的 [<color=#90EE90>{prestiges}</color>]中! (<color=yellow>{slotIndex}</color>).",
     "863911874": "<color=yellow> {count}</color> _______________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________ <color=green>{famName}</color>{(familiar BuffsData.Familiar Buffs.ContersKey(famKey))?永久失效連結 (中文(简体) ). (单位:美元)",
     "2645405211": "无效的拼写, 使用 '<color=white>. class Isp </color>' 来查看选项 。",
-    "1282509635": "您启用了类 buffs, 使用 <color=white>'. class asseners' </color> 在更改类前禁用它们 !"
+    "1282509635": "您启用了类 buffs, 使用 <color=white>'. class asseners' </color> 在更改类前禁用它们 !",
+    "2480816305": "<color=#c0c0c0>{expertiseHandler.GetWeaponType()}</color> 专精已设为[<color=white>{level}</color>]，对象为 <color=green>{playerInfo.User.CharacterName.Value}</color>",
+    "3761416018": "第一个徒手槽已为<color=green>{playerInfo.User.CharacterName.Value}</color>设置为<color=white>{new PrefabGUID(ability).GetPrefabName()}</color>.",
+    "1826355702": "第二个徒手槽已为<color=green>{playerInfo.User.CharacterName.Value}</color>设置为<color=white>{new PrefabGUID(ability).GetPrefabName()}</color>.",
+    "1716911803": "<color=white>{box}</color>:",
+    "2001389111": "法术无效，使用 <color=white>'.class lsp'</color> 查看选项。",
+    "4140406916": "你还没有选择职业，请使用 <color=white>'.class s [Class]'</color>。",
+    "3399068440": "<color=white>被击杀的VBloods</color>：<color=#FF5733>{VBloodKills}</color> | <color=white>击杀单位</color>：<color=#FFD700>{UnitKills}</color> | <color=white>死亡次数</color>：<color=#808080>{Deaths}</color> | <color=white>在线时间</color>：<color=#1E90FF>{OnlineTime}</color>小时 | <color=white>行走距离</color>：<color=#32CD32>{DistanceTraveled}</color>千米 | <color=white>消耗血量</color>：<color=red>{LitresBloodConsumed}</color>L",
+    "1465975319": "提醒{(GetPlayerBool(steamId, REMINDERS_KEY) ? \"<color=green>已启用</color>\" : \"<color=red>已禁用</color>\")}.",
+    "1945389717": "<color=white>{sctType}</color>滚动文字{(currentState ? \"<color=green>已启用</color>\" : \"<color=red>已禁用</color>\")}.",
+    "508045935": "表情动作{(GetPlayerBool(steamId, EMOTE_ACTIONS_KEY) ? \"<color=green>已启用</color>\" : \"<color=red>已禁用</color>\")}！",
+    "52573990": "专精记录现在{(GetPlayerBool(steamId, WEAPON_LOG_KEY) ? \"<color=green>已启用</color>\" : \"<color=red>已禁用</color>\")}。",
+    "1904876515": "任务记录现在{(GetPlayerBool(steamId, QUEST_LOG_KEY) ? \"<color=green>已启用</color>\" : \"<color=red>已禁用</color>\")}。",
+    "1095669519": "等级记录{(GetPlayerBool(SteamID, EXPERIENCE_LOG_KEY) ? \"<color=green>已启用</color>\" : \"<color=red>已禁用</color>\")}。",
+    "3112026815": "职业记录现在{(GetPlayerBool(steamId, PROFESSION_LOG_KEY) ? \"<color=green>已启用</color>\" : \"<color=red>已禁用</color>\")}。",
+    "542066310": "血统记录{(GetPlayerBool(steamId, BLOOD_LOG_KEY) ? \"<color=green>已启用</color>\" : \"<color=red>已禁用</color>\")}。",
+    "881612152": "Exo形态表情动作（<color=white>嘲讽</color>）{(GetPlayerBool(steamId, SHAPESHIFT_KEY) ? \"<color=green>已启用</color>\" : \"<color=red>已禁用</color>\")}"
   }
 }

--- a/Resources/Localization/Messages/Spanish.json
+++ b/Resources/Localization/Messages/Spanish.json
@@ -301,6 +301,18 @@
     "4009901629": "Tu <color=#BF40BF>misión semanal</color> ha sido rerolada por <color=#C0C0C0>{item.GetLocalizedName()}</color> x<color=white>{quantity}</color>!",
     "2305440578": "¡Completado {Quests.QuestTypeColor[questType]} para <color=green>{playerInfo.User.CharacterName.Value}</color>!",
     "216725398": "Eres nivel [<color=white>{data.Key}</color>] y tienes <color=yellow>{progress}</color> <color=#FFC0CB>pericia</color> (<color=white>{ProfessionSystem.GetLevelProgress(steamId, professionHandler)}%</color>) en {professionHandler.GetProfessionName()}",
-    "3399068440": "<color=white>VBloods asesinados</color>: <color=#FF5733>{VBloodKills}</color> | <color=white>Unidades matadas</color>: <color=#FFD700>{UnitKills}</color> | <color=white>Muertes</color>: <color=#808080>{Deaths}</color> | <color=white>Tiempo en línea</color>: <color=#1E90FF>{OnlineTime}</color>h | <color=white>Distancia recorrida</color>: <color=#32CD32>{DistanceTraveled}</color>kf | <color=white>Sangre consumida</color>: <color=red>{LitresBloodConsumed}</color>L"
+    "3399068440": "<color=white>VBloods asesinados</color>: <color=#FF5733>{VBloodKills}</color> | <color=white>Unidades matadas</color>: <color=#FFD700>{UnitKills}</color> | <color=white>Muertes</color>: <color=#808080>{Deaths}</color> | <color=white>Tiempo en línea</color>: <color=#1E90FF>{OnlineTime}</color>h | <color=white>Distancia recorrida</color>: <color=#32CD32>{DistanceTraveled}</color>kf | <color=white>Sangre consumida</color>: <color=red>{LitresBloodConsumed}</color>L",
+    "3066749917": "<color=green>{famName}</color>{(buffsData.FamiliarBuffs.ContainsKey(familiarId) ? \"{colorCode}*</color>\" : \"\")} [<color=white>{level}</color>][<color=#90EE90>{prestiges}</color>] añadido a <color=white>{groupName}</color>! (<color=yellow>{slotIndex}</color>)",
+    "1465975319": "Recordatorios {(GetPlayerBool(steamId, REMINDERS_KEY) ? \"<color=green>habilitados</color>\" : \"<color=red>deshabilitados</color>\")}.",
+    "1945389717": "<color=white>{sctType}</color> texto desplazable {(currentState ? \"<color=green>habilitado</color>\" : \"<color=red>deshabilitado</color>\")}.",
+    "2511919794": "<color=yellow>{count}</color>| <color=green>{famName}</color>{(familiarBuffsData.FamiliarBuffs.ContainsKey(famKey) ? \"{colorCode}*</color> {levelAndPrestiges}\" : \" {levelAndPrestiges}\")}",
+    "508045935": "Acciones de emoticono {(GetPlayerBool(steamId, EMOTE_ACTIONS_KEY) ? \"<color=green>habilitadas</color>\" : \"<color=red>deshabilitadas</color>\")}!",
+    "52573990": "El registro de pericia ahora está {(GetPlayerBool(steamId, WEAPON_LOG_KEY) ? \"<color=green>habilitado</color>\" : \"<color=red>deshabilitado</color>\")}",
+    "1904876515": "El registro de misiones ahora está {(GetPlayerBool(steamId, QUEST_LOG_KEY) ? \"<color=green>habilitado</color>\" : \"<color=red>deshabilitado</color>\")}",
+    "3706417587": "Tipo de misión inválido '{questTypeName}'. Valores válidos: {string.Join(\", \", Enum.GetNames(typeof(QuestType)))}",
+    "1095669519": "El registro de nivel {(GetPlayerBool(SteamID, EXPERIENCE_LOG_KEY) ? \"<color=green>habilitado</color>\" : \"<color=red>deshabilitado</color>\")}",
+    "3112026815": "El registro de profesión ahora está {(GetPlayerBool(steamId, PROFESSION_LOG_KEY) ? \"<color=green>habilitado</color>\" : \"<color=red>deshabilitado</color>\")}",
+    "542066310": "El registro de Legado de Sangre {(GetPlayerBool(steamId, BLOOD_LOG_KEY) ? \"<color=green>habilitado</color>\" : \"<color=red>deshabilitado</color>\")}",
+    "881612152": "Acción de gesto en forma Exo (<color=white>provocación</color>) {(GetPlayerBool(steamId, SHAPESHIFT_KEY) ? \"<color=green>habilitada</color>\" : \"<color=red>deshabilitada</color>\")}"
   }
 }


### PR DESCRIPTION
## Summary
- translate missing Spanish message toggles and actions
- add Portuguese translations for battle group and logging prompts
- fill Simplified Chinese gaps for expertise and slot messages

## Testing
- `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations` *(fails: Missing hashes in German.json, French.json, Polish.json, Thai.json, Italian.json, Turkish.json, Japanese.json, Russian.json, Ukrainian.json, Korean.json, Hungarian.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893911f0ad8832d96c6b21a7dcabea1