### PR TITLE
feat: add binding failed message

### DIFF
--- a/Resources/Localization/Messages/Brazilian.json
+++ b/Resources/Localization/Messages/Brazilian.json
@@ -400,7 +400,8 @@
     "2471836655": "Couldn't find familiar to unbind! If this doesn't seem right try using '<color=white>.fam reset</color>'.",
     "2814501768": "<color=green>{0}</color>{1}*</color> <color=#FFC0CB>unbound</color>!",
     "3987763597": "<color=green>{0}</color> <color=#FFC0CB>unbound</color>!",
-    "2772168133": "{0}[<color=white>{1}</color>]"
+    "2772168133": "{0}[<color=white>{1}</color>]",
+    "binding-failed": "A ligação falhou..."
   },
   "_meta": {
     "1716911803": "Intencionalmente idêntico ao inglês; placeholder dinâmico"

--- a/Resources/Localization/Messages/English.json
+++ b/Resources/Localization/Messages/English.json
@@ -1,6 +1,7 @@
 {
   "Messages": {
     "welcome": "Welcome to Bloodcraft",
+    "binding-failed": "Binding failed...",
     "profession-improved": "{0} improved to [\u003Ccolor=white\u003E{1}\u003C/color\u003E]",
     "profession-proficiency-gain": "\u002B\u003Ccolor=yellow\u003E{0}\u003C/color\u003E \u003Ccolor=#FFC0CB\u003Eproficiency\u003C/color\u003E in {1} (\u003Ccolor=white\u003E{2}%\u003C/color\u003E)",
     "profession-bonus-received": "\u003Ccolor=green\u003E{0}\u003C/color\u003Ex\u003Ccolor=white\u003E{1}\u003C/color\u003E received from {2}",

--- a/Resources/Localization/Messages/French.json
+++ b/Resources/Localization/Messages/French.json
@@ -400,6 +400,7 @@
     "2471836655": "Couldn't find familiar to unbind! If this doesn't seem right try using '<color=white>.fam reset</color>'.",
     "2814501768": "<color=green>{0}</color>{1}*</color> <color=#FFC0CB>unbound</color>!",
     "3987763597": "<color=green>{0}</color> <color=#FFC0CB>unbound</color>!",
-    "2772168133": "{0}[<color=white>{1}</color>]"
+    "2772168133": "{0}[<color=white>{1}</color>]",
+    "binding-failed": "La reliure a échoué..."
   }
 }

--- a/Resources/Localization/Messages/German.json
+++ b/Resources/Localization/Messages/German.json
@@ -400,6 +400,7 @@
     "2471836655": "Couldn't find familiar to unbind! If this doesn't seem right try using '<color=white>.fam reset</color>'.",
     "2814501768": "<color=green>{0}</color>{1}*</color> <color=#FFC0CB>unbound</color>!",
     "3987763597": "<color=green>{0}</color> <color=#FFC0CB>unbound</color>!",
-    "2772168133": "{0}[<color=white>{1}</color>]"
+    "2772168133": "{0}[<color=white>{1}</color>]",
+    "binding-failed": "Bindung fehlgeschlagen..."
   }
 }

--- a/Resources/Localization/Messages/Hungarian.json
+++ b/Resources/Localization/Messages/Hungarian.json
@@ -400,6 +400,7 @@
     "2471836655": "Couldn't find familiar to unbind! If this doesn't seem right try using '<color=white>.fam reset</color>'.",
     "2814501768": "<color=green>{0}</color>{1}*</color> <color=#FFC0CB>unbound</color>!",
     "3987763597": "<color=green>{0}</color> <color=#FFC0CB>unbound</color>!",
-    "2772168133": "{0}[<color=white>{1}</color>]"
+    "2772168133": "{0}[<color=white>{1}</color>]",
+    "binding-failed": "A kötés meghibásodott..."
   }
 }

--- a/Resources/Localization/Messages/Italian.json
+++ b/Resources/Localization/Messages/Italian.json
@@ -400,6 +400,7 @@
     "2471836655": "Couldn't find familiar to unbind! If this doesn't seem right try using '<color=white>.fam reset</color>'.",
     "2814501768": "<color=green>{0}</color>{1}*</color> <color=#FFC0CB>unbound</color>!",
     "3987763597": "<color=green>{0}</color> <color=#FFC0CB>unbound</color>!",
-    "2772168133": "{0}[<color=white>{1}</color>]"
+    "2772168133": "{0}[<color=white>{1}</color>]",
+    "binding-failed": "Binding non è riuscito..."
   }
 }

--- a/Resources/Localization/Messages/Japanese.json
+++ b/Resources/Localization/Messages/Japanese.json
@@ -400,6 +400,7 @@
     "2471836655": "Couldn't find familiar to unbind! If this doesn't seem right try using '<color=white>.fam reset</color>'.",
     "2814501768": "<color=green>{0}</color>{1}*</color> <color=#FFC0CB>unbound</color>!",
     "3987763597": "<color=green>{0}</color> <color=#FFC0CB>unbound</color>!",
-    "2772168133": "{0}[<color=white>{1}</color>]"
+    "2772168133": "{0}[<color=white>{1}</color>]",
+    "binding-failed": "バインディングが失敗しました..."
   }
 }

--- a/Resources/Localization/Messages/Korean.json
+++ b/Resources/Localization/Messages/Korean.json
@@ -400,7 +400,8 @@
     "2471836655": "Couldn't find familiar to unbind! If this doesn't seem right try using '<color=white>.fam reset</color>'.",
     "2814501768": "<color=green>{0}</color>{1}*</color> <color=#FFC0CB>unbound</color>!",
     "3987763597": "<color=green>{0}</color> <color=#FFC0CB>unbound</color>!",
-    "2772168133": "{0}[<color=white>{1}</color>]"
+    "2772168133": "{0}[<color=white>{1}</color>]",
+    "binding-failed": "바인딩 실패..."
   },
   "_meta": {
     "1716911803": "Intentionally identical to English; dynamic placeholder"

--- a/Resources/Localization/Messages/Latam.json
+++ b/Resources/Localization/Messages/Latam.json
@@ -400,7 +400,8 @@
     "2471836655": "Couldn't find familiar to unbind! If this doesn't seem right try using '<color=white>.fam reset</color>'.",
     "2814501768": "<color=green>{0}</color>{1}*</color> <color=#FFC0CB>unbound</color>!",
     "3987763597": "<color=green>{0}</color> <color=#FFC0CB>unbound</color>!",
-    "2772168133": "{0}[<color=white>{1}</color>]"
+    "2772168133": "{0}[<color=white>{1}</color>]",
+    "binding-failed": "La vinculación falló..."
   },
   "_meta": {
     "1716911803": "Intentionally identical to English; dynamic placeholder",

--- a/Resources/Localization/Messages/Polish.json
+++ b/Resources/Localization/Messages/Polish.json
@@ -400,7 +400,8 @@
     "2471836655": "Couldn't find familiar to unbind! If this doesn't seem right try using '<color=white>.fam reset</color>'.",
     "2814501768": "<color=green>{0}</color>{1}*</color> <color=#FFC0CB>unbound</color>!",
     "3987763597": "<color=green>{0}</color> <color=#FFC0CB>unbound</color>!",
-    "2772168133": "{0}[<color=white>{1}</color>]"
+    "2772168133": "{0}[<color=white>{1}</color>]",
+    "binding-failed": "Wiązanie nie powiodło się..."
   },
   "_meta": {
     "1716911803": "Intentionally identical to English; dynamic placeholder"

--- a/Resources/Localization/Messages/Russian.json
+++ b/Resources/Localization/Messages/Russian.json
@@ -400,6 +400,7 @@
     "2471836655": "Couldn't find familiar to unbind! If this doesn't seem right try using '<color=white>.fam reset</color>'.",
     "2814501768": "<color=green>{0}</color>{1}*</color> <color=#FFC0CB>unbound</color>!",
     "3987763597": "<color=green>{0}</color> <color=#FFC0CB>unbound</color>!",
-    "2772168133": "{0}[<color=white>{1}</color>]"
+    "2772168133": "{0}[<color=white>{1}</color>]",
+    "binding-failed": "Переплет не удался..."
   }
 }

--- a/Resources/Localization/Messages/SChinese.json
+++ b/Resources/Localization/Messages/SChinese.json
@@ -400,6 +400,7 @@
     "2471836655": "Couldn't find familiar to unbind! If this doesn't seem right try using '<color=white>.fam reset</color>'.",
     "2814501768": "<color=green>{0}</color>{1}*</color> <color=#FFC0CB>unbound</color>!",
     "3987763597": "<color=green>{0}</color> <color=#FFC0CB>unbound</color>!",
-    "2772168133": "{0}[<color=white>{1}</color>]"
+    "2772168133": "{0}[<color=white>{1}</color>]",
+    "binding-failed": "约束失败..."
   }
 }

--- a/Resources/Localization/Messages/Spanish.json
+++ b/Resources/Localization/Messages/Spanish.json
@@ -400,7 +400,8 @@
     "2471836655": "Couldn't find familiar to unbind! If this doesn't seem right try using '<color=white>.fam reset</color>'.",
     "2814501768": "<color=green>{0}</color>{1}*</color> <color=#FFC0CB>unbound</color>!",
     "3987763597": "<color=green>{0}</color> <color=#FFC0CB>unbound</color>!",
-    "2772168133": "{0}[<color=white>{1}</color>]"
+    "2772168133": "{0}[<color=white>{1}</color>]",
+    "binding-failed": "La vinculación falló..."
   },
   "_meta": {
     "1716911803": "Intentionally identical to English; dynamic placeholder"

--- a/Resources/Localization/Messages/TChinese.json
+++ b/Resources/Localization/Messages/TChinese.json
@@ -400,7 +400,8 @@
     "2471836655": "Couldn't find familiar to unbind! If this doesn't seem right try using '<color=white>.fam reset</color>'.",
     "2814501768": "<color=green>{0}</color>{1}*</color> <color=#FFC0CB>unbound</color>!",
     "3987763597": "<color=green>{0}</color> <color=#FFC0CB>unbound</color>!",
-    "2772168133": "{0}[<color=white>{1}</color>]"
+    "2772168133": "{0}[<color=white>{1}</color>]",
+    "binding-failed": "約束失敗..."
   },
   "_meta": {
     "1716911803": "Intentionally identical to English; dynamic placeholder"

--- a/Resources/Localization/Messages/Thai.json
+++ b/Resources/Localization/Messages/Thai.json
@@ -400,6 +400,7 @@
     "2471836655": "Couldn't find familiar to unbind! If this doesn't seem right try using '<color=white>.fam reset</color>'.",
     "2814501768": "<color=green>{0}</color>{1}*</color> <color=#FFC0CB>unbound</color>!",
     "3987763597": "<color=green>{0}</color> <color=#FFC0CB>unbound</color>!",
-    "2772168133": "{0}[<color=white>{1}</color>]"
+    "2772168133": "{0}[<color=white>{1}</color>]",
+    "binding-failed": "การผูกมัดล้มเหลว..."
   }
 }

--- a/Resources/Localization/Messages/Turkish.json
+++ b/Resources/Localization/Messages/Turkish.json
@@ -400,6 +400,7 @@
     "2471836655": "Couldn't find familiar to unbind! If this doesn't seem right try using '<color=white>.fam reset</color>'.",
     "2814501768": "<color=green>{0}</color>{1}*</color> <color=#FFC0CB>unbound</color>!",
     "3987763597": "<color=green>{0}</color> <color=#FFC0CB>unbound</color>!",
-    "2772168133": "{0}[<color=white>{1}</color>]"
+    "2772168133": "{0}[<color=white>{1}</color>]",
+    "binding-failed": "Bağlayıcı başarısız oldu..."
   }
 }

--- a/Resources/Localization/Messages/Ukrainian.json
+++ b/Resources/Localization/Messages/Ukrainian.json
@@ -400,7 +400,8 @@
     "2471836655": "Couldn't find familiar to unbind! If this doesn't seem right try using '<color=white>.fam reset</color>'.",
     "2814501768": "<color=green>{0}</color>{1}*</color> <color=#FFC0CB>unbound</color>!",
     "3987763597": "<color=green>{0}</color> <color=#FFC0CB>unbound</color>!",
-    "2772168133": "{0}[<color=white>{1}</color>]"
+    "2772168133": "{0}[<color=white>{1}</color>]",
+    "binding-failed": "Не вдалося обов'язково..."
   },
   "_meta": {
     "1716911803": "Intentionally identical to English; dynamic placeholder",

--- a/Resources/Localization/Messages/Vietnamese.json
+++ b/Resources/Localization/Messages/Vietnamese.json
@@ -400,7 +400,8 @@
     "2471836655": "Couldn't find familiar to unbind! If this doesn't seem right try using '<color=white>.fam reset</color>'.",
     "2814501768": "<color=green>{0}</color>{1}*</color> <color=#FFC0CB>unbound</color>!",
     "3987763597": "<color=green>{0}</color> <color=#FFC0CB>unbound</color>!",
-    "2772168133": "{0}[<color=white>{1}</color>]"
+    "2772168133": "{0}[<color=white>{1}</color>]",
+    "binding-failed": "Binding thất bại..."
   },
   "_meta": {
     "1716911803": "Intentionally identical to English; dynamic placeholder"

--- a/Systems/Familiars/FamiliarBindingSystem.cs
+++ b/Systems/Familiars/FamiliarBindingSystem.cs
@@ -64,6 +64,8 @@ internal static class FamiliarBindingSystem
 
     const string SHINY_DEFAULT = "<color=#FF69B4>";
 
+    const string BINDING_FAILED_MESSAGE = "Binding failed...";
+
     static readonly int _maxFamiliarLevel = ConfigService.MaxFamiliarLevel;
     static readonly float _familiarPrestigeStatMultiplier = ConfigService.FamiliarPrestigeStatMultiplier;
 
@@ -239,7 +241,7 @@ internal static class FamiliarBindingSystem
                 else
                 {
                     familiar.Destroy();
-                    LocalizationService.Reply(EntityManager, user, "Binding failed...");
+                    LocalizationService.Reply(EntityManager, user, BINDING_FAILED_MESSAGE);
 
                     return false;
                 }


### PR DESCRIPTION
## Summary
- localize familiar binding failure message
- translate binding failure across supported languages

## Testing
- `python Tools/fix_tokens.py --check-only`
- `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations --show-text`


------
https://chatgpt.com/codex/tasks/task_e_689cb73249f4832d876885b88cb6c08c