### PR TITLE
Add configurable allowlist for English detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -806,6 +806,11 @@ dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- generate-me
 4. **Verify translations.**
    `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations --show-text`
    This command confirms every hash exists and no English text remains.
+
+### English detection allowlist
+
+`Tools/language_utils.py` flags untranslated strings by searching for common English stop words.
+To ignore project-specific terms like "Bloodcraft", add them to `Tools/english_allowlist.txt`, one per line.
 Each language model resides under `Resources/Localization/Models/<DIR>`. Combine the split archives, inspect `metadata.json` to confirm the language pair, and then install:
 
 ```bash

--- a/Tools/english_allowlist.txt
+++ b/Tools/english_allowlist.txt
@@ -1,0 +1,3 @@
+# Words that should not trigger English detection.
+# Add one term per line.
+Bloodcraft

--- a/Tools/language_utils.py
+++ b/Tools/language_utils.py
@@ -6,10 +6,21 @@ _STOP_WORDS_PATH = os.path.join(os.path.dirname(__file__), "english_stopwords.tx
 with open(_STOP_WORDS_PATH, encoding="utf-8") as f:
     STOP_WORDS: Set[str] = {line.strip().lower() for line in f if line.strip()}
 
+_ALLOWLIST_PATH = os.path.join(os.path.dirname(__file__), "english_allowlist.txt")
+if os.path.exists(_ALLOWLIST_PATH):
+    with open(_ALLOWLIST_PATH, encoding="utf-8") as f:
+        ALLOWLIST: Set[str] = {line.strip().lower() for line in f if line.strip()}
+else:
+    ALLOWLIST: Set[str] = set()
+
 _WORD_RE = re.compile(r"\b\w+\b")
 
 
 def contains_english(text: str) -> bool:
-    """Return True if the text appears to contain English words."""
+    """Return True if the text appears to contain English words.
+
+    Words listed in ``english_allowlist.txt`` are ignored.
+    """
     words = set(_WORD_RE.findall(text.lower()))
+    words -= ALLOWLIST
     return any(word in STOP_WORDS for word in words)

--- a/Tools/test_language_utils.py
+++ b/Tools/test_language_utils.py
@@ -1,0 +1,6 @@
+import language_utils
+
+
+def test_allowlisted_word_is_ignored(monkeypatch):
+    monkeypatch.setattr(language_utils, "STOP_WORDS", {"bloodcraft"})
+    assert not language_utils.contains_english("Bloodcraft")


### PR DESCRIPTION
## Summary
- add `Tools/english_allowlist.txt` to ignore project-specific terms during English detection
- teach `contains_english` to honor the allowlist
- document how to extend the allowlist
- test allowlisted words to avoid false positives

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68984e51c9fc832d9f34dcabec165ed7