### PR TITLE
Ensure translate_argos creates log/report directories

### DIFF
--- a/Tools/test_translate_argos.py
+++ b/Tools/test_translate_argos.py
@@ -1,7 +1,12 @@
+import json
 import os
+import subprocess
+import sys
 import tempfile
+
 import pytest
 
+import translate_argos
 from translate_argos import ensure_model_installed
 
 
@@ -15,3 +20,53 @@ def test_raises_when_segments_present_without_model():
         with pytest.raises(RuntimeError) as err:
             ensure_model_installed(root, "xx")
         assert "cd Resources/Localization/Models/xx" in str(err.value)
+
+
+def test_creates_directories_for_logs_and_reports(tmp_path, monkeypatch):
+    root = tmp_path
+    messages_dir = root / "Resources" / "Localization" / "Messages"
+    messages_dir.mkdir(parents=True)
+    (messages_dir / "English.json").write_text(
+        json.dumps({"Messages": {"hash": "Hello"}})
+    )
+
+    target_rel = "Resources/Localization/Messages/Test.json"
+    log_path = root / "logs" / "nested" / "out.log"
+    report_path = root / "reports" / "nested" / "report.json"
+
+    class DummyTranslator:
+        def translate(self, text):
+            return "Bonjour"
+
+    monkeypatch.setattr(
+        translate_argos.argos_translate,
+        "get_translation_from_codes",
+        lambda src, dst: DummyTranslator(),
+    )
+    monkeypatch.setattr(
+        translate_argos.argos_translate, "load_installed_languages", lambda: None
+    )
+    monkeypatch.setattr(translate_argos, "contains_english", lambda s: False)
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: None)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "translate_argos.py",
+            target_rel,
+            "--to",
+            "xx",
+            "--root",
+            str(root),
+            "--log-file",
+            str(log_path),
+            "--report-file",
+            str(report_path),
+            "--overwrite",
+        ],
+    )
+
+    translate_argos.main()
+
+    assert log_path.is_file()
+    assert report_path.is_file()

--- a/Tools/translate_argos.py
+++ b/Tools/translate_argos.py
@@ -155,10 +155,16 @@ def main():
     )
     ap.add_argument("--overwrite", action="store_true", help="Translate all messages even if already present")
     ap.add_argument("--verbose", action="store_true", help="Print per-message translation details")
-    ap.add_argument("--log-file", help="Write verbose output to this file")
+    ap.add_argument(
+        "--log-file",
+        help="Write verbose output to this file; missing directories are created",
+    )
     ap.add_argument(
         "--report-file",
-        help="Write skipped hashes and reasons to this JSON or CSV file",
+        help=(
+            "Write skipped hashes and reasons to this JSON or CSV file; "
+            "missing directories are created"
+        ),
     )
     args = ap.parse_args()
 
@@ -175,7 +181,12 @@ def main():
             "Assemble or install the model, or run `.codex/install.sh`."
         )
 
-    log_fp = open(args.log_file, "w", encoding="utf-8") if args.log_file else None
+    log_fp = None
+    if args.log_file:
+        log_dir = os.path.dirname(args.log_file)
+        if log_dir:
+            os.makedirs(log_dir, exist_ok=True)
+        log_fp = open(args.log_file, "w", encoding="utf-8")
 
     def log_verbose(msg: str) -> None:
         if args.verbose:
@@ -313,6 +324,9 @@ def main():
         log_fp.close()
 
     if args.report_file:
+        report_dir = os.path.dirname(args.report_file)
+        if report_dir:
+            os.makedirs(report_dir, exist_ok=True)
         ext = os.path.splitext(args.report_file)[1].lower()
         with open(args.report_file, "w", encoding="utf-8", newline="") as fp:
             if ext == ".json":


### PR DESCRIPTION
## Summary
- create parent directories for log and skip report files in translate_argos
- document automatic directory creation in CLI help
- add regression test covering nested log/report paths

## Testing
- `pytest -q`
- `dotnet test Bloodcraft.Tests/Bloodcraft.Tests.csproj` *(fails: .NET 6 runtime missing)*


------
https://chatgpt.com/codex/tasks/task_e_68984d5781e0832db0758376e0a11132