### PR TITLE
Refactor server replies for localization

### DIFF
--- a/Commands/FamiliarCommands.cs
+++ b/Commands/FamiliarCommands.cs
@@ -1529,7 +1529,7 @@ internal static class FamiliarCommands
 
         EmoteSystemPatch.BattleChallenges.Add((ctx.User.PlatformId, playerInfo.User.PlatformId));
         LocalizationService.Reply(ctx, $"Challenged <color=white>{playerInfo.User.CharacterName.Value}</color> to a battle! (<color=yellow>30s</color> until it expires)");
-        LocalizationService.HandleServerReply(EntityManager, playerInfo.User, $"<color=white>{ctx.User.CharacterName.Value}</color> has challenged you to a battle! (<color=yellow>30s</color> until it expires, accept by emoting '<color=green>Yes</color>' or decline by emoting '<color=red>No</color>')");
+        LocalizationService.Reply(EntityManager, playerInfo.User, "<color=white>{0}</color> has challenged you to a battle! (<color=yellow>30s</color> until it expires, accept by emoting '<color=green>Yes</color>' or decline by emoting '<color=red>No</color>')", ctx.User.CharacterName.Value);
 
         ChallengeExpiredRoutine((ctx.User.PlatformId, playerInfo.User.PlatformId)).Start();
     }

--- a/Interfaces/EclipseInterface.cs
+++ b/Interfaces/EclipseInterface.cs
@@ -63,7 +63,7 @@ internal class VersionHandler_1_3 : IVersionHandler<ProgressDataV1_3>
         string message = BuildConfigMessage();
         string messageWithMAC = $"{message};mac{ChatMessageSystemPatch.GenerateMAC(message)}";
 
-        LocalizationService.HandleServerReply(Core.EntityManager, user, messageWithMAC);
+        LocalizationService.Reply(Core.EntityManager, user, messageWithMAC);
     }
     public void SendClientProgress(Entity playerCharacter, ulong steamId)
     {
@@ -85,7 +85,7 @@ internal class VersionHandler_1_3 : IVersionHandler<ProgressDataV1_3>
         string message = BuildProgressMessage(data);
         string messageWithMAC = $"{message};mac{ChatMessageSystemPatch.GenerateMAC(message)}";
 
-        LocalizationService.HandleServerReply(Core.EntityManager, user, messageWithMAC);
+        LocalizationService.Reply(Core.EntityManager, user, messageWithMAC);
     }
     public string BuildConfigMessage()
     {

--- a/Patches/EmoteSystemPatch.cs
+++ b/Patches/EmoteSystemPatch.cs
@@ -104,15 +104,15 @@ internal static class EmoteSystemPatch
                 {
                     if (playerCharacter.HasBuff(_dominateBuff) && EmoteActions.ContainsKey(useEmoteEvent.Action))
                     {
-                        LocalizationService.HandleServerReply(EntityManager, user, "You can't use emote actions when using dominate form!");
+                        LocalizationService.Reply(EntityManager, user, "You can't use emote actions when using dominate form!");
                     }
                     else if (playerCharacter.HasBuff(_takeFlightBuff) && EmoteActions.ContainsKey(useEmoteEvent.Action))
                     {
-                        LocalizationService.HandleServerReply(EntityManager, user, "You can't use emote actions when using bat form!");
+                        LocalizationService.Reply(EntityManager, user, "You can't use emote actions when using bat form!");
                     }
                     else if (useEmoteEvent.Action.Equals(_beckonAbilityGroup) && playerCharacter.PlayerInCombat())
                     {
-                        LocalizationService.HandleServerReply(EntityManager, user, "You can't interact with your familiar during combat!");
+                        LocalizationService.Reply(EntityManager, user, "You can't interact with your familiar during combat!");
                     }
                     else if (EmoteActions.TryGetValue(useEmoteEvent.Action, out var action)) action.Invoke(user, playerCharacter, steamId);
                 }
@@ -128,7 +128,7 @@ internal static class EmoteSystemPatch
         if (!ShapeshiftCache.TryGetShapeshiftBuff(steamId, out PrefabGUID shapeshiftBuff))
         {
             BlockShapeshift.Add(steamId);
-            LocalizationService.HandleServerReply(EntityManager, user, "Select a form you've unlocked first! ('<color=white>.prestige sf [<color=orange>EvolvedVampire|CorruptedSerpent</color>]</color>')");
+            LocalizationService.Reply(EntityManager, user, "Select a form you've unlocked first! ('<color=white>.prestige sf [<color=orange>EvolvedVampire|CorruptedSerpent</color>]</color>')");
             return;
         }
 
@@ -171,7 +171,7 @@ internal static class EmoteSystemPatch
                 {
                     if (!_familiarPvP && playerCharacter.HasBuff(_pvpCombatBuff))
                     {
-                        LocalizationService.HandleServerReply(EntityManager, user, "You can't call your familiar during PvP combat!");
+                        LocalizationService.Reply(EntityManager, user, "You can't call your familiar during PvP combat!");
                         return;
                     }
                     else CallFamiliar(playerCharacter, familiar, user, steamId);
@@ -188,25 +188,25 @@ internal static class EmoteSystemPatch
             }
             else
             {
-                LocalizationService.HandleServerReply(EntityManager, user, "Active familiar doesn't exist! If that doesn't seem right try using '<color=white>.fam reset</color>'.");
+                LocalizationService.Reply(EntityManager, user, "Active familiar doesn't exist! If that doesn't seem right try using '<color=white>.fam reset</color>'.");
             }
         }
         else
         {
-            LocalizationService.HandleServerReply(EntityManager, user, "Couldn't find active familiar...");
+            LocalizationService.Reply(EntityManager, user, "Couldn't find active familiar...");
         }
     }
     public static void CombatMode(User user, Entity playerCharacter, ulong steamId)
     {
         if (!_familiarCombat)
         {
-            LocalizationService.HandleServerReply(EntityManager, user, "Familiar combat is not enabled.");
+            LocalizationService.Reply(EntityManager, user, "Familiar combat is not enabled.");
             return;
         }
 
         if (playerCharacter.PlayerInCombat())
         {
-            LocalizationService.HandleServerReply(EntityManager, user, "You can't toggle familiar combat mode during PvE/PvP combat!");
+            LocalizationService.Reply(EntityManager, user, "You can't toggle familiar combat mode during PvE/PvP combat!");
             return;
         }
         else if (steamId.HasActiveFamiliar())
@@ -215,7 +215,7 @@ internal static class EmoteSystemPatch
 
             if (!familiar.Exists())
             {
-                LocalizationService.HandleServerReply(EntityManager, user, "Couldn't find active familiar...");
+                LocalizationService.Reply(EntityManager, user, "Couldn't find active familiar...");
                 return;
             }
             else if (familiar.HasBuff(_invulnerableBuff))
@@ -225,7 +225,7 @@ internal static class EmoteSystemPatch
                 EnableAggro(familiar);
                 Familiars.EnableAggroable(familiar);
 
-                LocalizationService.HandleServerReply(EntityManager, user, "Familiar combat <color=green>enabled</color>.");
+                LocalizationService.Reply(EntityManager, user, "Familiar combat <color=green>enabled</color>.");
             }
             else
             {
@@ -234,12 +234,12 @@ internal static class EmoteSystemPatch
                 DisableAggro(familiar);
                 Familiars.DisableAggroable(familiar);
 
-                LocalizationService.HandleServerReply(EntityManager, user, "Familiar combat <color=red>disabled</color>.");
+                LocalizationService.Reply(EntityManager, user, "Familiar combat <color=red>disabled</color>.");
             }
         }
         else
         {
-            LocalizationService.HandleServerReply(EntityManager, user, "Couldn't find active familiar...");
+            LocalizationService.Reply(EntityManager, user, "Couldn't find active familiar...");
         }
     }
     public static void InteractMode(User user, Entity playerCharacter, ulong steamId)
@@ -252,14 +252,14 @@ internal static class EmoteSystemPatch
 
         if (activeFamiliarData.Dismissed)
         {
-            LocalizationService.HandleServerReply(EntityManager, user, "Can't interact with familiar when dismissed!");
+            LocalizationService.Reply(EntityManager, user, "Can't interact with familiar when dismissed!");
             return;
         }
         else if (familiar.Exists() && servant.Exists() && coffin.Exists())
         {
             if (familiar.HasBuff(_vanishBuff))
             {
-                LocalizationService.HandleServerReply(EntityManager, user, "Can't interact with familiar when binding/unbinding!");
+                LocalizationService.Reply(EntityManager, user, "Can't interact with familiar when binding/unbinding!");
                 return;
             }
 

--- a/Patches/ServerBootstrapSystemPatches.cs
+++ b/Patches/ServerBootstrapSystemPatches.cs
@@ -337,9 +337,7 @@ internal static class ServerBootstrapSystemPatches
                         int roundedXP = (int)(Math.Round(currentRestedXP / 100.0) * 100);
 
                         steamId.SetPlayerRestedXP(new KeyValuePair<DateTime, float>(DateTime.UtcNow, currentRestedXP));
-                        string message = $"+<color=#FFD700>{roundedXP}</color> <color=green>rested</color> <color=#FFC0CB>experience</color> earned from being logged out in your coffin!";
-
-                        LocalizationService.HandleServerReply(EntityManager, user, message);
+                        LocalizationService.Reply(EntityManager, user, "+<color=#FFD700>{0}</color> <color=green>rested</color> <color=#FFC0CB>experience</color> earned from being logged out in your coffin!", roundedXP);
                     }
                 }
             }

--- a/Services/BattleService.cs
+++ b/Services/BattleService.cs
@@ -550,19 +550,19 @@ internal class BattleService
     {
         if (playerOne.TryGetPlayerInfo(out PlayerInfo playerInfo))
         {
-            LocalizationService.HandleServerReply(EntityManager, playerInfo.User, message);
+            LocalizationService.Reply(EntityManager, playerInfo.User, message);
         }
 
         if (playerTwo.TryGetPlayerInfo(out playerInfo))
         {
-            LocalizationService.HandleServerReply(EntityManager, playerInfo.User, message);
+            LocalizationService.Reply(EntityManager, playerInfo.User, message);
         }
     }
     static void NotifyPlayer(ulong steamId, string message)
     {
         if (steamId.TryGetPlayerInfo(out PlayerInfo playerInfo) && playerInfo.User.IsConnected)
         {
-            LocalizationService.HandleServerReply(EntityManager, playerInfo.User, message);
+            LocalizationService.Reply(EntityManager, playerInfo.User, message);
         }
     }
     static void GenerateBattleFormations(float3 battleCenter)

--- a/Services/LocalizationService.cs
+++ b/Services/LocalizationService.cs
@@ -289,6 +289,30 @@ internal class LocalizationService // the bones are from KindredCommands, ty Odj
         Reply(ctx, message);
     }
 
+    public static void Reply(EntityManager entityManager, User user, string englishText, params object[] args)
+    {
+        uint hash = ComputeHash(englishText);
+        string message = englishText;
+
+        if (_messageDictionary.TryGetValue(hash, out string localized))
+        {
+            message = args.Length > 0 ? string.Format(localized, args) : localized;
+        }
+        else if (args.Length > 0)
+        {
+            message = string.Format(englishText, args);
+        }
+
+        FixedString512Bytes fixedMessage = new(message);
+        ServerChatUtils.SendSystemMessageToClient(entityManager, user, ref fixedMessage);
+    }
+
+    [Obsolete("Use Reply instead")]
+    public static void HandleServerReply(EntityManager entityManager, User user, string message)
+    {
+        Reply(entityManager, user, message);
+    }
+
     static readonly ComponentType[] _networkEventComponents =
     [
         ComponentType.ReadOnly(Il2CppType.Of<FromCharacter>()),
@@ -319,10 +343,4 @@ internal class LocalizationService // the bones are from KindredCommands, ty Odj
         networkEntity.Write(_networkEventType);
         networkEntity.Write(chatMessageEvent);
     }
-    public static void HandleServerReply(EntityManager entityManager, User user, string message)
-    {
-        FixedString512Bytes fixedMessage = new(message);
-        ServerChatUtils.SendSystemMessageToClient(entityManager, user, ref fixedMessage);
-    }
-
 }

--- a/Systems/Expertise/WeaponSystem.cs
+++ b/Systems/Expertise/WeaponSystem.cs
@@ -326,8 +326,9 @@ internal static class WeaponSystem
 
         if (GetPlayerBool(steamId, WEAPON_LOG_KEY))
         {
-            LocalizationService.HandleServerReply(EntityManager, user,
-                $"+<color=yellow>{gainedIntXP}</color> <color=#c0c0c0>{weaponType.ToString().ToLower()}</color> <color=#FFC0CB>expertise</color> (<color=white>{levelProgress}%</color>)");
+            LocalizationService.Reply(EntityManager, user,
+                "+<color=yellow>{0}</color> <color=#c0c0c0>{1}</color> <color=#FFC0CB>expertise</color> (<color=white>{2}%</color>)",
+                gainedIntXP, weaponType.ToString().ToLower(), levelProgress);
         }
 
         if (GetPlayerBool(steamId, SCT_PLAYER_WEP_KEY))
@@ -340,8 +341,9 @@ internal static class WeaponSystem
     {
         if (newLevel <= _maxExpertiseLevel)
         {
-            LocalizationService.HandleServerReply(EntityManager, user,
-                $"<color=#c0c0c0>{weaponType}</color> improved to [<color=white>{newLevel}</color>]!");
+            LocalizationService.Reply(EntityManager, user,
+                "<color=#c0c0c0>{0}</color> improved to [<color=white>{1}</color>]!",
+                weaponType, newLevel);
         }
 
         if (GetPlayerBool(steamID, REMINDERS_KEY))
@@ -354,8 +356,9 @@ internal static class WeaponSystem
                     int choicesLeft = _expertiseStatChoices - currentStatCount;
                     string bonusString = choicesLeft > 1 ? "bonuses" : "bonus";
 
-                    LocalizationService.HandleServerReply(EntityManager, user,
-                        $"{choicesLeft} <color=white>stat</color> <color=#00FFFF>{bonusString}</color> available for <color=#c0c0c0>{weaponType.ToString().ToLower()}</color>; use '<color=white>.wep cst {weaponType} [Stat]</color>' to choose and '<color=white>.wep lst'</color> to view expertise stat options. (toggle reminders with <color=white>'.misc remindme'</color>)");
+                    LocalizationService.Reply(EntityManager, user,
+                        "{0} <color=white>stat</color> <color=#00FFFF>{1}</color> available for <color=#c0c0c0>{2}</color>; use '<color=white>.wep cst {3} [Stat]</color>' to choose and '<color=white>.wep lst'</color> to view expertise stat options. (toggle reminders with <color=white>'.misc remindme'</color>)",
+                        choicesLeft, bonusString, weaponType.ToString().ToLower(), weaponType);
                 }
             }
         }

--- a/Systems/Familiars/FamiliarBindingSystem.cs
+++ b/Systems/Familiars/FamiliarBindingSystem.cs
@@ -239,7 +239,7 @@ internal static class FamiliarBindingSystem
                 else
                 {
                     familiar.Destroy();
-                    LocalizationService.HandleServerReply(EntityManager, user, $"Binding failed...");
+                    LocalizationService.Reply(EntityManager, user, "Binding failed...");
 
                     return false;
                 }
@@ -793,8 +793,14 @@ internal static class FamiliarBindingSystem
                 }
             }
             
-            string message = isShiny ? $"<color=green>{familiarId.GetLocalizedName()}</color>{colorCode}*</color> <color=#00FFFF>bound</color>!" : $"<color=green>{familiarId.GetLocalizedName()}</color> <color=#00FFFF>bound</color>!";
-            LocalizationService.HandleServerReply(EntityManager, user, message);
+            if (isShiny)
+            {
+                LocalizationService.Reply(EntityManager, user, "<color=green>{0}</color>{1}*</color> <color=#00FFFF>bound</color>!", familiarId.GetLocalizedName(), colorCode);
+            }
+            else
+            {
+                LocalizationService.Reply(EntityManager, user, "<color=green>{0}</color> <color=#00FFFF>bound</color>!", familiarId.GetLocalizedName());
+            }
         }
     }
     static void HandleResistanceBuffForShiny(Entity familiar)

--- a/Systems/Familiars/FamiliarUnlockSystem.cs
+++ b/Systems/Familiars/FamiliarUnlockSystem.cs
@@ -169,16 +169,16 @@ internal static class FamiliarUnlockSystem
 
             if (!isShiny)
             {
-                LocalizationService.HandleServerReply(EntityManager, user, $"New unit unlocked: <color=green>{targetPrefabGuid.GetLocalizedName()}</color>");
+                LocalizationService.Reply(EntityManager, user, "New unit unlocked: <color=green>{0}</color>", targetPrefabGuid.GetLocalizedName());
             }
             else if (isShiny)
             {
-                LocalizationService.HandleServerReply(EntityManager, user, $"New <color=#00FFFF>shiny</color> unit unlocked: <color=green>{targetPrefabGuid.GetLocalizedName()}</color>");
+                LocalizationService.Reply(EntityManager, user, "New <color=#00FFFF>shiny</color> unit unlocked: <color=green>{0}</color>", targetPrefabGuid.GetLocalizedName());
             }
         }
         else if (isShiny)
         {
-            LocalizationService.HandleServerReply(EntityManager, user, $"<color=#00FFFF>Shiny</color> unlocked: <color=green>{targetPrefabGuid.GetLocalizedName()}</color>");
+            LocalizationService.Reply(EntityManager, user, "<color=#00FFFF>Shiny</color> unlocked: <color=green>{0}</color>", targetPrefabGuid.GetLocalizedName());
         }
     }
     public static bool HandleShiny(int famKey, ulong steamId, float chance, int choice = -1)

--- a/Systems/Legacies/BloodSystem.cs
+++ b/Systems/Legacies/BloodSystem.cs
@@ -292,8 +292,9 @@ internal static class BloodSystem
     {
         if (newLevel <= _maxBloodLevel)
         {
-            LocalizationService.HandleServerReply(EntityManager, user,
-                $"<color=red>{bloodType}</color> legacy improved to [<color=white>{newLevel}</color>]!");
+            LocalizationService.Reply(EntityManager, user,
+                "<color=red>{0}</color> legacy improved to [<color=white>{1}</color>]!",
+                bloodType, newLevel);
         }
 
         if (GetPlayerBool(steamID, REMINDERS_KEY))
@@ -307,8 +308,9 @@ internal static class BloodSystem
                     int choicesLeft = _legacyStatChoices - currentStatCount;
                     string bonusString = choicesLeft > 1 ? "bonuses" : "bonus";
 
-                    LocalizationService.HandleServerReply(EntityManager, user,
-                        $"{choicesLeft} <color=white>stat</color> <color=#00FFFF>{bonusString}</color> available for <color=red>{bloodType.ToString().ToLower()}</color>; use '<color=white>.bl cst [Stat]</color>' to choose and '<color=white>.bl lst</color>' to see options. (toggle reminders with <color=white>'.misc remindme'</color>)");
+                    LocalizationService.Reply(EntityManager, user,
+                        "{0} <color=white>stat</color> <color=#00FFFF>{1}</color> available for <color=red>{2}</color>; use '<color=white>.bl cst [Stat]</color>' to choose and '<color=white>.bl lst</color>' to see options. (toggle reminders with <color=white>'.misc remindme'</color>)",
+                        choicesLeft, bonusString, bloodType.ToString().ToLower());
                 }
             }
         }
@@ -329,8 +331,9 @@ internal static class BloodSystem
 
         if (GetPlayerBool(steamId, BLOOD_LOG_KEY))
         {
-            LocalizationService.HandleServerReply(EntityManager, user,
-                $"+<color=yellow>{gainedIntXP}</color> <color=red>{bloodType}</color> <color=#FFC0CB>essence</color> (<color=white>{levelProgress}%</color>)");
+            LocalizationService.Reply(EntityManager, user,
+                "+<color=yellow>{0}</color> <color=red>{1}</color> <color=#FFC0CB>essence</color> (<color=white>{2}%</color>)",
+                gainedIntXP, bloodType, levelProgress);
         }
 
         if (GetPlayerBool(steamId, SCT_PLAYER_BL_KEY))

--- a/Systems/Leveling/LevelingSystem.cs
+++ b/Systems/Leveling/LevelingSystem.cs
@@ -234,25 +234,33 @@ internal static class LevelingSystem
 
             if (newLevel <= _maxPlayerLevel)
             {
-                LocalizationService.HandleServerReply(EntityManager, user,
-                    $"Congratulations, you've reached level <color=white>{newLevel}</color>!");
+                LocalizationService.Reply(EntityManager, user,
+                    "Congratulations, you've reached level <color=white>{0}</color>!",
+                    newLevel);
             }
 
             if (_classes && GetPlayerBool(steamId, REMINDERS_KEY) && !steamId.HasClass(out PlayerClass? _))
             {
-                LocalizationService.HandleServerReply(EntityManager, user,
-                    $"Don't forget to choose a class! Use <color=white>'.class l'</color> to view choices and see what they have to offer with <color=white>'.class lb [Class]'</color> (buffs), <color=white>'.class lsp [Class]'</color> (spells), and <color=white>'.class lst [Class]'</color> (synergies). (toggle reminders with <color=white>'.misc remindme'</color>)");
+                LocalizationService.Reply(EntityManager, user,
+                    "Don't forget to choose a class! Use <color=white>'.class l'</color> to view choices and see what they have to offer with <color=white>'.class lb [Class]'</color> (buffs), <color=white>'.class lsp [Class]'</color> (spells), and <color=white>'.class lst [Class]'</color> (synergies). (toggle reminders with <color=white>'.misc remindme'</color>)");
             }
         }
 
         if (GetPlayerBool(steamId, EXPERIENCE_LOG_KEY))
         {
             int levelProgress = GetLevelProgress(steamId);
-            string message = restedXP > 0
-                ? $"+<color=yellow>{gainedIntXP}</color> <color=green>rested</color> <color=#FFC0CB>experience</color> (<color=white>{levelProgress}%</color>)"
-                : $"+<color=yellow>{gainedIntXP}</color> <color=#FFC0CB>experience</color> (<color=white>{levelProgress}%</color>)";
-
-            LocalizationService.HandleServerReply(EntityManager, user, message);
+            if (restedXP > 0)
+            {
+                LocalizationService.Reply(EntityManager, user,
+                    "+<color=yellow>{0}</color> <color=green>rested</color> <color=#FFC0CB>experience</color> (<color=white>{1}%</color>)",
+                    gainedIntXP, levelProgress);
+            }
+            else
+            {
+                LocalizationService.Reply(EntityManager, user,
+                    "+<color=yellow>{0}</color> <color=#FFC0CB>experience</color> (<color=white>{1}%</color>)",
+                    gainedIntXP, levelProgress);
+            }
         }
 
         if (GetPlayerBool(steamId, SCT_PLAYER_LVL_KEY))

--- a/Systems/Leveling/PrestigeManager.cs
+++ b/Systems/Leveling/PrestigeManager.cs
@@ -556,7 +556,7 @@ internal static class PrestigeManager
         float gainMultiplier = ConfigService.PrestigeRateMultiplier * level;
 
         string gainPercentage = (gainMultiplier * 100).ToString("F2") + "%";
-        LocalizationService.HandleServerReply(EntityManager, user, $"Player <color=green>{user.CharacterName.Value}</color> has prestiged in <color=#90EE90>Experience</color>[<color=white>{level}</color>]! Growth rates for expertise/legacies increased by <color=green>{gainPercentage}</color>, experience from unit kills reduced by <color=red>{reductionPercentage}</color>.");
+        LocalizationService.Reply(EntityManager, user, "Player <color=green>{0}</color> has prestiged in <color=#90EE90>Experience</color>[<color=white>{1}</color>]! Growth rates for expertise/legacies increased by <color=green>{2}</color>, experience from unit kills reduced by <color=red>{3}</color>.", user.CharacterName.Value, level, gainPercentage, reductionPercentage);
     }
     public static void ReplyOtherPrestigeEffects(User user, ulong playerId, PrestigeType parsedPrestigeType, int level)
     {
@@ -573,7 +573,7 @@ internal static class PrestigeManager
         string statGainString = (statGainIncrease * 100).ToString("F2") + "%";
 
         string totalEffectString = (combinedFactor * 100).ToString("F2") + "%";
-        LocalizationService.HandleServerReply(EntityManager, user, $"Player <color=green>{user.CharacterName.Value}</color> has prestiged in <color=#90EE90>{parsedPrestigeType}</color>[<color=white>{level}</color>]! Growth rate reduced by <color=yellow>{percentageReductionString}</color> and stat bonuses improved by <color=green>{statGainString}</color>. The total change in growth rate with leveling prestige bonus is <color=yellow>{totalEffectString}</color>.");
+        LocalizationService.Reply(EntityManager, user, "Player <color=green>{0}</color> has prestiged in <color=#90EE90>{1}</color>[<color=white>{2}</color>]! Growth rate reduced by <color=yellow>{3}</color> and stat bonuses improved by <color=green>{4}</color>. The total change in growth rate with leveling prestige bonus is <color=yellow>{5}</color>.", user.CharacterName.Value, parsedPrestigeType, level, percentageReductionString, statGainString, totalEffectString);
     }
     public static bool TryParsePrestigeType(string prestigeType, out PrestigeType parsedPrestigeType)
     {

--- a/Systems/Professions/ProfessionSystem.cs
+++ b/Systems/Professions/ProfessionSystem.cs
@@ -330,13 +330,13 @@ internal static class ProfessionSystem
         if (leveledUp)
         {
             int newLevel = ConvertXpToLevel(handler.GetProfessionData(steamID).Value);
-            if (newLevel < MAX_PROFESSION_LEVEL) LocalizationService.HandleServerReply(EntityManager, user, $"{professionName} improved to [<color=white>{newLevel}</color>]");
+            if (newLevel < MAX_PROFESSION_LEVEL) LocalizationService.Reply(EntityManager, user, "{0} improved to [<color=white>{1}</color>]", professionName, newLevel);
         }
 
         if (GetPlayerBool(steamID, PROFESSION_LOG_KEY))
         {
             int levelProgress = GetLevelProgress(steamID, handler);
-            LocalizationService.HandleServerReply(EntityManager, user, $"+<color=yellow>{(int)gainedXP}</color> <color=#FFC0CB>proficiency</color> in {professionName.ToLower()} (<color=white>{levelProgress}%</color>)");
+            LocalizationService.Reply(EntityManager, user, "+<color=yellow>{0}</color> <color=#FFC0CB>proficiency</color> in {1} (<color=white>{2}%</color>)", (int)gainedXP, professionName.ToLower(), levelProgress);
         }
 
         if (GetPlayerBool(steamID, SCT_PROFESSIONS_KEY))
@@ -388,7 +388,7 @@ internal static class ProfessionSystem
     }
     static void HandleExperienceAndBonusYield(User user, Entity userEntity, Entity playerCharacter, Entity target, PrefabGUID resource, string professionName, float bonusYield, bool professionLogging, bool sctYield, ref float delay)
     {
-        if (professionLogging) LocalizationService.HandleServerReply(EntityManager, user, $"<color=green>{resource.GetLocalizedName()}</color>x<color=white>{bonusYield}</color> received from {professionName}");
+        if (professionLogging) LocalizationService.Reply(EntityManager, user, "<color=green>{0}</color>x<color=white>{1}</color> received from {2}", resource.GetLocalizedName(), bonusYield, professionName);
         if (sctYield) HandleBonusYieldScrollingText(target, _bonusYieldSCT, _bonusYieldAssetGuid, playerCharacter, userEntity, _bonusYieldColor, bonusYield, ref delay);
     }
     static int GoldOreRoll(int level)
@@ -415,13 +415,13 @@ internal static class ProfessionSystem
     {
         if (ServerGameManager.TryAddInventoryItem(playerCharacter, _goldOre, goldOre))
         {
-            if (professionLogging) LocalizationService.HandleServerReply(EntityManager, user, $"<color=green>Gold Ore</color>x<color=white>{goldOre}</color> received from {professionName}");
+            if (professionLogging) LocalizationService.Reply(EntityManager, user, "<color=green>Gold Ore</color>x<color=white>{0}</color> received from {1}", goldOre, professionName);
             if (sctYield) HandleBonusYieldScrollingText(target, _bonusYieldSCT, _bonusYieldAssetGuid, playerCharacter, userEntity, _goldOreColor, goldOre, ref delay);
         }
         else
         {
             InventoryUtilitiesServer.CreateDropItem(EntityManager, playerCharacter, _goldOre, goldOre, new Entity());
-            if (professionLogging) LocalizationService.HandleServerReply(EntityManager, user, $"<color=green>Gold Ore</color>x<color=white>{goldOre}</color> received from {professionName}, but it dropped on the ground since your inventory is full.");
+            if (professionLogging) LocalizationService.Reply(EntityManager, user, "<color=green>Gold Ore</color>x<color=white>{0}</color> received from {1}, but it dropped on the ground since your inventory is full.", goldOre, professionName);
             if (sctYield) HandleBonusYieldScrollingText(target, _bonusYieldSCT, _bonusYieldAssetGuid, playerCharacter, userEntity, _goldOreColor, goldOre, ref delay);
         }
     }
@@ -449,14 +449,14 @@ internal static class ProfessionSystem
     {
         if (ServerGameManager.TryAddInventoryItem(playerCharacter, _radiantFibre, amount))
         {
-            if (professionLogging) LocalizationService.HandleServerReply(EntityManager, user, $"<color=green>Gold Ore</color>x<color=white>{amount}</color> received from {professionName}");
+            if (professionLogging) LocalizationService.Reply(EntityManager, user, "<color=green>Gold Ore</color>x<color=white>{0}</color> received from {1}", amount, professionName);
             if (sctYield) HandleBonusYieldScrollingText(target, _bonusYieldSCT, _bonusYieldAssetGuid, playerCharacter, userEntity, _radiantFiberColor, amount, ref delay);
         }
         else
         {
             InventoryUtilitiesServer.CreateDropItem(EntityManager, playerCharacter, _radiantFibre, amount, new Entity());
 
-            if (professionLogging) LocalizationService.HandleServerReply(EntityManager, user, $"<color=green>Gold Ore</color>x<color=white>{amount}</color> received from {professionName}, but it dropped on the ground since your inventory is full.");
+            if (professionLogging) LocalizationService.Reply(EntityManager, user, "<color=green>Gold Ore</color>x<color=white>{0}</color> received from {1}, but it dropped on the ground since your inventory is full.", amount, professionName);
             if (sctYield) HandleBonusYieldScrollingText(target, _bonusYieldSCT, _bonusYieldAssetGuid, playerCharacter, userEntity, _radiantFiberColor, amount, ref delay);
         }
     }
@@ -510,11 +510,11 @@ internal static class ProfessionSystem
             {
                 if (!fellOnGround)
                 {
-                    LocalizationService.HandleServerReply(EntityManager, user, $"<color=green>Bonus Seed(s)</color>x<color=white>{quantity}</color> received from {professionName}!");
+                    LocalizationService.Reply(EntityManager, user, "<color=green>Bonus Seed(s)</color>x<color=white>{0}</color> received from {1}!", quantity, professionName);
                 }
                 else
                 {
-                    LocalizationService.HandleServerReply(EntityManager, user, $"<color=green>Bonus Seed(s)</color>x<color=white>{quantity}</color> received from {professionName}, but some fell on the ground since your inventory is full.");
+                    LocalizationService.Reply(EntityManager, user, "<color=green>Bonus Seed(s)</color>x<color=white>{0}</color> received from {1}, but some fell on the ground since your inventory is full.", quantity, professionName);
                 }
             }
 
@@ -573,11 +573,11 @@ internal static class ProfessionSystem
             {
                 if (!fellOnGround)
                 {
-                    LocalizationService.HandleServerReply(EntityManager, user, $"<color=green>Bonus Saplings(s)</color>x<color=white>{quantity}</color> received from {professionName}!");
+                    LocalizationService.Reply(EntityManager, user, "<color=green>Bonus Saplings(s)</color>x<color=white>{0}</color> received from {1}!", quantity, professionName);
                 }
                 else
                 {
-                    LocalizationService.HandleServerReply(EntityManager, user, $"<color=green>Bonus Saplings(s)</color>x<color=white>{quantity}</color> received from {professionName}, but some fell on the ground since your inventory is full.");
+                    LocalizationService.Reply(EntityManager, user, "<color=green>Bonus Saplings(s)</color>x<color=white>{0}</color> received from {1}, but some fell on the ground since your inventory is full.", quantity, professionName);
                 }
             }
 
@@ -591,7 +591,7 @@ internal static class ProfessionSystem
     {
         if (ServerGameManager.TryAddInventoryItem(playerCharacter, _mutantGrease, mutantGrease))
         {
-            if (professionLogging) LocalizationService.HandleServerReply(EntityManager, user, $"<color=green>Mutant Grease</color>x<color=white>{mutantGrease}</color> received from {professionName}");
+            if (professionLogging) LocalizationService.Reply(EntityManager, user, "<color=green>Mutant Grease</color>x<color=white>{0}</color> received from {1}", mutantGrease, professionName);
 
             if (sctYield) HandleBonusYieldScrollingText(target, _bonusYieldSCT, _bonusYieldAssetGuid, playerCharacter, userEntity, _mutantGreaseColor, mutantGrease, ref delay);
         }
@@ -599,7 +599,7 @@ internal static class ProfessionSystem
         {
             InventoryUtilitiesServer.CreateDropItem(EntityManager, playerCharacter, _mutantGrease, mutantGrease, new Entity());
 
-            if (professionLogging) LocalizationService.HandleServerReply(EntityManager, user, $"<color=green>Mutant Grease</color>x<color=white>{mutantGrease}</color> received from {professionName}, but it dropped on the ground since your inventory is full.");
+            if (professionLogging) LocalizationService.Reply(EntityManager, user, "<color=green>Mutant Grease</color>x<color=white>{0}</color> received from {1}, but it dropped on the ground since your inventory is full.", mutantGrease, professionName);
             if (sctYield) HandleBonusYieldScrollingText(target, _bonusYieldSCT, _bonusYieldAssetGuid, playerCharacter, userEntity, _mutantGreaseColor, mutantGrease, ref delay);
         }
     }

--- a/Systems/Quests/QuestSystem.cs
+++ b/Systems/Quests/QuestSystem.cs
@@ -455,13 +455,13 @@ internal static class QuestSystem
                     targets = [..GetGoalPrefabsForLevelEnumerable(goal, level)];
 
                     questData[QuestType.Daily] = (GenerateQuestObjective(goal, targets, QuestType.Daily), 0, now);
-                    LocalizationService.HandleServerReply(EntityManager, user, "Your <color=#00FFFF>Daily Quest</color> has been refreshed!");
+                    LocalizationService.Reply(EntityManager, user, "Your <color=#00FFFF>Daily Quest</color> has been refreshed!");
 
                     goal = targetTypes.Last();
                     targets = [..GetGoalPrefabsForLevelEnumerable(goal, level)];
 
                     questData[QuestType.Weekly] = (GenerateQuestObjective(goal, targets, QuestType.Weekly), 0, now);
-                    LocalizationService.HandleServerReply(EntityManager, user, "Your <color=#BF40BF>Weekly Quest</color> has been refreshed!");
+                    LocalizationService.Reply(EntityManager, user, "Your <color=#BF40BF>Weekly Quest</color> has been refreshed!");
                 }
                 else if (refreshDaily)
                 {
@@ -469,7 +469,7 @@ internal static class QuestSystem
                     targets = [..GetGoalPrefabsForLevelEnumerable(goal, level)];
 
                     questData[QuestType.Daily] = (GenerateQuestObjective(goal, targets, QuestType.Daily), 0, now);
-                    LocalizationService.HandleServerReply(EntityManager, user, "Your <color=#00FFFF>Daily Quest</color> has been refreshed!");
+                    LocalizationService.Reply(EntityManager, user, "Your <color=#00FFFF>Daily Quest</color> has been refreshed!");
                 }
                 else if (refreshWeekly)
                 {
@@ -477,7 +477,7 @@ internal static class QuestSystem
                     targets = [..GetGoalPrefabsForLevelEnumerable(goal, level)];
 
                     questData[QuestType.Weekly] = (GenerateQuestObjective(goal, targets, QuestType.Weekly), 0, now);
-                    LocalizationService.HandleServerReply(EntityManager, user, "Your <color=#BF40BF>Weekly Quest</color> has been refreshed!");
+                    LocalizationService.Reply(EntityManager, user, "Your <color=#BF40BF>Weekly Quest</color> has been refreshed!");
                 }
 
                 steamId.SetPlayerQuests(questData);
@@ -625,7 +625,7 @@ internal static class QuestSystem
                         questData[QuestType.Daily] = (GenerateQuestObjective(goal, targets, QuestType.Daily), 0, DateTime.UtcNow);
 
                         var dailyQuest = questData[QuestType.Daily];
-                        LocalizationService.HandleServerReply(EntityManager, user, $"New <color=#00FFFF>Daily Quest</color> available: <color=green>{dailyQuest.Objective.Goal}</color> <color=white>{dailyQuest.Objective.Target.GetLocalizedName()}</color>x<color=#FFC0CB>{dailyQuest.Objective.RequiredAmount}</color> [<color=white>{dailyQuest.Progress}</color>/<color=yellow>{dailyQuest.Objective.RequiredAmount}</color>]");
+                        LocalizationService.Reply(EntityManager, user, "New <color=#00FFFF>Daily Quest</color> available: <color=green>{0}</color> <color=white>{1}</color>x<color=#FFC0CB>{2}</color> [<color=white>{3}</color>/<color=yellow>{2}</color>]", dailyQuest.Objective.Goal, dailyQuest.Objective.Target.GetLocalizedName(), dailyQuest.Objective.RequiredAmount, dailyQuest.Progress);
                     }
                 }
             }
@@ -657,14 +657,12 @@ internal static class QuestSystem
 
         if (ServerGameManager.TryAddInventoryItem(user.LocalCharacter._Entity, reward, quantity))
         {
-            string message = $"You've received <color=#ffd9eb>{reward.GetLocalizedName()}</color>x<color=white>{quantity}</color> for completing your {colorType}!";
-            LocalizationService.HandleServerReply(EntityManager, user, message);
+            LocalizationService.Reply(EntityManager, user, "You've received <color=#ffd9eb>{0}</color>x<color=white>{1}</color> for completing your {2}!", reward.GetLocalizedName(), quantity, colorType);
         }
         else
         {
             InventoryUtilitiesServer.CreateDropItem(EntityManager, user.LocalCharacter._Entity, reward, quantity, new Entity());
-            string message = $"You've received <color=#ffd9eb>{reward.GetLocalizedName()}</color>x<color=white>{quantity}</color> for completing your {colorType}! It dropped on the ground because your inventory was full.";
-            LocalizationService.HandleServerReply(EntityManager, user, message);
+            LocalizationService.Reply(EntityManager, user, "You've received <color=#ffd9eb>{0}</color>x<color=white>{1}</color> for completing your {2}! It dropped on the ground because your inventory was full.", reward.GetLocalizedName(), quantity, colorType);
         }
     }
     static void HandleExperienceReward(User user, QuestType questType)
@@ -677,8 +675,7 @@ internal static class QuestSystem
             float xpPercentage = XP_PERCENTAGE * _questMultipliers[questType] * 100;
             if (progressType.Contains("expertise") && progressType.Contains("essence")) xpPercentage *= 0.5f;
 
-            string xpMessage = $"You've been awarded <color=yellow>{xpPercentage:F1}%</color> of your total {progressType}!";
-            LocalizationService.HandleServerReply(EntityManager, user, xpMessage);
+            LocalizationService.Reply(EntityManager, user, "You've been awarded <color=yellow>{0:F1}%</color> of your total {1}!", xpPercentage, progressType);
         }
     }
     static string ProcessQuestExperienceGain(User user, int multiplier, float percentOfTotalXP)
@@ -880,11 +877,7 @@ internal static class QuestSystem
 
         if (GetPlayerBool(steamId, QUEST_LOG_KEY) && !quest.Value.Objective.Complete)
         {
-            string message = $"Progress added to {colorType}: <color=green>{quest.Value.Objective.Goal}</color> " +
-                             $"<color=white>{quest.Value.Objective.Target.GetLocalizedName()}</color> " +
-                             $"[<color=white>{questData[quest.Key].Progress}</color>/<color=yellow>{quest.Value.Objective.RequiredAmount}</color>]";
-
-            LocalizationService.HandleServerReply(EntityManager, user, message);
+            LocalizationService.Reply(EntityManager, user, "Progress added to {0}: <color=green>{1}</color> <color=white>{2}</color> [<color=white>{3}</color>/<color=yellow>{4}</color>]", colorType, quest.Value.Objective.Goal, quest.Value.Objective.Target.GetLocalizedName(), questData[quest.Key].Progress, quest.Value.Objective.RequiredAmount);
         }
 
         _delayedQuestMessages[steamId].Remove(quest.Key);

--- a/Utilities/Familiars.cs
+++ b/Utilities/Familiars.cs
@@ -503,14 +503,13 @@ internal static class Familiars
 
         UpdateActiveFamiliarDismissed(steamId, false);
 
-        string message = "<color=yellow>Familiar</color> <color=green>enabled</color>!";
-        LocalizationService.HandleServerReply(EntityManager, user, message);
+        LocalizationService.Reply(EntityManager, user, "<color=yellow>Familiar</color> <color=green>enabled</color>!");
     }
     public static void DismissFamiliar(Entity playerCharacter, Entity familiar, User user, ulong steamId)
     {
         if (familiar.HasBuff(_vanishBuff))
         {
-            LocalizationService.HandleServerReply(EntityManager, user, "Can't dismiss familiar when binding/unbinding!");
+            LocalizationService.Reply(EntityManager, user, "Can't dismiss familiar when binding/unbinding!");
             return;
         }
 
@@ -536,8 +535,7 @@ internal static class Familiars
 
         UpdateActiveFamiliarDismissed(steamId, true);
 
-        string message = "<color=yellow>Familiar</color> <color=red>disabled</color>!";
-        LocalizationService.HandleServerReply(EntityManager, user, message);
+        LocalizationService.Reply(EntityManager, user, "<color=yellow>Familiar</color> <color=red>disabled</color>!");
     }
     public static string GetShinyInfo(FamiliarBuffsData buffsData, Entity familiar, int familiarId)
     {
@@ -624,12 +622,12 @@ internal static class Familiars
 
         if (hasActive)
         {
-            LocalizationService.HandleServerReply(EntityManager, user, "You already have an active familiar! Unbind that one first.");
+            LocalizationService.Reply(EntityManager, user, "You already have an active familiar! Unbind that one first.");
             return;
         }
         else if (playerCharacter.HasBuff(_pveCombatBuff) || playerCharacter.HasBuff(_dominateBuff) || playerCharacter.HasBuff(_takeFlightBuff) || playerCharacter.HasBuff(_pvpCombatBuff))
         {
-            LocalizationService.HandleServerReply(EntityManager, user, "You can't bind in combat or when using certain forms! (dominating presence, bat)");
+            LocalizationService.Reply(EntityManager, user, "You can't bind in combat or when using certain forms! (dominating presence, bat)");
             return;
         }
 
@@ -637,7 +635,7 @@ internal static class Familiars
 
         if (string.IsNullOrEmpty(box))
         {
-            LocalizationService.HandleServerReply(EntityManager, user, "Couldn't find active box! Use '<color=white>.fam listboxes</color>' and select one with '<color=white>.fam cb [BoxName]</color>");
+            LocalizationService.Reply(EntityManager, user, "Couldn't find active box! Use '<color=white>.fam listboxes</color>' and select one with '<color=white>.fam cb [BoxName]</color>");
             return;
         }
         else if (!hasActive && LoadFamiliarUnlocksData(steamId).FamiliarUnlocks.TryGetValue(box, out var famKeys))
@@ -646,7 +644,7 @@ internal static class Familiars
             {
                 if (boxIndex < 1 || boxIndex > famKeys.Count)
                 {
-                    LocalizationService.HandleServerReply(EntityManager, user, $"Invalid index for active box, try binding or smartbind via command.");
+                    LocalizationService.Reply(EntityManager, user, "Invalid index for active box, try binding or smartbind via command.");
                     return;
                 }
 
@@ -654,11 +652,11 @@ internal static class Familiars
             }
             else if (boxIndex == -1)
             {
-                LocalizationService.HandleServerReply(EntityManager, user, $"Couldn't find binding preset, try binding or smartbind via command.");
+                LocalizationService.Reply(EntityManager, user, "Couldn't find binding preset, try binding or smartbind via command.");
             }
             else if (boxIndex < 1 || boxIndex > famKeys.Count)
             {
-                LocalizationService.HandleServerReply(EntityManager, user, $"Invalid index, use <color=white>1</color>-<color=white>{famKeys.Count}</color>! (Active Box - <color=yellow>{box}</color>)");
+                LocalizationService.Reply(EntityManager, user, "Invalid index, use <color=white>1</color>-<color=white>{0}</color>! (Active Box - <color=yellow>{1}</color>)", famKeys.Count, box);
             }
             else
             {
@@ -668,7 +666,7 @@ internal static class Familiars
         }
         else
         {
-            LocalizationService.HandleServerReply(EntityManager, user, "Couldn't find familiar actives or familiar already active! If this doesn't seem right try using '<color=white>.fam reset</color>'.");
+            LocalizationService.Reply(EntityManager, user, "Couldn't find familiar actives or familiar already active! If this doesn't seem right try using '<color=white>.fam reset</color>'.");
         }
     }
     public static void UnbindFamiliar(User user, Entity playerCharacter, bool smartBind = false, int index = -1)
@@ -684,7 +682,7 @@ internal static class Familiars
 
             if (familiar.HasBuff(_interactModeBuff))
             {
-                LocalizationService.HandleServerReply(EntityManager, user, "Can't unbind familiar right now! (interacting)");
+                LocalizationService.Reply(EntityManager, user, "Can't unbind familiar right now! (interacting)");
                 return;
             }
 
@@ -696,11 +694,11 @@ internal static class Familiars
         }
         else if (isDismissed)
         {
-            LocalizationService.HandleServerReply(EntityManager, user, "Can't unbind familiar right now! (dismissed)");
+            LocalizationService.Reply(EntityManager, user, "Can't unbind familiar right now! (dismissed)");
         }
         else
         {
-            LocalizationService.HandleServerReply(EntityManager, user, "Couldn't find familiar to unbind! If this doesn't seem right try using '<color=white>.fam reset</color>'.");
+            LocalizationService.Reply(EntityManager, user, "Couldn't find familiar to unbind! If this doesn't seem right try using '<color=white>.fam reset</color>'.");
         }
     }
     static IEnumerator UnbindFamiliarDelayRoutine(User user, Entity playerCharacter, Entity familiar,
@@ -737,8 +735,14 @@ internal static class Familiars
         familiar.Destroy();
         ResetActiveFamiliarData(steamId);
 
-        string message = !string.IsNullOrEmpty(shinyHexColor) ? $"<color=green>{prefabGuid.GetLocalizedName()}</color>{shinyHexColor}*</color> <color=#FFC0CB>unbound</color>!" : $"<color=green>{prefabGuid.GetLocalizedName()}</color> <color=#FFC0CB>unbound</color>!";
-        LocalizationService.HandleServerReply(EntityManager, user, message);
+        if (!string.IsNullOrEmpty(shinyHexColor))
+        {
+            LocalizationService.Reply(EntityManager, user, "<color=green>{0}</color>{1}*</color> <color=#FFC0CB>unbound</color>!", prefabGuid.GetLocalizedName(), shinyHexColor);
+        }
+        else
+        {
+            LocalizationService.Reply(EntityManager, user, "<color=green>{0}</color> <color=#FFC0CB>unbound</color>!", prefabGuid.GetLocalizedName());
+        }
 
         if (smartBind)
         {

--- a/Utilities/Misc.cs
+++ b/Utilities/Misc.cs
@@ -509,14 +509,12 @@ internal static class Misc
 
         if (hasSpace && ServerGameManager.TryAddInventoryItem(playerCharacter, itemType, amount))
         {
-            string message = "Your bag feels slightly heavier...";
-            LocalizationService.HandleServerReply(EntityManager, user, message);
+            LocalizationService.Reply(EntityManager, user, "Your bag feels slightly heavier...");
         }
         else
         {
-            string message = "Something fell out of your bag!";
             InventoryUtilitiesServer.CreateDropItem(EntityManager, playerCharacter, itemType, amount, new Entity()); // does this create multiple drops to account for excessive stacks? noting for later
-            LocalizationService.HandleServerReply(EntityManager, user, message);
+            LocalizationService.Reply(EntityManager, user, "Something fell out of your bag!");
         }
     }
     public static bool RollForChance(float chance)

--- a/Utilities/Shapeshifts.cs
+++ b/Utilities/Shapeshifts.cs
@@ -112,7 +112,7 @@ internal static class Shapeshifts
     {
         string timeRemaining = GetTimeUntilCharged(steamId, value);
 
-        if (!string.IsNullOrEmpty(timeRemaining)) LocalizationService.HandleServerReply(EntityManager, user, $"Not enough energy to maintain form... (<color=yellow>{timeRemaining}</color>)");
+        if (!string.IsNullOrEmpty(timeRemaining)) LocalizationService.Reply(EntityManager, user, "Not enough energy to maintain form... (<color=yellow>{0}</color>)", timeRemaining);
     }
     static string GetTimeUntilCharged(ulong steamId, float value)
     {


### PR DESCRIPTION
## Summary
- route server replies through hash-based localization
- update player-facing messages to use new localization overload

## Testing
- `dotnet test Bloodcraft.Tests/Bloodcraft.Tests.csproj` *(fails: You must install or update .NET to run this application. Missing Microsoft.NETCore.App 6.0 runtime)*

------
https://chatgpt.com/codex/tasks/task_e_6898eaafca38832d84831f284f5810b7