### PR TITLE
Use sentinel token for Argos token-only lines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ Current PRDs and task lists are stored in `.project-management/current-prd/`, wh
 4. Automatically translate missing strings with Argos:
    `python Tools/translate_argos.py Resources/Localization/Messages/<Language>.json --to <iso-code> --batch-size 100 --max-retries 3 --verbose --log-file translate.log`
    `--verbose` and `--log-file` help pinpoint skipped or untranslated strings. `translate.py` still exists but prints a deprecation warning.
-5. The script hides `<...>` tags and `{...}` placeholders as `[[TOKEN_n]]` tokens. Lines consisting only of tokens are given a dummy `TRANSLATE` suffix so Argos will process them.
+5. The script hides `<...>` tags and `{...}` placeholders as `[[TOKEN_n]]` tokens. Lines consisting only of tokens are given a `[[TOKEN_SENTINEL]]` suffix so Argos will process them. The placeholder is stripped afterward and `fix_tokens.py` restores any altered tokens.
    **DO NOT** edit text inside these tokens, tags, or variables.
 6. After translation, run the checker to ensure nothing remains in English:
    `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations`


### PR DESCRIPTION
## Summary
- replace TRANSLATE hack with [[TOKEN_SENTINEL]] marker for token-only lines
- verify sentinel survives translation and strip it before saving
- run fix_tokens after translation to restore placeholder tokens

## Testing
- `python -m py_compile Tools/translate_argos.py`
- `/usr/lib/dotnet6/dotnet test Bloodcraft.Tests/Bloodcraft.Tests.csproj` *(fails: Invalid expression term '[')*
- `python Tools/fix_tokens.py --check-only`

------
https://chatgpt.com/codex/tasks/task_e_68979c6d87e4832d979ed17f3c14dbb7