### PR TITLE
Use localization keys for bag messages

### DIFF
--- a/Resources/Localization/Messages/Brazilian.json
+++ b/Resources/Localization/Messages/Brazilian.json
@@ -313,7 +313,9 @@
     "1095669519": "O registro de nível {(GetPlayerBool(SteamID, EXPERIENCE_LOG_KEY) ? \"<color=green>ativado</color>\" : \"<color=red>desativado</color>\")}.",
     "3112026815": "O registro de profissão agora está {(GetPlayerBool(steamId, PROFESSION_LOG_KEY) ? \"<color=green>ativado</color>\" : \"<color=red>desativado</color>\")}.",
     "542066310": "O registro de Legado de Sangue {(GetPlayerBool(steamId, BLOOD_LOG_KEY) ? \"<color=green>ativado</color>\" : \"<color=red>desativado</color>\")}.",
-    "881612152": "Ação de emote da forma Exo (<color=white>provocar</color>) {(GetPlayerBool(steamId, SHAPESHIFT_KEY) ? \"<color=green>ativada</color>\" : \"<color=red>desativada</color>\")}"
+    "881612152": "Ação de emote da forma Exo (<color=white>provocar</color>) {(GetPlayerBool(steamId, SHAPESHIFT_KEY) ? \"<color=green>ativada</color>\" : \"<color=red>desativada</color>\")}",
+    "1669157395": "Sua bolsa está um pouco mais pesada...",
+    "2346236465": "Algo caiu da sua bolsa!"
   },
   "_meta": {
     "1716911803": "Intencionalmente idêntico ao inglês; placeholder dinâmico"

--- a/Resources/Localization/Messages/English.json
+++ b/Resources/Localization/Messages/English.json
@@ -313,6 +313,8 @@
     "3112026815": "Profession logging is now {(GetPlayerBool(steamId, PROFESSION_LOG_KEY) ? \u0022\u003Ccolor=green\u003Eenabled\u003C/color\u003E\u0022 : \u0022\u003Ccolor=red\u003Edisabled\u003C/color\u003E\u0022)}.",
     "542066310": "Blood Legacy logging {(GetPlayerBool(steamId, BLOOD_LOG_KEY) ? \u0022\u003Ccolor=green\u003Eenabled\u003C/color\u003E\u0022 : \u0022\u003Ccolor=red\u003Edisabled\u003C/color\u003E\u0022)}.",
     "881612152": "Exo form emote action (\u003Ccolor=white\u003Etaunt\u003C/color\u003E) {(GetPlayerBool(steamId, SHAPESHIFT_KEY) ? \u0022\u003Ccolor=green\u003Eenabled\u003C/color\u003E\u0022 : \u0022\u003Ccolor=red\u003Edisabled\u003C/color\u003E\u0022)}",
-    "2978826451": "\u003Ccolor=green\u003E{famName}\u003C/color\u003E{(buffsData.FamiliarBuffs.ContainsKey(familiarId) ? \u0022{colorCode}*\u003C/color\u003E\u0022 : \u0022\u0022)} [\u003Ccolor=white\u003E{level}\u003C/color\u003E][\u003Ccolor=#90EE90\u003E{prestiges}\u003C/color\u003E] added to \u003Ccolor=white\u003E{groupName}\u003C/color\u003E! (\u003Ccolor=yellow\u003E{slotIndex}\u003C/color\u003E)"
+    "2978826451": "\u003Ccolor=green\u003E{famName}\u003C/color\u003E{(buffsData.FamiliarBuffs.ContainsKey(familiarId) ? \u0022{colorCode}*\u003C/color\u003E\u0022 : \u0022\u0022)} [\u003Ccolor=white\u003E{level}\u003C/color\u003E][\u003Ccolor=#90EE90\u003E{prestiges}\u003C/color\u003E] added to \u003Ccolor=white\u003E{groupName}\u003C/color\u003E! (\u003Ccolor=yellow\u003E{slotIndex}\u003C/color\u003E)",
+    "1669157395": "Your bag feels slightly heavier...",
+    "2346236465": "Something fell out of your bag!"
   }
 }

--- a/Resources/Localization/Messages/French.json
+++ b/Resources/Localization/Messages/French.json
@@ -313,7 +313,9 @@
     "508045935": "Actions d'émote {(GetPlayerBool(steamId, EMOTE_ACTIONS_KEY) ? \"<color=green>activées</color>\" : \"<color=red>désactivées</color>\")}!",
     "52573990": "L'enregistrement de l'expertise est maintenant {(GetPlayerBool(steamId, WEAPON_LOG_KEY) ? \"<color=green>activé</color>\" : \"<color=red>désactivé</color>\")}.",
     "542066310": "L'enregistrement de l'héritage du sang {(GetPlayerBool(steamId, BLOOD_LOG_KEY) ? \"<color=green>activé</color>\" : \"<color=red>désactivé</color>\")}.",
-    "881612152": "Action d'émote de l'exoforme (<color=white>taunt</color>) {(GetPlayerBool(steamId, SHAPESHIFT_KEY) ? \"<color=green>activée</color>\" : \"<color=red>désactivée</color>\")}"
+    "881612152": "Action d'émote de l'exoforme (<color=white>taunt</color>) {(GetPlayerBool(steamId, SHAPESHIFT_KEY) ? \"<color=green>activée</color>\" : \"<color=red>désactivée</color>\")}",
+    "1669157395": "Votre sac paraît légèrement plus lourd...",
+    "2346236465": "Quelque chose est tombé de votre sac !"
   },
   "_meta": {
     "2316405313": "Identique à l'anglais intentionnellement ; espace réservé dynamique",

--- a/Resources/Localization/Messages/German.json
+++ b/Resources/Localization/Messages/German.json
@@ -313,7 +313,9 @@
     "3706417587": "Ungültiger Quest-Typ '{questTypeName}'. Gültige Werte sind: {string.Join(\", \", Enum.GetNames(typeof(QuestType)))}",
     "3112026815": "Berufs-Protokollierung ist nun {(GetPlayerBool(steamId, PROFESSION_LOG_KEY) ? \"<color=green>aktiviert</color>\" : \"<color=red>deaktiviert</color>\")}.",
     "542066310": "Blut-Vermächtnis-Protokollierung {(GetPlayerBool(steamId, BLOOD_LOG_KEY) ? \"<color=green>aktiviert</color>\" : \"<color=red>deaktiviert</color>\")}.",
-    "881612152": "Exo-Form-Emote-Aktion (<color=white>Spott</color>) {(GetPlayerBool(steamId, SHAPESHIFT_KEY) ? \"<color=green>aktiviert</color>\" : \"<color=red>deaktiviert</color>\")}"
+    "881612152": "Exo-Form-Emote-Aktion (<color=white>Spott</color>) {(GetPlayerBool(steamId, SHAPESHIFT_KEY) ? \"<color=green>aktiviert</color>\" : \"<color=red>deaktiviert</color>\")}",
+    "1669157395": "Deine Tasche fühlt sich etwas schwerer an...",
+    "2346236465": "Etwas ist aus deiner Tasche gefallen!"
   },
   "_meta": {
     "1716911803": "Absichtlich identisch mit Englisch; dynamischer Platzhalter"

--- a/Resources/Localization/Messages/Hungarian.json
+++ b/Resources/Localization/Messages/Hungarian.json
@@ -313,6 +313,8 @@
     "3112026815": "A munkavégzési naplózás {(GetPlayerBool(steamId, PROFESSION_LOG_KEY) ? \"<color=green>enabled</color>\" : \"<color=red>disabled</color>\")}.",
     "542066310": "Vérörökségi naplózás {(GetPlayerBool(steamId, BLOOD_LOG_KEY) ? \"<color=green>enabled</color>\" : \"<color=red>disabled</color>\")}.",
     "881612152": "Exo formában emote action (<color=white> taunt </color>) {(GetPlayerBool(steamId, SHAPESHIFT_KEY) ? \"<color=green>enabled</color>\" : \"<color=red>disabled</color>\")}",
-    "2978826451": "<color=green>{famName}</color>{(buffsData.FamiliarBuffs.ContainsKey(familiarId) ? '{colorCode}*</color>' : '')} [<color=white>{level}</color>][<color=#90EE90>{prestiges}</color>] hozzáadva <color=white>{groupName}</color>-hoz! (<color=yellow>{slotIndex}</color>)"
+    "2978826451": "<color=green>{famName}</color>{(buffsData.FamiliarBuffs.ContainsKey(familiarId) ? '{colorCode}*</color>' : '')} [<color=white>{level}</color>][<color=#90EE90>{prestiges}</color>] hozzáadva <color=white>{groupName}</color>-hoz! (<color=yellow>{slotIndex}</color>)",
+    "1669157395": "A táskád kissé nehezebbnek tűnik...",
+    "2346236465": "Valami kiesett a táskádból!"
   }
 }

--- a/Resources/Localization/Messages/Italian.json
+++ b/Resources/Localization/Messages/Italian.json
@@ -313,7 +313,9 @@
     "1095669519": "Registrazione livello {(GetPlayerBool(SteamID, EXPERIENCE_LOG_KEY) ? \"<color=green>abilitata</color>\" : \"<color=red>disabilitata</color>\")}",
     "3112026815": "La registrazione delle professioni è ora {(GetPlayerBool(steamId, PROFESSION_LOG_KEY) ? \"<color=green>abilitata</color>\" : \"<color=red>disabilitata</color>\")}",
     "542066310": "Registrazione dell'Eredità del Sangue {(GetPlayerBool(steamId, BLOOD_LOG_KEY) ? \"<color=green>abilitata</color>\" : \"<color=red>disabilitata</color>\")}",
-    "881612152": "Azione emote della forma Exo (<color=white>taunt</color>) {(GetPlayerBool(steamId, SHAPESHIFT_KEY) ? \"<color=green>abilitata</color>\" : \"<color=red>disabilitata</color>\")}"
+    "881612152": "Azione emote della forma Exo (<color=white>taunt</color>) {(GetPlayerBool(steamId, SHAPESHIFT_KEY) ? \"<color=green>abilitata</color>\" : \"<color=red>disabilitata</color>\")}",
+    "1669157395": "La tua borsa sembra leggermente più pesante...",
+    "2346236465": "Qualcosa è caduto dalla tua borsa!"
   },
   "_meta": {
     "1716911803": "Identico intenzionalmente all'inglese; segnaposto dinamico"

--- a/Resources/Localization/Messages/Japanese.json
+++ b/Resources/Localization/Messages/Japanese.json
@@ -313,7 +313,9 @@
     "3706417587": "無効なクエストタイプ '{questTypeName}' です。有効な値: {string.Join(\", \", Enum.GetNames(typeof(QuestType)))}",
     "3112026815": "職業ログは現在{(GetPlayerBool(steamId, PROFESSION_LOG_KEY) ? \"<color=green>有効</color>\" : \"<color=red>無効</color>\")}です。",
     "542066310": "血のレガシーログは{(GetPlayerBool(steamId, BLOOD_LOG_KEY) ? \"<color=green>有効</color>\" : \"<color=red>無効</color>\")}です。",
-    "881612152": "エクソフォームのエモートアクション（<color=white>挑発</color>）は{(GetPlayerBool(steamId, SHAPESHIFT_KEY) ? \"<color=green>有効</color>\" : \"<color=red>無効</color>\")}です。"
+    "881612152": "エクソフォームのエモートアクション（<color=white>挑発</color>）は{(GetPlayerBool(steamId, SHAPESHIFT_KEY) ? \"<color=green>有効</color>\" : \"<color=red>無効</color>\")}です。",
+    "1669157395": "バッグが少し重くなった気がする...",
+    "2346236465": "何かがバッグから落ちた!"
   },
   "_meta": {
     "1716911803": "Intentionally identical to English; dynamic placeholder"

--- a/Resources/Localization/Messages/Korean.json
+++ b/Resources/Localization/Messages/Korean.json
@@ -313,7 +313,9 @@
     "3112026815": "직업 로그가 이제 {(GetPlayerBool(steamId, PROFESSION_LOG_KEY) ? \"<color=green>활성화됨</color>\" : \"<color=red>비활성화됨</color>\")}.",
     "542066310": "혈통 로그가 {(GetPlayerBool(steamId, BLOOD_LOG_KEY) ? \"<color=green>활성화됨</color>\" : \"<color=red>비활성화됨</color>\")}.",
     "881612152": "엑소 형태 감정표현 (<color=white>도발</color>)이 {(GetPlayerBool(steamId, SHAPESHIFT_KEY) ? \"<color=green>활성화됨</color>\" : \"<color=red>비활성화됨</color>\")}",
-    "2978826451": "<color=green>{famName}</color>{(buffsData.FamiliarBuffs.ContainsKey(familiarId) ? \"{colorCode}*</color>\" : \"\")} [<color=white>{level}</color>][<color=#90EE90>{prestiges}</color>]이(가) <color=white>{groupName}</color>에 추가되었습니다! (<color=yellow>{slotIndex}</color>)"
+    "2978826451": "<color=green>{famName}</color>{(buffsData.FamiliarBuffs.ContainsKey(familiarId) ? \"{colorCode}*</color>\" : \"\")} [<color=white>{level}</color>][<color=#90EE90>{prestiges}</color>]이(가) <color=white>{groupName}</color>에 추가되었습니다! (<color=yellow>{slotIndex}</color>)",
+    "1669157395": "가방이 약간 무거워진 것 같다...",
+    "2346236465": "뭔가 가방에서 떨어졌어요!"
   },
   "_meta": {
     "1716911803": "Intentionally identical to English; dynamic placeholder"

--- a/Resources/Localization/Messages/Latam.json
+++ b/Resources/Localization/Messages/Latam.json
@@ -313,7 +313,9 @@
     "3112026815": "El registro de la profesión ahora está {(GetPlayerBool(steamId, PROFESSION_LOG_KEY) ? \"<color=green>habilitado</color>\" : \"<color=red>deshabilitado</color>\")}.",
     "542066310": "Registro de Legado de sangre {(GetPlayerBool(steamId, BLOOD_LOG_KEY) ? \"<color=green>habilitado</color>\" : \"<color=red>deshabilitado</color>\")}.",
     "881612152": "Acción de gesto de forma Exo (<color=white>burla</color>) {(GetPlayerBool(steamId, SHAPESHIFT_KEY) ? \"<color=green>habilitada</color>\" : \"<color=red>deshabilitada</color>\")}",
-    "2978826451": "<color=green>{famName}</color>{(buffsData.FamiliarBuffs.ContainsKey(familiarId) ? \"{colorCode}*</color>\" : \"\")} [<color=white>{level}</color>][<color=#90EE90>{prestiges}</color>] added to <color=white>{groupName}</color>! (<color=yellow>{slotIndex}</color>)"
+    "2978826451": "<color=green>{famName}</color>{(buffsData.FamiliarBuffs.ContainsKey(familiarId) ? \"{colorCode}*</color>\" : \"\")} [<color=white>{level}</color>][<color=#90EE90>{prestiges}</color>] added to <color=white>{groupName}</color>! (<color=yellow>{slotIndex}</color>)",
+    "1669157395": "Tu bolsa se siente un poco más pesada...",
+    "2346236465": "¡Algo se cayó de tu bolsa!"
   },
   "_meta": {
     "1716911803": "Intentionally identical to English; dynamic placeholder",

--- a/Resources/Localization/Messages/Polish.json
+++ b/Resources/Localization/Messages/Polish.json
@@ -313,7 +313,9 @@
     "3112026815": "Rejestrowanie zawodu jest teraz [[token_4]].",
     "542066310": "Logowanie z dziedzictwa krwi [[token_4]].",
     "881612152": "Exo Form Form Action ([[token_0]] taunt [[token_1]]) [[token_6]]]",
-    "2978826451": "[[Token_0]] [[token_11]] [[token_1]] {(BuffsData.familiarBuffs.ContainsKey (znajomość)? ”[[Token_12]]*[[token_2]]\": \"\")}} [[[Token_3]] [[token_13]] [[token_4]]]] [[[token_5]] [[token_14]]] [[token_6]]] Dodano do [[token_7]]] [[token_15]] [[token_8]]]! ([[Token_9]] [[token_16]] [[token_10]])"
+    "2978826451": "[[Token_0]] [[token_11]] [[token_1]] {(BuffsData.familiarBuffs.ContainsKey (znajomość)? ”[[Token_12]]*[[token_2]]\": \"\")}} [[[Token_3]] [[token_13]] [[token_4]]]] [[[token_5]] [[token_14]]] [[token_6]]] Dodano do [[token_7]]] [[token_15]] [[token_8]]]! ([[Token_9]] [[token_16]] [[token_10]])",
+    "1669157395": "Twoja torba wydaje się nieco cięższa...",
+    "2346236465": "Coś wypadło z twojej torby!"
   },
   "_meta": {
     "1716911803": "Intentionally identical to English; dynamic placeholder"

--- a/Resources/Localization/Messages/Russian.json
+++ b/Resources/Localization/Messages/Russian.json
@@ -313,6 +313,8 @@
     "3112026815": "Журнал профессий теперь {(GetPlayerBool(steamId, PROFESSION_LOG_KEY) ? \"<color=green>включен</color>\" : \"<color=red>отключен</color>\")}.",
     "542066310": "Журнал Blood Legacy {(GetPlayerBool(steamId, BLOOD_LOG_KEY) ? \"<color=green>включен</color>\" : \"<color=red>отключен</color>\")}.",
     "881612152": "Действие эмоции формы Exo (<color=white>taunt</color>) {(GetPlayerBool(steamId, SHAPESHIFT_KEY) ? \"<color=green>включено</color>\" : \"<color=red>отключено</color>\")}.",
-    "2978826451": "<color=green>{famName}</color>{(buffsData.FamiliarBuffs.ContainsKey(familiarId) ? \"{colorCode}*</color>\" : \"\")} [<color=white>{level}</color>][<color=#90EE90>{prestiges}</color>] добавлено в <color=white>{groupName}</color>! (<color=yellow>{slotIndex}</color>)"
+    "2978826451": "<color=green>{famName}</color>{(buffsData.FamiliarBuffs.ContainsKey(familiarId) ? \"{colorCode}*</color>\" : \"\")} [<color=white>{level}</color>][<color=#90EE90>{prestiges}</color>] добавлено в <color=white>{groupName}</color>! (<color=yellow>{slotIndex}</color>)",
+    "1669157395": "Твоя сумка кажется немного тяжелее...",
+    "2346236465": "Из твоей сумки что-то выпало!"
   }
 }

--- a/Resources/Localization/Messages/SChinese.json
+++ b/Resources/Localization/Messages/SChinese.json
@@ -313,6 +313,8 @@
     "1095669519": "等级记录{(GetPlayerBool(SteamID, EXPERIENCE_LOG_KEY) ? \"<color=green>已启用</color>\" : \"<color=red>已禁用</color>\")}。",
     "3112026815": "职业记录现在{(GetPlayerBool(steamId, PROFESSION_LOG_KEY) ? \"<color=green>已启用</color>\" : \"<color=red>已禁用</color>\")}。",
     "542066310": "血统记录{(GetPlayerBool(steamId, BLOOD_LOG_KEY) ? \"<color=green>已启用</color>\" : \"<color=red>已禁用</color>\")}。",
-    "881612152": "Exo形态表情动作（<color=white>嘲讽</color>）{(GetPlayerBool(steamId, SHAPESHIFT_KEY) ? \"<color=green>已启用</color>\" : \"<color=red>已禁用</color>\")}"
+    "881612152": "Exo形态表情动作（<color=white>嘲讽</color>）{(GetPlayerBool(steamId, SHAPESHIFT_KEY) ? \"<color=green>已启用</color>\" : \"<color=red>已禁用</color>\")}",
+    "1669157395": "你的包感觉稍微重了一点...",
+    "2346236465": "有东西从你的包里掉出来了！"
   }
 }

--- a/Resources/Localization/Messages/Spanish.json
+++ b/Resources/Localization/Messages/Spanish.json
@@ -313,7 +313,9 @@
     "1095669519": "El registro de nivel {(GetPlayerBool(SteamID, EXPERIENCE_LOG_KEY) ? \"<color=green>habilitado</color>\" : \"<color=red>deshabilitado</color>\")}",
     "3112026815": "El registro de profesión ahora está {(GetPlayerBool(steamId, PROFESSION_LOG_KEY) ? \"<color=green>habilitado</color>\" : \"<color=red>deshabilitado</color>\")}",
     "542066310": "El registro de Legado de Sangre {(GetPlayerBool(steamId, BLOOD_LOG_KEY) ? \"<color=green>habilitado</color>\" : \"<color=red>deshabilitado</color>\")}",
-    "881612152": "Acción de gesto en forma Exo (<color=white>provocación</color>) {(GetPlayerBool(steamId, SHAPESHIFT_KEY) ? \"<color=green>habilitada</color>\" : \"<color=red>deshabilitada</color>\")}"
+    "881612152": "Acción de gesto en forma Exo (<color=white>provocación</color>) {(GetPlayerBool(steamId, SHAPESHIFT_KEY) ? \"<color=green>habilitada</color>\" : \"<color=red>deshabilitada</color>\")}",
+    "1669157395": "Tu bolsa se siente un poco más pesada...",
+    "2346236465": "¡Algo se cayó de tu bolsa!"
   },
   "_meta": {
     "1716911803": "Intentionally identical to English; dynamic placeholder"

--- a/Resources/Localization/Messages/TChinese.json
+++ b/Resources/Localization/Messages/TChinese.json
@@ -313,7 +313,9 @@
     "1812818458": "你在<color=#90EE90> 經驗</color>[<color=white>{prestigeLevel}</color>] 中享有威望。 <color=green>{gainPercentage}</color>, 單位殺人的經驗減少<color=red>{reductionPercentage}</color>。",
     "1443941563": "取消了所有玩家的聲望",
     "3066749917": "<color=green>{famName}</color>{(buffsData.FamiliarBuffs.ContesKey(familiar))_BAR__BAR__BAR__BAR__BAR__BAR__BAR__BAR__BAR__BAR__BAR__BAR__BAR__BAR__BAR__BAR_ Id) $\"{colorCode}*</color>\":\"[<color=white>{level}</color>][<color=#90EE90>{prestiges}</color>] 加上<color=white>{groupName}</color>! (<color=yellow>{slotIndex}</color>)",
-    "2511919794": "<color=yellow>{count}</color>** <color=green>{famName}</color>{(familiar BuffsData.FamiliarBuffs.ContsKey(famKey)? $\"{colorCode}*</color>{levelAndPrestiges}: ${levelAndPrestiges}"
+    "2511919794": "<color=yellow>{count}</color>** <color=green>{famName}</color>{(familiar BuffsData.FamiliarBuffs.ContsKey(famKey)? $\"{colorCode}*</color>{levelAndPrestiges}: ${levelAndPrestiges},",
+    "1669157395": "你的包包感覺稍微重了一點...",
+    "2346236465": "有東西從你的包包掉出來了！"
   },
   "_meta": {
     "1716911803": "Intentionally identical to English; dynamic placeholder"

--- a/Resources/Localization/Messages/Thai.json
+++ b/Resources/Localization/Messages/Thai.json
@@ -313,6 +313,8 @@
     "3112026815": "การบันทึกอาชีพคือ {(GetPlayerBool(steamId, PROFESSION_LOG_KEY) ? \"<color=green>เปิดใช้งาน</color>\" : \"<color=red>ปิดใช้งาน</color>\")}.",
     "542066310": "การบันทึกมรดกเลือด {(GetPlayerBool(steamId, BLOOD_LOG_KEY) ? \"<color=green>เปิดใช้งาน</color>\" : \"<color=red>ปิดใช้งาน</color>\")}.",
     "881612152": "การแสดงอารมณ์รูปแบบ Exo (<color=white>ท้าทาย</color>) {(GetPlayerBool(steamId, SHAPESHIFT_KEY) ? \"<color=green>เปิดใช้งาน</color>\" : \"<color=red>ปิดใช้งาน</color>\")}",
-    "2978826451": "<color=green>{famName}</color>(buffsData. famifitionrbuffs. ContunesKey (fifilitionrid) ?\"{colorCode}*</color>\":\"\") [<color=white>{level}</color>) [<color=#90EE90>{prestiges}</color>) เพิ่ม<color=white>{groupName}</color>ไม่! (<color=yellow>{slotIndex}</color>)"
+    "2978826451": "<color=green>{famName}</color>(buffsData. famifitionrbuffs. ContunesKey (fifilitionrid) ?\"{colorCode}*</color>\":\"\") [<color=white>{level}</color>) [<color=#90EE90>{prestiges}</color>) เพิ่ม<color=white>{groupName}</color>ไม่! (<color=yellow>{slotIndex}</color>)",
+    "1669157395": "กระเป๋าของคุณรู้สึกหนักขึ้นเล็กน้อย...",
+    "2346236465": "มีบางอย่างหล่นออกจากกระเป๋าของคุณ!"
   }
 }

--- a/Resources/Localization/Messages/Turkish.json
+++ b/Resources/Localization/Messages/Turkish.json
@@ -313,6 +313,8 @@
     "3112026815": "Meslek günlüğü şimdi {(GetPlayerBool(steamId, PROFESSION_LOG_KEY) ? \"<color=green>enabled</color>\" : \"<color=red>disabled</color>\")}.",
     "542066310": "Kan Mirası kaydı {(GetPlayerBool(steamId, BLOOD_LOG_KEY) ? \"<color=green>etkin</color>\" : \"<color=red>devre dışı</color>\")}.",
     "881612152": "Exo formu emote eylemi (<color=white>alay</color>) {(GetPlayerBool(steamId, SHAPESHIFT_KEY) ? \"<color=green>etkin</color>\" : \"<color=red>devre dışı</color>\")}",
-    "2978826451": "<color=green>{famName}</color>{(Buffsdata.familiarbuffs.containskey (tanıdık)? \"{colorCode}*</color>\":\" \")} [<color=white>{level}</color>] [<color=#90EE90>{prestiges}</color>] ekledi<color=white>{groupName}</color>! (<color=yellow>{slotIndex}</color>)"
+    "2978826451": "<color=green>{famName}</color>{(Buffsdata.familiarbuffs.containskey (tanıdık)? \"{colorCode}*</color>\":\" \")} [<color=white>{level}</color>] [<color=#90EE90>{prestiges}</color>] ekledi<color=white>{groupName}</color>! (<color=yellow>{slotIndex}</color>)",
+    "1669157395": "Çantan biraz daha ağırlaştı...",
+    "2346236465": "Bir şey çantandan düştü!"
   }
 }

--- a/Resources/Localization/Messages/Ukrainian.json
+++ b/Resources/Localization/Messages/Ukrainian.json
@@ -313,7 +313,9 @@
     "3112026815": "Журнал професій {(GetPlayerBool(steamId, PROFESSION_LOG_KEY) ? \"<color=green>увімкнено</color>\" : \"<color=red>вимкнено</color>\")}.",
     "542066310": "Журнал спадщини крові {(GetPlayerBool(steamId, BLOOD_LOG_KEY) ? \"<color=green>увімкнено</color>\" : \"<color=red>вимкнено</color>\")}.",
     "881612152": "Дія емодзі форми Exo (<color=white>taunt</color>) {(GetPlayerBool(steamId, SHAPESHIFT_KEY) ? \"<color=green>увімкнено</color>\" : \"<color=red>вимкнено</color>\")}",
-    "2978826451": "<color=green>{famName}</color>{(buffsData.FamiliarBuffs.ContainsKey(familiarId) ? \"{colorCode}*</color>\" : \"\")}[<color=white>{level}</color>][<color=#90EE90>{prestiges}</color>] додано до <color=white>{groupName}</color>! (<color=yellow>{slotIndex}</color>)"
+    "2978826451": "<color=green>{famName}</color>{(buffsData.FamiliarBuffs.ContainsKey(familiarId) ? \"{colorCode}*</color>\" : \"\")}[<color=white>{level}</color>][<color=#90EE90>{prestiges}</color>] додано до <color=white>{groupName}</color>! (<color=yellow>{slotIndex}</color>)",
+    "1669157395": "Твоя сумка здається трохи важчою...",
+    "2346236465": "Щось випало з твоєї сумки!"
   },
   "_meta": {
     "1716911803": "Intentionally identical to English; dynamic placeholder",

--- a/Resources/Localization/Messages/Vietnamese.json
+++ b/Resources/Localization/Messages/Vietnamese.json
@@ -313,7 +313,9 @@
     "3112026815": "Ghi nhật ký nghề bây giờ là {(GetPlayerBool(steamId, PROFESSION_LOG_KEY) ? \"<color=green>bật</color>\" : \"<color=red>tắt</color>\")}",
     "542066310": "Ghi nhật ký di sản {(GetPlayerBool(steamId, BLOOD_LOG_KEY) ? \"<color=green>bật</color>\" : \"<color=red>tắt</color>\")}",
     "881612152": "Exo form hành động emote (<color=white>tain</color>) {(getPlayerBool (steamid, shapeshift_key)? \"<Color = green> enable</color>\": \"",
-    "2978826451": "<color=green>{famName}</color>{(buffsData.FamiliarBuffs.ContainsKey(familiarId) ? \"{colorCode}*</color> \":\" \")} [<color=white>{level}</color>] <color=#90EE90>{prestiges}2"
+    "2978826451": "<color=green>{famName}</color>{(buffsData.FamiliarBuffs.ContainsKey(familiarId) ? \"{colorCode}*</color> \":\" \")} [<color=white>{level}</color>] <color=#90EE90>{prestiges}2",
+    "1669157395": "Túi của bạn cảm thấy nặng hơn một chút...",
+    "2346236465": "Có thứ gì đó rơi ra khỏi túi của bạn!"
   },
   "_meta": {
     "1716911803": "Intentionally identical to English; dynamic placeholder"

--- a/Utilities/Misc.cs
+++ b/Utilities/Misc.cs
@@ -186,6 +186,9 @@ internal static class Misc
         public const string DAGGERS_KEY = nameof(WeaponType.Daggers);
         public const string CLAWS_KEY = nameof(WeaponType.Claws);
 
+        const string BAG_HEAVIER_MESSAGE = "Your bag feels slightly heavier...";
+        const string ITEM_DROPPED_MESSAGE = "Something fell out of your bag!";
+
         public static readonly Dictionary<string, bool> DefaultBools = new()
         {
             [EXPERIENCE_LOG_KEY] = false,
@@ -509,12 +512,12 @@ internal static class Misc
 
         if (hasSpace && ServerGameManager.TryAddInventoryItem(playerCharacter, itemType, amount))
         {
-            LocalizationService.Reply(EntityManager, user, "Your bag feels slightly heavier...");
+            LocalizationService.Reply(EntityManager, user, BAG_HEAVIER_MESSAGE);
         }
         else
         {
             InventoryUtilitiesServer.CreateDropItem(EntityManager, playerCharacter, itemType, amount, new Entity()); // does this create multiple drops to account for excessive stacks? noting for later
-            LocalizationService.Reply(EntityManager, user, "Something fell out of your bag!");
+            LocalizationService.Reply(EntityManager, user, ITEM_DROPPED_MESSAGE);
         }
     }
     public static bool RollForChance(float chance)


### PR DESCRIPTION
## Summary
- Replace direct bag message strings with localization key constants
- Add localized translations for bag messages across supported languages

## Testing
- `python Tools/fix_tokens.py --check-only`
- `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- generate-messages` *(fails: command not found)*
- `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations --show-text` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a0b175f40832d831f57964d2572db