### PR TITLE
Validate Argos model presence before translation

### DIFF
--- a/Tools/test_translate_argos.py
+++ b/Tools/test_translate_argos.py
@@ -1,0 +1,17 @@
+import os
+import tempfile
+import pytest
+
+from translate_argos import ensure_model_installed
+
+
+def test_raises_when_segments_present_without_model():
+    with tempfile.TemporaryDirectory() as root:
+        model_dir = os.path.join(
+            root, "Resources", "Localization", "Models", "xx"
+        )
+        os.makedirs(model_dir)
+        open(os.path.join(model_dir, "translate-test.z01"), "wb").close()
+        with pytest.raises(RuntimeError) as err:
+            ensure_model_installed(root, "xx")
+        assert "cd Resources/Localization/Models/xx" in str(err.value)


### PR DESCRIPTION
## Summary
- warn when Argos model segments exist without an installed `.argosmodel`
- skip model checks if the translator is already loaded
- add unit test covering missing model error path

## Testing
- `pytest Tools/test_translate_argos.py`
- `PATH=/usr/share/dotnet:$PATH dotnet test Bloodcraft.Tests/Bloodcraft.Tests.csproj` *(fails: Invalid expression term '[' errors)*

------
https://chatgpt.com/codex/tasks/task_e_68983f9019d4832d8930af1cc3c6aa05