### PR TITLE
docs: add localization contributor guide

### DIFF
--- a/Docs/Localization.md
+++ b/Docs/Localization.md
@@ -1,0 +1,26 @@
+# Localization Contributor Guide
+
+Bloodcraft uses hash-based localization. Follow these steps when adding or editing messages.
+
+## Replace interpolated strings
+
+Instead of C# string interpolation, use `LocalizationService.Reply` with numbered placeholders:
+
+```csharp
+LocalizationService.Reply(ctx, "You're level {0}", level);
+```
+
+## Update language JSONs
+
+When you add or change a message, update every JSON file under `Resources/Localization/Messages` to include the same numbered placeholders `{0}`, `{1}`, etc. so translations match the English template.
+
+## Verify translation hashes
+
+After updating the files, run:
+
+```bash
+dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations
+```
+
+The command should report no hash changes, confirming placeholders are aligned across languages.
+

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - [Configuration](#configuration)
 - [Recommended Mods](#recommended-mods)
 - [Development Setup](#development-setup)
+- [Localization Guide](Docs/Localization.md)
 - [Codex Workflow](#codex-workflow)
 - [Workflow Source](#workflow-source)
 - [Credits](#credits)
@@ -786,6 +787,8 @@ Run `.codex/install.sh` once to install the .NET SDK and Argos Translate. The sc
 `~/.local/bin` to your `PATH` so the `argos-translate` CLI is available in future sessions.
 
 ## Localization (WIP)
+
+For guidelines on adding or updating messages, see [Localization Contributor Guide](Docs/Localization.md).
 
 Messages shown by the plugin are stored under `Resources/Localization/Messages`.
 To update `English.json` with the latest hashes run:


### PR DESCRIPTION
## Summary
- document localization workflow including placeholder usage and hash checks
- link localization guide from README for easy discovery

## Testing
- `~/.dotnet/dotnet test`
- `~/.dotnet/dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations` *(fails: The build failed. Fix the build errors and run again.)*

------
https://chatgpt.com/codex/tasks/task_e_6898fe028338832da2210a01def25c6c