### PR TITLE
Run token checks after translation

### DIFF
--- a/Tools/fix_tokens.py
+++ b/Tools/fix_tokens.py
@@ -103,15 +103,24 @@ def main() -> None:
     ap = argparse.ArgumentParser(description="Fix token placeholders in localization JSON files")
     ap.add_argument("--root", default=Path(__file__).resolve().parents[1], help="Repo root")
     ap.add_argument("--check-only", action="store_true", help="Report issues without modifying files")
+    ap.add_argument("paths", nargs="*", help="Specific localization JSON files to process")
     args = ap.parse_args()
 
     root = Path(args.root).resolve()
     messages_tokens = load_english_messages(root)
     node_tokens = load_english_nodes(root)
 
-    files = list((root / "Resources" / "Localization" / "Messages").glob("*.json"))
-    files = [p for p in files if p.name != "English.json"]
-    files += [p for p in (root / "Resources" / "Localization").glob("*.json") if p.name != "English.json"]
+    if args.paths:
+        files = []
+        for p in args.paths:
+            path = Path(p)
+            if not path.is_absolute():
+                path = (root / path).resolve()
+            files.append(path)
+    else:
+        files = list((root / "Resources" / "Localization" / "Messages").glob("*.json"))
+        files = [p for p in files if p.name != "English.json"]
+        files += [p for p in (root / "Resources" / "Localization").glob("*.json") if p.name != "English.json"]
 
     issues = False
     for path in files:

--- a/Tools/translate_argos.py
+++ b/Tools/translate_argos.py
@@ -308,15 +308,16 @@ def main():
     with open(target_path, "w", encoding="utf-8") as f:
         json.dump(target, f, indent=2, ensure_ascii=False)
 
-    subprocess.run(
+    result = subprocess.run(
         [
             sys.executable,
             os.path.join(os.path.dirname(__file__), "fix_tokens.py"),
-            "--root",
-            root,
-        ],
-        check=True,
+            "--check-only",
+            target_path,
+        ]
     )
+    if result.returncode != 0:
+        raise SystemExit(result.returncode)
 
     print(f"Wrote translations to {target_path}")
 
@@ -340,9 +341,15 @@ def main():
         print(f"Wrote skip report to {args.report_file}")
 
     if skipped:
-        print("Skipped the following message hashes due to repeated errors:")
-        for k in skipped:
-            print(f" - {k}")
+        if args.report_file and os.path.exists(args.report_file):
+            print("Untranslated message hashes detected:")
+            with open(args.report_file, "r", encoding="utf-8") as fp:
+                print(fp.read())
+        else:
+            print("Skipped the following message hashes due to repeated errors:")
+            for k in skipped:
+                print(f" - {k}")
+        raise SystemExit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- call `fix_tokens.py` in check-only mode for the translated file
- exit when token placeholders remain or when skipped hashes are reported
- allow `fix_tokens.py` to target specific localization files and expand tests

## Testing
- `pytest`
- `dotnet test` *(fails: You must install or update .NET to run this application)*

------
https://chatgpt.com/codex/tasks/task_e_689adf88a538832dbf7954d8c1ab6d01