### PR TITLE
Ensure .NET 6 runtime is installed

### DIFF
--- a/.codex/install.sh
+++ b/.codex/install.sh
@@ -14,10 +14,16 @@ if ! command -v dotnet >/dev/null; then
     bash "$SCRIPT_DIR/dotnet-install.sh" --channel "$DOTNET_VERSION" --install-dir "$HOME/.dotnet"
 fi
 
-# Install .NET 6 targeting pack if not already present
+# Install .NET 6 SDK if not already present
 if ! dotnet --list-sdks 2>/dev/null | grep -q '^6\.'; then
-    echo "Installing .NET 6 targeting pack..."
+    echo "Installing .NET 6 SDK..."
     bash "$SCRIPT_DIR/dotnet-install.sh" --channel "6.0" --install-dir "$HOME/.dotnet" --no-path
+fi
+
+# Install .NET 6 runtime if missing
+if ! dotnet --list-runtimes 2>/dev/null | grep -q '^Microsoft.NETCore.App 6\.'; then
+    echo "Installing .NET 6 runtime..."
+    bash "$SCRIPT_DIR/dotnet-install.sh" --channel "6.0" --runtime "dotnet" --install-dir "$HOME/.dotnet" --no-path
 fi
 
 export DOTNET_ROOT="$HOME/.dotnet"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Jairon O.; Odjit; Jera; Kokuren TCG and Gaming Shop; Rexxn; Eduardo G.; DirtyMik
 
 ## Development setup
 
-Run `.codex/install.sh` once to install the .NET SDK and Argos Translate dependencies. See
+Run `.codex/install.sh` once to install the .NET SDK, the .NET 6 runtime, and Argos Translate dependencies. After running the script, verify the runtime with `dotnet --list-runtimes` and ensure `Microsoft.NETCore.App 6.0.x` is listed. See
 [AGENTS.md](AGENTS.md) for the full workflow. For instructions on customizing
 `FROM_LANG` and `TO_LANG`, jump to the [Localization](#localization-wip) section.
 
@@ -788,8 +788,8 @@ Run `.codex/install.sh` once to install the .NET SDK and Argos Translate depende
   
 ## Development Setup
 
-Run `.codex/install.sh` once to install the .NET SDK and Argos Translate. The script adds
-`~/.local/bin` to your `PATH` so the `argos-translate` CLI is available in future sessions.
+Run `.codex/install.sh` once to install the .NET SDK, the .NET 6 runtime, and Argos Translate. The script adds
+`~/.local/bin` to your `PATH` so the `argos-translate` CLI is available in future sessions. Confirm the runtime with `dotnet --list-runtimes` and look for `Microsoft.NETCore.App 6.0.x`.
 
 ## Localization (WIP)
 

--- a/dev_init.sh
+++ b/dev_init.sh
@@ -5,7 +5,7 @@ set -e
 BEPINEX_PLUGIN_DIR="/path/to/BepInEx/plugins"
 
 if ! command -v dotnet >/dev/null; then
-    echo ".NET SDK is required. Run .codex/install.sh first." >&2
+    echo ".NET SDK and .NET 6 runtime are required. Run .codex/install.sh first." >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Install .NET 6 runtime in `.codex/install.sh` when missing
- Note .NET 6 runtime requirement in setup docs and dev script

## Testing
- `bash .codex/install.sh`
- `dotnet --list-runtimes | head`
- `dotnet test Bloodcraft.Tests/Bloodcraft.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_689a1ee9ed38832d9b86e759ed3a74e1