### PR TITLE
Support prefab name parsing for banned units

### DIFF
--- a/Bloodcraft.Tests/Bloodcraft.Tests.csproj
+++ b/Bloodcraft.Tests/Bloodcraft.Tests.csproj
@@ -6,7 +6,6 @@
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>
     <EnablePreviewFeatures>true</EnablePreviewFeatures>
-
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -21,11 +20,12 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>
     <Compile Include="..\Utilities\LocalizationHelpers.cs" Link="LocalizationHelpers.cs" />
+    <Compile Include="..\Utilities\Configuration.cs" Link="Configuration.cs" />
   </ItemGroup>
 
 </Project>

--- a/Bloodcraft.Tests/ConfigurationTests.cs
+++ b/Bloodcraft.Tests/ConfigurationTests.cs
@@ -1,0 +1,29 @@
+using Bloodcraft.Services;
+using Bloodcraft.Utilities;
+using ProjectM;
+using Stunlock.Core;
+using Xunit;
+
+namespace Bloodcraft.Tests;
+
+public class ConfigurationTests
+{
+    [Fact]
+    public void ParsePrefabGuidsFromString_ParsesNumericGuid()
+    {
+        var result = Configuration.ParsePrefabGuidsFromString("123456");
+        Assert.Single(result);
+        Assert.Equal(new PrefabGUID(123456), result[0]);
+    }
+
+    [Fact]
+    public void ParsePrefabGuidsFromString_ParsesNameCaseInsensitive()
+    {
+        PrefabGUID guid = new(654321);
+        ((Dictionary<PrefabGUID, string>)LocalizationService.PrefabGuidNames)[guid] = "CHAR_Test_Prefab";
+
+        var result = Configuration.ParsePrefabGuidsFromString("char_test_prefab");
+        Assert.Single(result);
+        Assert.Equal(guid, result[0]);
+    }
+}

--- a/Bloodcraft.Tests/Stubs.cs
+++ b/Bloodcraft.Tests/Stubs.cs
@@ -1,0 +1,103 @@
+using System.Collections.Generic;
+using Stunlock.Core;
+
+namespace Bloodcraft.Services
+{
+    public static class ConfigService
+    {
+        public static string BannedUnits = string.Empty;
+        public static string BannedTypes = string.Empty;
+        public static string QuestRewardAmounts = string.Empty;
+        public static string QuestRewards = string.Empty;
+        public static string KitQuantities = string.Empty;
+        public static string KitPrefabs = string.Empty;
+    }
+
+    public static class LocalizationService
+    {
+        public static Dictionary<PrefabGUID, string> PrefabGuidNames { get; } = new();
+    }
+}
+
+namespace Bloodcraft.Commands
+{
+    public static class MiscCommands
+    {
+        public static Dictionary<PrefabGUID, int> StarterKitItemPrefabGUIDs { get; } = new();
+    }
+}
+
+namespace Bloodcraft.Patches
+{
+    public static class AbilityRunScriptsSystemPatch
+    {
+        public static void AddClassSpell(PrefabGUID spell, int index) { }
+    }
+}
+
+namespace Bloodcraft.Systems.Familiars
+{
+    public static class FamiliarUnlockSystem
+    {
+        public static HashSet<PrefabGUID> ConfiguredPrefabGuidBans { get; } = new();
+        public static HashSet<UnitCategory> ConfiguredCategoryBans { get; } = new();
+    }
+
+    public enum UnitCategory { }
+}
+
+namespace Bloodcraft.Systems.Quests
+{
+    public static class QuestSystem
+    {
+        public static Dictionary<PrefabGUID, int> QuestRewards { get; } = new();
+    }
+}
+
+namespace Bloodcraft.Utilities
+{
+    public static class Classes
+    {
+        public static Dictionary<string, string> ClassSpellsMap { get; } = new();
+    }
+}
+
+namespace Stunlock.Core
+{
+    public readonly struct PrefabGUID : System.IEquatable<PrefabGUID>
+    {
+        readonly int _hash;
+        public PrefabGUID(int hash) => _hash = hash;
+        public bool HasValue() => _hash != 0;
+        public bool Equals(PrefabGUID other) => _hash == other._hash;
+        public override bool Equals(object obj) => obj is PrefabGUID other && Equals(other);
+        public override int GetHashCode() => _hash;
+    }
+}
+
+namespace ProjectM
+{
+    public class PrefabCollectionSystem
+    {
+        public Dictionary<string, Stunlock.Core.PrefabGUID> SpawnableNameToPrefabGuidDictionary { get; } = new();
+    }
+}
+
+namespace Bloodcraft
+{
+    public static class Core
+    {
+        public static SystemService SystemService { get; } = new();
+        public static Logger Log { get; } = new();
+    }
+
+    public class SystemService
+    {
+        public ProjectM.PrefabCollectionSystem PrefabCollectionSystem { get; } = new();
+    }
+
+    public class Logger
+    {
+        public void LogWarning(string message) { }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -628,7 +628,7 @@ Run `.codex/install.sh` once to install the .NET SDK and Argos Translate depende
 - **Allow Minions**: `AllowMinions` (bool, default: False)
   Allow Minions to be unlocked as familiars (leaving these excluded by default since some have undesirable behaviour and I am not sifting through them all to correct that, enable at own risk).
 - **Banned Units**: `BannedUnits` (string, default: "")
-  The PrefabGUID hashes for units that cannot be used as familiars. Same structure as the buff lists except unit prefabs.
+  Comma-separated Prefab GUID hashes or prefab names for units that cannot be used as familiars (e.g., `123456`, `CHAR_Vampire_Dracula_VBlood`).
 - **Banned Types**: `BannedTypes` (string, default: "")
   The types of units that cannot be used as familiars go here (Human, Undead, Demon, Mechanical, Beast).
 - **Unit Familiar Multiplier**: `UnitFamiliarMultiplier` (float, default: 7.5)


### PR DESCRIPTION
## Summary
- add ParsePrefabGuidsFromString helper to resolve numeric GUIDs or prefab names
- allow BannedUnits to accept prefab names in config
- cover numeric and name-based parsing with unit tests

## Testing
- `dotnet build`
- `dotnet test Bloodcraft.Tests/Bloodcraft.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_6897d62610e8832d9bf830759fd8932a