### PR TITLE
refactor: parameterize localization messages

### DIFF
--- a/Commands/FamiliarCommands.cs
+++ b/Commands/FamiliarCommands.cs
@@ -279,7 +279,7 @@ internal static class FamiliarCommands
                 }
 
                 PrefabGUID PrefabGUID = new(familiarId);
-                LocalizationService.Reply(ctx, $"<color=green>{PrefabGUID.GetLocalizedName()}</color> moved - <color=white>{name}</color>");
+                LocalizationService.Reply(ctx, "<color=green>{0}</color> moved - <color=white>{1}</color>", PrefabGUID.GetLocalizedName(), name);
             }
         }
         else if (data.FamiliarUnlocks.ContainsKey(name))
@@ -430,7 +430,7 @@ internal static class FamiliarCommands
 
         if (IsBannedPrefabGuid(vBloodPrefabGuid))
         {
-            LocalizationService.Reply(ctx, $"<color=white>{vBloodPrefabGuid.GetLocalizedName()}</color> is not available per configured familiar bans!");
+            LocalizationService.Reply(ctx, "<color=white>{0}</color> is not available per configured familiar bans!", vBloodPrefabGuid.GetLocalizedName());
             return;
         }
         else
@@ -442,7 +442,7 @@ internal static class FamiliarCommands
 
                 if (unlocksData.FamiliarUnlocks.Values.Any(list => list.Contains(vBloodPrefabGuid.GuidHash)))
                 {
-                    LocalizationService.Reply(ctx, $"<color=white>{vBloodPrefabGuid.GetLocalizedName()}</color> is already unlocked!");
+                    LocalizationService.Reply(ctx, "<color=white>{0}</color> is already unlocked!", vBloodPrefabGuid.GetLocalizedName());
                     return;
                 }
 
@@ -478,20 +478,20 @@ internal static class FamiliarCommands
                             unlocksData.FamiliarUnlocks[lastBoxName].Add(vBloodPrefabGuid.GuidHash);
 
                             SaveFamiliarUnlocksData(steamId, unlocksData);
-                            LocalizationService.Reply(ctx, $"New unit unlocked: <color=green>{vBloodPrefabGuid.GetLocalizedName()}</color>");
+                            LocalizationService.Reply(ctx, "New unit unlocked: <color=green>{0}</color>", vBloodPrefabGuid.GetLocalizedName());
                         }
                         else if (unlocksData.FamiliarUnlocks.ContainsKey(lastBoxName))
                         {
                             unlocksData.FamiliarUnlocks[lastBoxName].Add(vBloodPrefabGuid.GuidHash);
 
                             SaveFamiliarUnlocksData(steamId, unlocksData);
-                            LocalizationService.Reply(ctx, $"New unit unlocked: <color=green>{vBloodPrefabGuid.GetLocalizedName()}</color>");
+                            LocalizationService.Reply(ctx, "New unit unlocked: <color=green>{0}</color>", vBloodPrefabGuid.GetLocalizedName());
                         }
                     }
                 }
                 else
                 {
-                    LocalizationService.Reply(ctx, $"Not enough <color=#ffd9eb>{exoItem.GetLocalizedName()}</color>x<color=white>{factoredCost}</color> for {vBloodPrefabGuid.GetPrefabName()}!");
+                    LocalizationService.Reply(ctx, "Not enough <color=#ffd9eb>{0}</color>x<color=white>{1}</color> for {2}!", exoItem.GetLocalizedName(), factoredCost, vBloodPrefabGuid.GetPrefabName());
                 }
             }
             else
@@ -527,7 +527,7 @@ internal static class FamiliarCommands
             familiarSet.RemoveAt(choice - 1);
             SaveFamiliarUnlocksData(steamId, data);
 
-            LocalizationService.Reply(ctx, $"<color=green>{familiarId.GetLocalizedName()}</color> removed from <color=white>{activeBox}</color>.");
+            LocalizationService.Reply(ctx, "<color=green>{0}</color> removed from <color=white>{1}</color>.", familiarId.GetLocalizedName(), activeBox);
         }
         else
         {
@@ -955,7 +955,7 @@ internal static class FamiliarCommands
             }
             else
             {
-                LocalizationService.Reply(ctx, $"Familiar attempting to prestige must be at max level (<color=white>{ConfigService.MaxFamiliarLevel}</color>) or requires <color=#ffd9eb>{_itemSchematic.GetLocalizedName()}</color><color=yellow>x</color><color=white>{clampedCost}</color>.");
+                LocalizationService.Reply(ctx, "Familiar attempting to prestige must be at max level (<color=white>{0}</color>) or requires <color=#ffd9eb>{1}</color><color=yellow>x</color><color=white>{2}</color>.", ConfigService.MaxFamiliarLevel, _itemSchematic.GetLocalizedName(), clampedCost);
             }
         }
         else
@@ -1225,7 +1225,7 @@ internal static class FamiliarCommands
                 }
                 else
                 {
-                    LocalizationService.Reply(ctx, $"You don't have the required amount of <color=#ffd9eb>{_vampiricDust.GetLocalizedName()}</color>! (x<color=white>{clampedCost}</color>)");
+                    LocalizationService.Reply(ctx, "You don't have the required amount of <color=#ffd9eb>{0}</color>! (x<color=white>{1}</color>)", _vampiricDust.GetLocalizedName(), clampedCost);
                 }
             }
             else if (buffsData.FamiliarBuffs.ContainsKey(famKey))
@@ -1242,7 +1242,7 @@ internal static class FamiliarCommands
                 }
                 else
                 {
-                    LocalizationService.Reply(ctx, $"You don't have the required amount of <color=#ffd9eb>{_vampiricDust.GetLocalizedName()}</color>! (x<color=white>{changeQuantity}</color>)");
+                    LocalizationService.Reply(ctx, "You don't have the required amount of <color=#ffd9eb>{0}</color>! (x<color=white>{1}</color>)", _vampiricDust.GetLocalizedName(), changeQuantity);
                 }
             }
         }

--- a/Commands/LevelingCommands.cs
+++ b/Commands/LevelingCommands.cs
@@ -24,7 +24,7 @@ internal static class LevelingCommands
         var SteamID = ctx.Event.User.PlatformId;
 
         TogglePlayerBool(SteamID, EXPERIENCE_LOG_KEY);
-        LocalizationService.Reply(ctx, $"Level logging {(GetPlayerBool(SteamID, EXPERIENCE_LOG_KEY) ? "<color=green>enabled</color>" : "<color=red>disabled</color>")}.");
+        LocalizationService.Reply(ctx, "Level logging {0}.", GetPlayerBool(SteamID, EXPERIENCE_LOG_KEY) ? "<color=green>enabled</color>" : "<color=red>disabled</color>");
     }
 
     [Command(name: "get", adminOnly: false, usage: ".lvl get", description: "Display current leveling progress.")]
@@ -46,13 +46,13 @@ internal static class LevelingCommands
             int progress = (int)(xpData.Value - ConvertLevelToXp(level));
             int percent = LevelingSystem.GetLevelProgress(steamId);
 
-            LocalizationService.Reply(ctx, $"You're level [<color=white>{level}</color>][<color=#90EE90>{prestigeLevel}</color>] with <color=yellow>{progress}</color> <color=#FFC0CB>experience</color> (<color=white>{percent}%</color>)!");
+            LocalizationService.Reply(ctx, "You're level [<color=white>{0}</color>][<color=#90EE90>{1}</color>] with <color=yellow>{2}</color> <color=#FFC0CB>experience</color> (<color=white>{3}%</color>)!", level, prestigeLevel, progress, percent);
 
             if (ConfigService.RestedXPSystem && steamId.TryGetPlayerRestedXP(out var restedData) && restedData.Value > 0)
             {
                 int roundedXP = (int)(Math.Round(restedData.Value / 100.0) * 100);
 
-                LocalizationService.Reply(ctx, $"<color=#FFD700>{roundedXP}</color> bonus <color=#FFC0CB>experience</color> remaining from <color=green>resting</color>~");
+                LocalizationService.Reply(ctx, "<color=#FFD700>{0}</color> bonus <color=#FFC0CB>experience</color> remaining from <color=green>resting</color>~", roundedXP);
             }
         }
         else
@@ -73,7 +73,7 @@ internal static class LevelingCommands
         PlayerInfo playerInfo = GetPlayerInfo(name);
         if (!playerInfo.UserEntity.Exists())
         {
-            LocalizationService.Reply(ctx, $"Couldn't find player.");
+            LocalizationService.Reply(ctx, "Couldn't find player.");
             return;
         }
 
@@ -81,7 +81,7 @@ internal static class LevelingCommands
 
         if (level < 0 || level > ConfigService.MaxLevel)
         {
-            LocalizationService.Reply(ctx, $"Level must be between <color=white>0</color> and <color=white>{ConfigService.MaxLevel}</color>!");
+            LocalizationService.Reply(ctx, "Level must be between <color=white>0</color> and <color=white>{0}</color>!", ConfigService.MaxLevel);
             return;
         }
 
@@ -93,11 +93,11 @@ internal static class LevelingCommands
             steamId.SetPlayerExperience(xpData);
 
             LevelingSystem.SetLevel(playerInfo.CharEntity);
-            LocalizationService.Reply(ctx, $"Level set to <color=white>{level}</color> for <color=green>{foundUser.CharacterName.Value}</color>!");
+            LocalizationService.Reply(ctx, "Level set to <color=white>{0}</color> for <color=green>{1}</color>!", level, foundUser.CharacterName.Value);
         }
         else
         {
-            LocalizationService.Reply(ctx, $"Couldn't find experience data for {foundUser.CharacterName.Value}");
+            LocalizationService.Reply(ctx, "Couldn't find experience data for {0}", foundUser.CharacterName.Value);
         }
     }
 
@@ -122,14 +122,14 @@ internal static class LevelingCommands
             DataService.PlayerDictionaries._ignoreSharedExperience.Add(playerInfo.User.PlatformId);
             DataService.PlayerPersistence.SaveIgnoredSharedExperience();
 
-            LocalizationService.Reply(ctx, $"<color=green>{playerInfo.User.CharacterName.Value}</color> added to the ignore shared experience list!");
+            LocalizationService.Reply(ctx, "<color=green>{0}</color> added to the ignore shared experience list!", playerInfo.User.CharacterName.Value);
         }
         else if (DataService.PlayerDictionaries._ignoreSharedExperience.Contains(playerInfo.User.PlatformId))
         {
             DataService.PlayerDictionaries._ignoreSharedExperience.Remove(playerInfo.User.PlatformId);
             DataService.PlayerPersistence.SaveIgnoredSharedExperience();
 
-            LocalizationService.Reply(ctx, $"<color=green>{playerInfo.User.CharacterName.Value}</color> removed from the ignore shared experience list!");
+            LocalizationService.Reply(ctx, "<color=green>{0}</color> removed from the ignore shared experience list!", playerInfo.User.CharacterName.Value);
         }
     }
 }

--- a/Commands/QuestCommands.cs
+++ b/Commands/QuestCommands.cs
@@ -30,7 +30,7 @@ internal static class QuestCommands
         var steamId = ctx.Event.User.PlatformId;
 
         TogglePlayerBool(steamId, QUEST_LOG_KEY);
-        LocalizationService.Reply(ctx, $"Quest logging is now {(GetPlayerBool(steamId, QUEST_LOG_KEY) ? "<color=green>enabled</color>" : "<color=red>disabled</color>")}.");
+        LocalizationService.Reply(ctx, "Quest logging is now {0}.", GetPlayerBool(steamId, QUEST_LOG_KEY) ? "<color=green>enabled</color>" : "<color=red>disabled</color>");
     }
 
     [Command(name: "progress", shortHand: "p", adminOnly: false, usage: ".quest p [QuestType]", description: "Display your current quest progress.")]
@@ -137,7 +137,7 @@ internal static class QuestCommands
         int level = (ConfigService.LevelingSystem && steamId.TryGetPlayerExperience(out var data)) ? data.Key : Progression.GetSimulatedLevel(playerInfo.UserEntity);
         ForceRefresh(steamId, level);
 
-        LocalizationService.Reply(ctx, $"Quests for <color=green>{playerInfo.User.CharacterName.Value}</color> have been refreshed.");
+        LocalizationService.Reply(ctx, "Quests for <color=green>{0}</color> have been refreshed.", playerInfo.User.CharacterName.Value);
     }
 
     [Command(name: "reroll", shortHand: "r", adminOnly: false, usage: ".quest r [QuestType]", description: "Reroll quest for cost (daily only currently).")]
@@ -186,13 +186,13 @@ internal static class QuestCommands
                         int level = (ConfigService.LevelingSystem && steamId.TryGetPlayerExperience(out var data)) ? data.Key : Progression.GetSimulatedLevel(ctx.Event.SenderUserEntity);
                         ForceDaily(ctx.Event.User.PlatformId, level);
 
-                        LocalizationService.Reply(ctx, $"Your <color=#00FFFF>Daily Quest</color> has been rerolled for <color=#C0C0C0>{item.GetLocalizedName()}</color> x<color=white>{quantity}</color>!");
+                        LocalizationService.Reply(ctx, "Your <color=#00FFFF>Daily Quest</color> has been rerolled for <color=#C0C0C0>{0}</color> x<color=white>{1}</color>!", item.GetLocalizedName(), quantity);
                         Quests.QuestObjectiveReply(ctx, questData, type);
                     }
                 }
                 else
                 {
-                    LocalizationService.Reply(ctx, $"You couldn't afford to reroll your daily... (<color=#C0C0C0>{item.GetLocalizedName()}</color> x<color=white>{quantity}</color>)");
+                    LocalizationService.Reply(ctx, "You couldn't afford to reroll your daily... (<color=#C0C0C0>{0}</color> x<color=white>{1}</color>)", item.GetLocalizedName(), quantity);
                 }
             }
             else
@@ -219,13 +219,13 @@ internal static class QuestCommands
                         int level = (ConfigService.LevelingSystem && steamId.TryGetPlayerExperience(out var data)) ? data.Key : (int)ctx.Event.SenderCharacterEntity.Read<Equipment>().GetFullLevel();
                         ForceWeekly(ctx.Event.User.PlatformId, level);
 
-                        LocalizationService.Reply(ctx, $"Your <color=#BF40BF>Weekly Quest</color> has been rerolled for <color=#C0C0C0>{item.GetLocalizedName()}</color> x<color=white>{quantity}</color>!");
+                        LocalizationService.Reply(ctx, "Your <color=#BF40BF>Weekly Quest</color> has been rerolled for <color=#C0C0C0>{0}</color> x<color=white>{1}</color>!", item.GetLocalizedName(), quantity);
                         Quests.QuestObjectiveReply(ctx, questData, type);
                     }
                 }
                 else
                 {
-                    LocalizationService.Reply(ctx, $"You couldn't afford to reroll your wekly... (<color=#C0C0C0>{item.GetLocalizedName()}</color> x<color=white>{quantity}</color>)");
+                    LocalizationService.Reply(ctx, "You couldn't afford to reroll your wekly... (<color=#C0C0C0>{0}</color> x<color=white>{1}</color>)", item.GetLocalizedName(), quantity);
                 }
             }
             else
@@ -272,20 +272,20 @@ internal static class QuestCommands
 
         if (!Enum.TryParse<QuestType>(questTypeName, true, out var questType))
         {
-            LocalizationService.Reply(ctx, $"Invalid quest type '{questTypeName}'. Valid values are: {string.Join(", ", Enum.GetNames(typeof(QuestType)))}");
+            LocalizationService.Reply(ctx, "Invalid quest type '{0}'. Valid values are: {1}", questTypeName, string.Join(", ", Enum.GetNames(typeof(QuestType))));
             return;
         }
 
         if (!questData.ContainsKey(questType))
         {
-            LocalizationService.Reply(ctx, $"Player does not have an active {questType} quest to complete.");
+            LocalizationService.Reply(ctx, "Player does not have an active {0} quest to complete.", questType);
             return;
         }
 
         var quest = questData[questType];
         if (quest.Objective.Complete)
         {
-            LocalizationService.Reply(ctx, $"The {questType} quest is already complete for {playerInfo.User.CharacterName.Value}.");
+            LocalizationService.Reply(ctx, "The {0} quest is already complete for {1}.", questType, playerInfo.User.CharacterName.Value);
             return;
         }
 
@@ -299,6 +299,6 @@ internal static class QuestCommands
 
         ProcessQuestProgress(questData, target, toAdd, user);
 
-        LocalizationService.Reply(ctx, $"Completed {Quests.QuestTypeColor[questType]} for <color=green>{playerInfo.User.CharacterName.Value}</color>!");
+        LocalizationService.Reply(ctx, "Completed {0} for <color=green>{1}</color>!", Quests.QuestTypeColor[questType], playerInfo.User.CharacterName.Value);
     }
 }

--- a/Services/DataService.cs
+++ b/Services/DataService.cs
@@ -1189,7 +1189,7 @@ internal static class DataService
                 var data = LoadFamiliarBattleGroupsData(steamId);
                 if (data.BattleGroups.Count >= MAX_BATTLE_GROUPS)
                 {
-                    LocalizationService.Reply(ctx, $"Can't have more than <color=white>{MAX_BATTLE_GROUPS}</color> battle groups!");
+                    LocalizationService.Reply(ctx, "Can't have more than <color=white>{0}</color> battle groups!", MAX_BATTLE_GROUPS);
                     return false;
                 }
 
@@ -1207,7 +1207,7 @@ internal static class DataService
 
                 data.BattleGroups.Remove(group);
                 SaveFamiliarBattleGroupsData(steamId, data);
-                LocalizationService.Reply(ctx, $"Deleted battle group <color=white>{groupName}</color>!");
+                LocalizationService.Reply(ctx, "Deleted battle group <color=white>{0}</color>!", groupName);
                 return true;
             }
             public static bool SetActiveBattleGroup(ChatCommandContext ctx, ulong steamId, string groupName)
@@ -1234,7 +1234,7 @@ internal static class DataService
                     BuildBattleGroupDetailsReply(steamId, buffsData, prestigeData, battleGroup, ref familiars);
 
                     string familiarReply = string.Join(", ", familiars);
-                    LocalizationService.Reply(ctx, $"Battle Group - {familiarReply}");
+                    LocalizationService.Reply(ctx, "Battle Group - {0}", familiarReply);
                 }
                 else
                 {

--- a/Utilities/Battles.cs
+++ b/Utilities/Battles.cs
@@ -180,7 +180,14 @@ internal static class Battles
             prestiges = prestigeData.FamiliarPrestige[familiarId].Key;
         }
 
-        LocalizationService.Reply(ctx, $"<color=green>{famName}</color>{(buffsData.FamiliarBuffs.ContainsKey(familiarId) ? $"{colorCode}*</color>" : "")} [<color=white>{level}</color>][<color=#90EE90>{prestiges}</color>] added to <color=white>{groupName}</color>! (<color=yellow>{slotIndex}</color>)");
+        LocalizationService.Reply(ctx,
+            "<color=green>{0}</color>{1} [<color=white>{2}</color>][<color=#90EE90>{3}</color>] added to <color=white>{4}</color>! (<color=yellow>{5}</color>)",
+            famName,
+            buffsData.FamiliarBuffs.ContainsKey(familiarId) ? $"{colorCode}*</color>" : string.Empty,
+            level,
+            prestiges,
+            groupName,
+            slotIndex);
     }
     */
     public static void HandleBattleGroupDetailsReply(ChatCommandContext ctx, ulong steamId, FamiliarBattleGroupsManager.FamiliarBattleGroup battleGroup)
@@ -194,7 +201,7 @@ internal static class Battles
             BuildBattleGroupDetailsReply(steamId, buffsData, prestigeData, battleGroup.Familiars, ref familiars);
 
             string familiarReply = string.Join(", ", familiars);
-            LocalizationService.Reply(ctx, $"Battle Group - {familiarReply}");
+            LocalizationService.Reply(ctx, "Battle Group - {0}", familiarReply);
             return;
         }
         else

--- a/Utilities/Classes.cs
+++ b/Utilities/Classes.cs
@@ -345,13 +345,13 @@ internal static class Classes
         if (!InventoryUtilities.TryGetInventoryEntity(EntityManager, ctx.User.LocalCharacter._Entity, out var inventoryEntity) ||
             ServerGameManager.GetInventoryItemCount(inventoryEntity, item) < quantity)
         {
-            LocalizationService.Reply(ctx, $"You do not have enough of the required item to change classes (<color=#ffd9eb>{item.GetLocalizedName()}</color>x<color=white>{quantity}</color>)");
+            LocalizationService.Reply(ctx, "You do not have enough of the required item to change classes (<color=#ffd9eb>{0}</color>x<color=white>{1}</color>)", item.GetLocalizedName(), quantity);
             return false;
         }
 
         if (!ServerGameManager.TryRemoveInventoryItem(inventoryEntity, item, quantity))
         {
-            LocalizationService.Reply(ctx, $"Failed to remove enough of the item required (<color=#ffd9eb>{item.GetLocalizedName()}</color>x<color=white>{quantity}</color>)");
+            LocalizationService.Reply(ctx, "Failed to remove enough of the item required (<color=#ffd9eb>{0}</color>x<color=white>{1}</color>)", item.GetLocalizedName(), quantity);
             return false;
         }
 
@@ -397,7 +397,7 @@ internal static class Classes
 
         if (passiveBuffs.Count == 0)
         {
-            LocalizationService.Reply(ctx, $"{FormatClassName(playerClass)} passives not found!");
+            LocalizationService.Reply(ctx, "{0} passives not found!", FormatClassName(playerClass));
             return;
         }
 
@@ -419,13 +419,13 @@ internal static class Classes
             return $"<color=yellow>{index + 1}</color>| {(prefabEntity.Has<ModifyUnitStatBuff_DOTS>() ? FormatModifyUnitStatBuffer(prefabEntity) : prefabName)} at level <color=green>{level}</color>";
         }).ToList();
 
-        LocalizationService.Reply(ctx, $"{FormatClassName(playerClass)} passives:");
+        LocalizationService.Reply(ctx, "{0} passives:", FormatClassName(playerClass));
 
         for (int i = 0; i < classBuffs.Count; i += 3) // Using batches of 4 for better readability
         {
             var batch = classBuffs.Skip(i).Take(3);
             string replyMessage = string.Join(", ", batch);
-            LocalizationService.Reply(ctx, $"{replyMessage}");
+            LocalizationService.Reply(ctx, "{0}", replyMessage);
         }
     }
 
@@ -436,7 +436,7 @@ internal static class Classes
 
         if (!hasWeaponStats && !hasBloodStats)
         {
-            LocalizationService.Reply(ctx, $"Couldn't find stat synergies for {FormatClassName(playerClass)}...");
+            LocalizationService.Reply(ctx, "Couldn't find stat synergies for {0}...", FormatClassName(playerClass));
             return;
         }
 
@@ -454,17 +454,17 @@ internal static class Classes
 
         if (allStats.Count == 0)
         {
-            LocalizationService.Reply(ctx, $"No stat synergies found for {FormatClassName(playerClass)}.");
+            LocalizationService.Reply(ctx, "No stat synergies found for {0}.", FormatClassName(playerClass));
             return;
         }
 
-        LocalizationService.Reply(ctx, $"{FormatClassName(playerClass)} stat synergies [x<color=white>{ConfigService.SynergyMultiplier}</color>]:");
+        LocalizationService.Reply(ctx, "{0} stat synergies [x<color=white>{1}</color>]:", FormatClassName(playerClass), ConfigService.SynergyMultiplier);
 
         for (int i = 0; i < allStats.Count; i += 6)
         {
             var batch = allStats.Skip(i).Take(6);
             string replyMessage = string.Join(", ", batch);
-            LocalizationService.Reply(ctx, $"{replyMessage}");
+            LocalizationService.Reply(ctx, "{0}", replyMessage);
         }
     }
 
@@ -507,7 +507,7 @@ internal static class Classes
 
         if (spells.Count == 0)
         {
-            LocalizationService.Reply(ctx, $"{FormatClassName(playerClass)} has no spells configured...");
+            LocalizationService.Reply(ctx, "{0} has no spells configured...", FormatClassName(playerClass));
             return;
         }
 
@@ -527,13 +527,13 @@ internal static class Classes
             classSpells.Insert(0, $"<color=yellow>{0}</color>| <color=white>{spellName}</color>");
         }
 
-        LocalizationService.Reply(ctx, $"{FormatClassName(playerClass)} spells:");
+        LocalizationService.Reply(ctx, "{0} spells:", FormatClassName(playerClass));
 
         for (int i = 0; i < classSpells.Count; i += 4)
         {
             var batch = classSpells.Skip(i).Take(4);
             string replyMessage = string.Join(", ", batch);
-            LocalizationService.Reply(ctx, $"{replyMessage}");
+            LocalizationService.Reply(ctx, "{0}", replyMessage);
         }
     }
     public static bool TryParseClass(string classType, out PlayerClass parsedClassType)
@@ -652,7 +652,7 @@ internal static class Classes
 
                 if (spellPrefabGUID.Equals(oldAbility))
                 {
-                    LocalizationService.Reply(ctx, $"Shift spell: <color=#CBC3E3>{spellName}</color>");
+                    LocalizationService.Reply(ctx, "Shift spell: <color=#CBC3E3>{0}</color>", spellName);
                     return;
                 }
                 for (int i = 0; i < firstBuffer.Length; i++)
@@ -717,7 +717,7 @@ internal static class Classes
                 JewelEquipUtilitiesServer.TryEquipJewel(ref _entityManagerRef, ref _prefabLookupMap, character, slot);
             }
 
-            LocalizationService.Reply(ctx, $"Shift spell: <color=#CBC3E3>{spellName}</color>");
+            LocalizationService.Reply(ctx, "Shift spell: <color=#CBC3E3>{0}</color>", spellName);
         }
         else if (spellPrefabGUID.HasValue())
         {
@@ -736,7 +736,7 @@ internal static class Classes
 
                 if (spellPrefabGUID.Equals(oldAbility))
                 {
-                    LocalizationService.Reply(ctx, $"Shift spell: <color=#CBC3E3>{spellName}</color>");
+                    LocalizationService.Reply(ctx, "Shift spell: <color=#CBC3E3>{0}</color>", spellName);
                     return;
                 }
                 for (int i = 0; i < firstBuffer.Length; i++)
@@ -781,12 +781,12 @@ internal static class Classes
                     JewelEquipUtilitiesServer.TryEquipJewel(ref _entityManagerRef, ref _prefabLookupMap, character, slot);
                 }
 
-                LocalizationService.Reply(ctx, $"Shift spell: <color=#CBC3E3>{spellName}</color>");
+                LocalizationService.Reply(ctx, "Shift spell: <color=#CBC3E3>{0}</color>", spellName);
             }
             else
             {
                 HandleNPCSpell(character, spellPrefabGUID);
-                LocalizationService.Reply(ctx, $"Shift spell: <color=#CBC3E3>{spellName}</color>");
+                LocalizationService.Reply(ctx, "Shift spell: <color=#CBC3E3>{0}</color>", spellName);
             }
         }
     }

--- a/Utilities/Familiars.cs
+++ b/Utilities/Familiars.cs
@@ -359,7 +359,7 @@ internal static class Familiars
             data.FamiliarUnlocks[activeBox].Add(prefabHash);
             SaveFamiliarUnlocksData(steamId, data);
 
-            LocalizationService.Reply(ctx, $"<color=green>{new PrefabGUID(prefabHash).GetLocalizedName()}</color> added to <color=white>{activeBox}</color>.");
+            LocalizationService.Reply(ctx, "<color=green>{0}</color> added to <color=white>{1}</color>.", new PrefabGUID(prefabHash).GetLocalizedName(), activeBox);
         }
         else if (unit.ToLower().StartsWith("char")) // search for full and/or partial name match
         {
@@ -390,7 +390,7 @@ internal static class Familiars
                 data.FamiliarUnlocks[activeBox].Add(match.GuidHash);
                 SaveFamiliarUnlocksData(steamId, data);
 
-                LocalizationService.Reply(ctx, $"<color=green>{match.GetLocalizedName()}</color> (<color=yellow>{match.GuidHash}</color>) added to <color=white>{activeBox}</color>.");
+                LocalizationService.Reply(ctx, "<color=green>{0}</color> (<color=yellow>{1}</color>) added to <color=white>{2}</color>.", match.GetLocalizedName(), match.GuidHash, activeBox);
             }
             else
             {
@@ -909,7 +909,7 @@ internal static class Familiars
 
         if (prestigeData.FamiliarPrestige[familiarId] >= ConfigService.MaxFamiliarPrestiges)
         {
-            LocalizationService.Reply(ctx, $"Your familiar has already prestiged the maximum number of times! (<color=white>{ConfigService.MaxFamiliarPrestiges}</color>)");
+            LocalizationService.Reply(ctx, "Your familiar has already prestiged the maximum number of times! (<color=white>{0}</color>)", ConfigService.MaxFamiliarPrestiges);
             return;
         }
 
@@ -936,13 +936,13 @@ internal static class Familiars
                 }
                 else
                 {
-                    LocalizationService.Reply(ctx, $"Familiar already has <color=#00FFFF>{FamiliarPrestigeStats[value]}</color> (<color=yellow>{value + 1}</color>) from prestiging, use '<color=white>.fam lst</color>' to see options.");
+                    LocalizationService.Reply(ctx, "Familiar already has <color=#00FFFF>{0}</color> (<color=yellow>{1}</color>) from prestiging, use '<color=white>.fam lst</color>' to see options.", FamiliarPrestigeStats[value], value + 1);
                     return;
                 }
             }
             else
             {
-                LocalizationService.Reply(ctx, $"Invalid familiar prestige stat, use '<color=white>.fam lst</color>' to see options.");
+                LocalizationService.Reply(ctx, "Invalid familiar prestige stat, use '<color=white>.fam lst</color>' to see options.");
                 return;
             }
         }
@@ -962,7 +962,7 @@ internal static class Familiars
             Entity familiar = GetActiveFamiliar(playerCharacter);
             ModifyUnitStats(familiar, xpData.FamiliarExperience[familiarId].Key, steamId, familiarId);
 
-            LocalizationService.Reply(ctx, $"Your familiar has prestiged [<color=#90EE90>{prestigeLevel}</color>]; the accumulated knowledge allowed them to retain their level!");
+            LocalizationService.Reply(ctx, "Your familiar has prestiged [<color=#90EE90>{0}</color>]; the accumulated knowledge allowed them to retain their level!", prestigeLevel);
 
             /*
             if (value == -1)

--- a/Utilities/Misc.cs
+++ b/Utilities/Misc.cs
@@ -186,8 +186,8 @@ internal static class Misc
         public const string DAGGERS_KEY = nameof(WeaponType.Daggers);
         public const string CLAWS_KEY = nameof(WeaponType.Claws);
 
-        const string BAG_HEAVIER_MESSAGE = "Your bag feels slightly heavier...";
-        const string ITEM_DROPPED_MESSAGE = "Something fell out of your bag!";
+        public const string BAG_HEAVIER_MESSAGE = "Your bag feels slightly heavier...";
+        public const string ITEM_DROPPED_MESSAGE = "Something fell out of your bag!";
 
         public static readonly Dictionary<string, bool> DefaultBools = new()
         {

--- a/Utilities/Quests.cs
+++ b/Utilities/Quests.cs
@@ -106,7 +106,7 @@ internal static class Quests
 
             if (!targetCache.IsCreated || !targetCache.ContainsKey(questObjective.Objective.Target))
             {
-                LocalizationService.Reply(ctx, $"Targets have all been killed, give them a chance to respawn! If this doesn't seem right consider rerolling your {QuestTypeColor[questType]}.");
+                LocalizationService.Reply(ctx, "Targets have all been killed, give them a chance to respawn! If this doesn't seem right consider rerolling your {0}.", QuestTypeColor[questType]);
                 return;
             }
 
@@ -153,10 +153,8 @@ internal static class Quests
             float distance = math.distance(userPosition, targetPosition);
             float3 direction = math.normalize(targetPosition - userPosition);
             string cardinalDirection = $"<color=yellow>{GetCardinalDirection(direction)}</color>";
-            double seconds = (DateTime.UtcNow - QuestService._lastUpdate).TotalSeconds;
 
-            // LocalizationService.HandleReply(ctx, $"Nearest <color=white>{questObjective.Objective.Target.GetLocalizedName()}</color> was <color=#00FFFF>{(int)distance}</color>f away to the {cardinalDirection} <color=#F88380>{(int)seconds}</color>s ago.");
-            LocalizationService.Reply(ctx, $"Nearest <color=white>{questObjective.Objective.Target.GetLocalizedName()}</color> was <color=#00FFFF>{(int)distance}</color>f away to the {cardinalDirection}!");
+            LocalizationService.Reply(ctx, "Nearest <color=white>{0}</color> was <color=#00FFFF>{1}</color>f away to the {2}!", questObjective.Objective.Target.GetLocalizedName(), (int)distance, cardinalDirection);
         }
         else
         {
@@ -168,17 +166,28 @@ internal static class Quests
         if (questData.TryGetValue(questType, out var questObjective) && !questObjective.Objective.Complete)
         {
             string timeLeft = GetTimeUntilReset(questObjective, questType);
-            LocalizationService.Reply(ctx, $"{QuestTypeColor[questType]}: <color=green>{questObjective.Objective.Goal}</color> <color=white>{questObjective.Objective.Target.GetLocalizedName()}</color>x<color=#FFC0CB>{questObjective.Objective.RequiredAmount}</color> [<color=white>{questObjective.Progress}</color>/<color=yellow>{questObjective.Objective.RequiredAmount}</color>]");
-            LocalizationService.Reply(ctx, $"Time until {questType} reset - <color=yellow>{timeLeft}</color> | {_questTargetType[questObjective.Objective.Goal]} Prefab: <color=white>{questObjective.Objective.Target.GetPrefabName()}</color>");
+            LocalizationService.Reply(ctx,
+                "{0}: <color=green>{1}</color> <color=white>{2}</color>x<color=#FFC0CB>{3}</color> [<color=white>{4}</color>/<color=yellow>{3}</color>]",
+                QuestTypeColor[questType],
+                questObjective.Objective.Goal,
+                questObjective.Objective.Target.GetLocalizedName(),
+                questObjective.Objective.RequiredAmount,
+                questObjective.Progress);
+            LocalizationService.Reply(ctx,
+                "Time until {0} reset - <color=yellow>{1}</color> | {2} Prefab: <color=white>{3}</color>",
+                questType,
+                timeLeft,
+                _questTargetType[questObjective.Objective.Goal],
+                questObjective.Objective.Target.GetPrefabName());
         }
         else if (questObjective.Objective.Complete)
         {
             string timeLeft = GetTimeUntilReset(questObjective, questType);
-            LocalizationService.Reply(ctx, $"You've already completed your {QuestTypeColor[questType]}! Time until {questType} reset - <color=yellow>{timeLeft}</color>");
+            LocalizationService.Reply(ctx, "You've already completed your {0}! Time until {1} reset - <color=yellow>{2}</color>", QuestTypeColor[questType], questType, timeLeft);
         }
         else
         {
-            LocalizationService.Reply(ctx, $"You don't have a {QuestTypeColor[questType]}.");
+            LocalizationService.Reply(ctx, "You don't have a {0}.", QuestTypeColor[questType]);
         }
     }
     static string GetTimeUntilReset((QuestObjective Objective, int Progress, DateTime LastReset) questObjective, QuestType questType)


### PR DESCRIPTION
## Summary
- replace embedded code expressions in localization strings with format placeholders
- update message handlers to supply parameters explicitly

## Testing
- `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- generate-messages` *(failed: missing .NET 6 runtime)*

------
https://chatgpt.com/codex/tasks/task_e_689a1187fecc832d9b884901091310be