### PR TITLE
Annotate dynamic box message to avoid translation warnings

### DIFF
--- a/Resources/Localization/Messages/Brazilian.json
+++ b/Resources/Localization/Messages/Brazilian.json
@@ -314,5 +314,8 @@
     "3112026815": "O registro de profissão agora está {(GetPlayerBool(steamId, PROFESSION_LOG_KEY) ? \"<color=green>ativado</color>\" : \"<color=red>desativado</color>\")}.",
     "542066310": "O registro de Legado de Sangue {(GetPlayerBool(steamId, BLOOD_LOG_KEY) ? \"<color=green>ativado</color>\" : \"<color=red>desativado</color>\")}.",
     "881612152": "Ação de emote da forma Exo (<color=white>provocar</color>) {(GetPlayerBool(steamId, SHAPESHIFT_KEY) ? \"<color=green>ativada</color>\" : \"<color=red>desativada</color>\")}"
+  },
+  "_meta": {
+    "1716911803": "Intentionally identical to English; dynamic placeholder"
   }
 }

--- a/Resources/Localization/Messages/English.json
+++ b/Resources/Localization/Messages/English.json
@@ -314,5 +314,8 @@
     "542066310": "Blood Legacy logging {(GetPlayerBool(steamId, BLOOD_LOG_KEY) ? \u0022\u003Ccolor=green\u003Eenabled\u003C/color\u003E\u0022 : \u0022\u003Ccolor=red\u003Edisabled\u003C/color\u003E\u0022)}.",
     "881612152": "Exo form emote action (\u003Ccolor=white\u003Etaunt\u003C/color\u003E) {(GetPlayerBool(steamId, SHAPESHIFT_KEY) ? \u0022\u003Ccolor=green\u003Eenabled\u003C/color\u003E\u0022 : \u0022\u003Ccolor=red\u003Edisabled\u003C/color\u003E\u0022)}",
     "2978826451": "\u003Ccolor=green\u003E{famName}\u003C/color\u003E{(buffsData.FamiliarBuffs.ContainsKey(familiarId) ? \u0022{colorCode}*\u003C/color\u003E\u0022 : \u0022\u0022)} [\u003Ccolor=white\u003E{level}\u003C/color\u003E][\u003Ccolor=#90EE90\u003E{prestiges}\u003C/color\u003E] added to \u003Ccolor=white\u003E{groupName}\u003C/color\u003E! (\u003Ccolor=yellow\u003E{slotIndex}\u003C/color\u003E)"
+  },
+  "_meta": {
+    "1716911803": "Intentionally identical to English; dynamic placeholder"
   }
 }

--- a/Resources/Localization/Messages/French.json
+++ b/Resources/Localization/Messages/French.json
@@ -295,5 +295,8 @@
     "709298301": "<color=#90EE90>{parsedPrestigeType}</color>[<color=white>{prestigeLevel}</color>] a obtenu du prestige! Taux de croissance réduit de <color=red>{percentageReductionString}</color> et bonus statistiques améliorés de <color=green>{statGainString}</color>. La variation totale du taux de croissance avec une prime de prestige est <color=yellow>{totalEffectString}</color>.",
     "1443941563": "Enlevez les buffs de prestige de tous les joueurs.",
     "1286090332": "Vous êtes niveau [<color=white>{data.Key}</color>][<color=#90EE90>{prestigeLevel}</color>] avec <color=yellow>{progress}</color> <color=#FFC0CB> </color> <color=white>{BloodSystem.GetLevelProgress(ctx.Event.User.PlatformId, handler)}%</color> dans <color=red>{handler.GetBloodType()}</color>!"
+  },
+  "_meta": {
+    "1716911803": "Intentionally identical to English; dynamic placeholder"
   }
 }

--- a/Resources/Localization/Messages/German.json
+++ b/Resources/Localization/Messages/German.json
@@ -248,5 +248,8 @@
     "2480816305": "<color=#c0c0c0>{expertiseHandler.GetWeaponType()}</color>-Fachwissen auf [<color=white>{level}</color>] für <color=green>{playerInfo.User.CharacterName.Value}</color> gesetzt",
     "3761416018": "Erster unbewaffneter Slot auf <color=white>{new PrefabGUID(ability).GetPrefabName()}</color> für <color=green>{playerInfo.User.CharacterName.Value}</color> gesetzt.",
     "1826355702": "Zweiter unbewaffneter Slot auf <color=white>{new PrefabGUID(ability).GetPrefabName()}</color> für <color=green>{playerInfo.User.CharacterName.Value}</color> gesetzt."
+  },
+  "_meta": {
+    "1716911803": "Intentionally identical to English; dynamic placeholder"
   }
 }

--- a/Resources/Localization/Messages/Hungarian.json
+++ b/Resources/Localization/Messages/Hungarian.json
@@ -121,5 +121,8 @@
     "2480816305": "<color=#c0c0c0>{expertiseHandler.GetWeaponType()}</color> szakértelem beállítva [<color=white>{level}</color>] <color=green>{playerInfo.User.CharacterName.Value}</color> számára",
     "3761416018": "Az első fegyvertelen nyílás <color=white>{new PrefabGUID(ability).GetPrefabName()}</color> értékre állítva <color=green>{playerInfo.User.CharacterName.Value}</color> számára.",
     "1826355702": "A második fegyvertelen nyílás <color=white>{new PrefabGUID(ability).GetPrefabName()}</color> értékre állítva <color=green>{playerInfo.User.CharacterName.Value}</color> számára."
+  },
+  "_meta": {
+    "1716911803": "Intentionally identical to English; dynamic placeholder"
   }
 }

--- a/Resources/Localization/Messages/Italian.json
+++ b/Resources/Localization/Messages/Italian.json
@@ -280,5 +280,8 @@
     "562341898": "Variazione totale del tasso di crescita compreso il bonus di prestigio di livellamento: <color=yellow>{totalEffectString}</color>",
     "1812818458": "Avete prestigio in <color=#90EE90>Esperienza</color>[<color=white>{prestigeLevel}</color>]! Tassi di crescita per tutte le competenze/leganze aumentati di <color=green>{gainPercentage}</color>, esperienza da unità uccisi da <color=red>{reductionPercentage}</color>.",
     "1443941563": "Rimossa prestigio buffs da tutti i giocatori."
+  },
+  "_meta": {
+    "1716911803": "Intentionally identical to English; dynamic placeholder"
   }
 }

--- a/Resources/Localization/Messages/Japanese.json
+++ b/Resources/Localization/Messages/Japanese.json
@@ -291,5 +291,8 @@
     "1812818458": "<color=#90EE90> で優先されている</color>[<color=white>{prestigeLevel}</color>]! <color=green>{gainPercentage}</color>によって増加したすべての専門知識/遺産の成長率、ユニットからの経験は<color=red>{reductionPercentage}</color>によって減少しました。",
     "709298301": "<color=#90EE90>{parsedPrestigeType}</color>[<color=white>{prestigeLevel}</color>]が正常に機能しました! <color=red>{percentageReductionString}</color>で成長率が低下し、<color=green>{statGainString}</color>によって改善された統計ボーナス。 プレステージボーナスをレベルアップした成長率の合計変更は<color=yellow>{totalEffectString}</color>です。",
     "1443941563": "すべてのプレーヤーからプレステージバフを削除します。"
+  },
+  "_meta": {
+    "1716911803": "Intentionally identical to English; dynamic placeholder"
   }
 }

--- a/Resources/Localization/Messages/Korean.json
+++ b/Resources/Localization/Messages/Korean.json
@@ -263,5 +263,8 @@
     "2480816305": "<color=#c0c0c0>{expertiseHandler.GetWeaponType()}</color> 전문 지식이 [<color=white>{level}</color>]로 설정되었습니다 <color=green>{playerInfo.User.CharacterName.Value}</color> 위해",
     "3761416018": "첫 번째 비무장 슬롯이 <color=white>{new PrefabGUID(ability).GetPrefabName()}</color>로 설정되어 <color=green>{playerInfo.User.CharacterName.Value}</color>에게 적용됩니다.",
     "1826355702": "두 번째 비무장 슬롯이 <color=white>{new PrefabGUID(ability).GetPrefabName()}</color>로 설정되어 <color=green>{playerInfo.User.CharacterName.Value}</color>에게 적용됩니다."
+  },
+  "_meta": {
+    "1716911803": "Intentionally identical to English; dynamic placeholder"
   }
 }

--- a/Resources/Localization/Messages/Latam.json
+++ b/Resources/Localization/Messages/Latam.json
@@ -314,5 +314,8 @@
     "542066310": "Blood Legacy logging {(GetPlayerBool(steamId, BLOOD_LOG_KEY) ? \"<color=green>enabled</color>\" : \"<color=red>disabled</color>\")}.",
     "881612152": "Exo form emote action (<color=white>taunt</color>) {(GetPlayerBool(steamId, SHAPESHIFT_KEY) ? \"<color=green>enabled</color>\" : \"<color=red>disabled</color>\")}",
     "2978826451": "<color=green>{famName}</color>{(buffsData.FamiliarBuffs.ContainsKey(familiarId) ? \"{colorCode}*</color>\" : \"\")} [<color=white>{level}</color>][<color=#90EE90>{prestiges}</color>] added to <color=white>{groupName}</color>! (<color=yellow>{slotIndex}</color>)"
+  },
+  "_meta": {
+    "1716911803": "Intentionally identical to English; dynamic placeholder"
   }
 }

--- a/Resources/Localization/Messages/Polish.json
+++ b/Resources/Localization/Messages/Polish.json
@@ -121,5 +121,8 @@
     "2480816305": "<color=#c0c0c0>{expertiseHandler.GetWeaponType()}</color> ustawiona na [<color=white>{level}</color>] dla <color=green>{playerInfo.User.CharacterName.Value}</color>",
     "3761416018": "Pierwsze nieuzbrojone gniazdo ustawione na <color=white>{new PrefabGUID(ability).GetPrefabName()}</color> dla <color=green>{playerInfo.User.CharacterName.Value}</color>.",
     "1826355702": "Drugie nieuzbrojone gniazdo ustawione na <color=white>{new PrefabGUID(ability).GetPrefabName()}</color> dla <color=green>{playerInfo.User.CharacterName.Value}</color>."
+  },
+  "_meta": {
+    "1716911803": "Intentionally identical to English; dynamic placeholder"
   }
 }

--- a/Resources/Localization/Messages/Russian.json
+++ b/Resources/Localization/Messages/Russian.json
@@ -223,5 +223,8 @@
     "562341898": "Общее изменение темпов роста, включая повышение престижа: <color=yellow>{totalEffectString}</color>",
     "1443941563": "Удалены престижные баффы от всех игроков.",
     "3706417587": "Недействительный квест типа «{questTypeName}». Действительные значения: {string.Join(\", \", Enum.GetNames(typeof(QuestType)))}"
+  },
+  "_meta": {
+    "1716911803": "Intentionally identical to English; dynamic placeholder"
   }
 }

--- a/Resources/Localization/Messages/SChinese.json
+++ b/Resources/Localization/Messages/SChinese.json
@@ -314,5 +314,8 @@
     "3112026815": "职业记录现在{(GetPlayerBool(steamId, PROFESSION_LOG_KEY) ? \"<color=green>已启用</color>\" : \"<color=red>已禁用</color>\")}。",
     "542066310": "血统记录{(GetPlayerBool(steamId, BLOOD_LOG_KEY) ? \"<color=green>已启用</color>\" : \"<color=red>已禁用</color>\")}。",
     "881612152": "Exo形态表情动作（<color=white>嘲讽</color>）{(GetPlayerBool(steamId, SHAPESHIFT_KEY) ? \"<color=green>已启用</color>\" : \"<color=red>已禁用</color>\")}"
+  },
+  "_meta": {
+    "1716911803": "Intentionally identical to English; dynamic placeholder"
   }
 }

--- a/Resources/Localization/Messages/Spanish.json
+++ b/Resources/Localization/Messages/Spanish.json
@@ -314,5 +314,8 @@
     "3112026815": "El registro de profesión ahora está {(GetPlayerBool(steamId, PROFESSION_LOG_KEY) ? \"<color=green>habilitado</color>\" : \"<color=red>deshabilitado</color>\")}",
     "542066310": "El registro de Legado de Sangre {(GetPlayerBool(steamId, BLOOD_LOG_KEY) ? \"<color=green>habilitado</color>\" : \"<color=red>deshabilitado</color>\")}",
     "881612152": "Acción de gesto en forma Exo (<color=white>provocación</color>) {(GetPlayerBool(steamId, SHAPESHIFT_KEY) ? \"<color=green>habilitada</color>\" : \"<color=red>deshabilitada</color>\")}"
+  },
+  "_meta": {
+    "1716911803": "Intentionally identical to English; dynamic placeholder"
   }
 }

--- a/Resources/Localization/Messages/TChinese.json
+++ b/Resources/Localization/Messages/TChinese.json
@@ -314,5 +314,8 @@
     "1443941563": "取消了所有玩家的聲望",
     "3066749917": "<color=green>{famName}</color>{(buffsData.FamiliarBuffs.ContesKey(familiar))_BAR__BAR__BAR__BAR__BAR__BAR__BAR__BAR__BAR__BAR__BAR__BAR__BAR__BAR__BAR__BAR_ Id) $\"{colorCode}*</color>\":\"[<color=white>{level}</color>][<color=#90EE90>{prestiges}</color>] 加上<color=white>{groupName}</color>! (<color=yellow>{slotIndex}</color>)",
     "2511919794": "<color=yellow>{count}</color>** <color=green>{famName}</color>{(familiar BuffsData.FamiliarBuffs.ContsKey(famKey)? $\"{colorCode}*</color>{levelAndPrestiges}: ${levelAndPrestiges}"
+  },
+  "_meta": {
+    "1716911803": "Intentionally identical to English; dynamic placeholder"
   }
 }

--- a/Resources/Localization/Messages/Thai.json
+++ b/Resources/Localization/Messages/Thai.json
@@ -120,5 +120,8 @@
     "2480816305": "กำหนด <color=#c0c0c0>{expertiseHandler.GetWeaponType()}</color> ไว้ที่ [<color=white>{level}</color>] สำหรับ <color=green>{playerInfo.User.CharacterName.Value}</color>",
     "3761416018": "สล็อตไม่มีอาวุธช่องแรกตั้งค่าเป็น <color=white>{new PrefabGUID(ability).GetPrefabName()}</color> สำหรับ <color=green>{playerInfo.User.CharacterName.Value}</color>.",
     "1826355702": "สล็อตไม่มีอาวุธช่องที่สองตั้งค่าเป็น <color=white>{new PrefabGUID(ability).GetPrefabName()}</color> สำหรับ <color=green>{playerInfo.User.CharacterName.Value}</color>."
+  },
+  "_meta": {
+    "1716911803": "Intentionally identical to English; dynamic placeholder"
   }
 }

--- a/Resources/Localization/Messages/Turkish.json
+++ b/Resources/Localization/Messages/Turkish.json
@@ -134,5 +134,8 @@
     "2480816305": "<color=#c0c0c0>{expertiseHandler.GetWeaponType()}</color> uzmanlığı [<color=white>{level}</color>] olarak ayarlandı <color=green>{playerInfo.User.CharacterName.Value}</color> için",
     "3761416018": "İlk silahsız yuva <color=white>{new PrefabGUID(ability).GetPrefabName()}</color> olarak ayarlandı <color=green>{playerInfo.User.CharacterName.Value}</color> için.",
     "1826355702": "İkinci silahsız yuva <color=white>{new PrefabGUID(ability).GetPrefabName()}</color> olarak ayarlandı <color=green>{playerInfo.User.CharacterName.Value}</color> için."
+  },
+  "_meta": {
+    "1716911803": "Intentionally identical to English; dynamic placeholder"
   }
 }

--- a/Resources/Localization/Messages/Ukrainian.json
+++ b/Resources/Localization/Messages/Ukrainian.json
@@ -262,5 +262,8 @@
     "2480816305": "<color=#c0c0c0>{expertiseHandler.GetWeaponType()}</color> встановлено на [<color=white>{level}</color>] для <color=green>{playerInfo.User.CharacterName.Value}</color>",
     "3761416018": "Перший незбройний слот встановлено на <color=white>{new PrefabGUID(ability).GetPrefabName()}</color> для <color=green>{playerInfo.User.CharacterName.Value}</color>.",
     "1826355702": "Другий незбройний слот встановлено на <color=white>{new PrefabGUID(ability).GetPrefabName()}</color> для <color=green>{playerInfo.User.CharacterName.Value}</color>."
+  },
+  "_meta": {
+    "1716911803": "Intentionally identical to English; dynamic placeholder"
   }
 }

--- a/Resources/Localization/Messages/Vietnamese.json
+++ b/Resources/Localization/Messages/Vietnamese.json
@@ -314,5 +314,8 @@
     "542066310": "Ghi nhật ký di sản {(GetPlayerBool(steamId, BLOOD_LOG_KEY) ? \"<color=green>enabled</color>\" : \"<color=red>disabled</color>\")}.",
     "881612152": "Exo form hành động emote (<color=white>tain</color>) {(getPlayerBool (steamid, shapeshift_key)? \"<Color = green> enable</color>\": \"",
     "2978826451": "<color=green>{famName}</color>{(buffsData.FamiliarBuffs.ContainsKey(familiarId) ? \"{colorCode}*</color> \":\" \")} [<color=white>{level}</color>] <color=#90EE90>{prestiges}2"
+  },
+  "_meta": {
+    "1716911803": "Intentionally identical to English; dynamic placeholder"
   }
 }


### PR DESCRIPTION
## Summary
- clarify that message hash `1716911803` is dynamic content
- mark hash `1716911803` as intentionally matching English across all language files to silence translation warnings

## Testing
- `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations` *(fails: missing hashes in existing translations)*

------
https://chatgpt.com/codex/tasks/task_e_6893b3362fa0832d8e9c237085a29316