### PR TITLE
chore: localize familiar unlock messages

### DIFF
--- a/Commands/FamiliarCommands.cs
+++ b/Commands/FamiliarCommands.cs
@@ -478,14 +478,14 @@ internal static class FamiliarCommands
                             unlocksData.FamiliarUnlocks[lastBoxName].Add(vBloodPrefabGuid.GuidHash);
 
                             SaveFamiliarUnlocksData(steamId, unlocksData);
-                            LocalizationService.Reply(ctx, "New unit unlocked: <color=green>{0}</color>", vBloodPrefabGuid.GetLocalizedName());
+                            LocalizationService.Reply(ctx, NEW_UNIT_UNLOCKED_MESSAGE, vBloodPrefabGuid.GetLocalizedName());
                         }
                         else if (unlocksData.FamiliarUnlocks.ContainsKey(lastBoxName))
                         {
                             unlocksData.FamiliarUnlocks[lastBoxName].Add(vBloodPrefabGuid.GuidHash);
 
                             SaveFamiliarUnlocksData(steamId, unlocksData);
-                            LocalizationService.Reply(ctx, "New unit unlocked: <color=green>{0}</color>", vBloodPrefabGuid.GetLocalizedName());
+                            LocalizationService.Reply(ctx, NEW_UNIT_UNLOCKED_MESSAGE, vBloodPrefabGuid.GetLocalizedName());
                         }
                     }
                 }

--- a/Resources/Localization/Messages/Brazilian.json
+++ b/Resources/Localization/Messages/Brazilian.json
@@ -324,6 +324,7 @@
     "4226920647": "<color=white>{0}</color> is not available per configured familiar bans!",
     "1695244872": "<color=white>{0}</color> is already unlocked!",
     "2428442751": "New unit unlocked: <color=green>{0}</color>",
+    "1271017097": "New <color=#00FFFF>shiny</color> unit unlocked: <color=green>{0}</color>",
     "3938781329": "Não é suficiente <color=#ffd9eb>{0}</color>x<color=white>{1}</color>{2}!",
     "3139406824": "<color=green>{0}</color><color=white>{1}</color>.",
     "3055272330": "A tentativa familiar de prestígio deve estar no nível máximo (<color=white>{0}</color> ou requer <color=#ffd9eb>{1}</color><color=yellow>x</color><color=white>{2}</color>.",

--- a/Resources/Localization/Messages/English.json
+++ b/Resources/Localization/Messages/English.json
@@ -325,6 +325,7 @@
     "4226920647": "\u003Ccolor=white\u003E{0}\u003C/color\u003E is not available per configured familiar bans!",
     "1695244872": "\u003Ccolor=white\u003E{0}\u003C/color\u003E is already unlocked!",
     "2428442751": "New unit unlocked: \u003Ccolor=green\u003E{0}\u003C/color\u003E",
+    "1271017097": "New \u003Ccolor=#00FFFF\u003Eshiny\u003C/color\u003E unit unlocked: \u003Ccolor=green\u003E{0}\u003C/color\u003E",
     "3938781329": "Not enough \u003Ccolor=#ffd9eb\u003E{0}\u003C/color\u003Ex\u003Ccolor=white\u003E{1}\u003C/color\u003E for {2}!",
     "3139406824": "\u003Ccolor=green\u003E{0}\u003C/color\u003E removed from \u003Ccolor=white\u003E{1}\u003C/color\u003E.",
     "3055272330": "Familiar attempting to prestige must be at max level (\u003Ccolor=white\u003E{0}\u003C/color\u003E) or requires \u003Ccolor=#ffd9eb\u003E{1}\u003C/color\u003E\u003Ccolor=yellow\u003Ex\u003C/color\u003E\u003Ccolor=white\u003E{2}\u003C/color\u003E.",

--- a/Resources/Localization/Messages/French.json
+++ b/Resources/Localization/Messages/French.json
@@ -324,6 +324,7 @@
     "4226920647": "<color=white>{0}</color> n'est pas disponible par interdictions familières configurées!",
     "1695244872": "<color=white>{0}</color> est déjà déverrouillé!",
     "2428442751": "Nouvelle unité déverrouillée: <color=green>{0}</color>",
+    "1271017097": "New <color=#00FFFF>shiny</color> unit unlocked: <color=green>{0}</color>",
     "3938781329": "Pas assez <color=#ffd9eb>{0}</color>x<color=white>{1}</color> pour {2}!",
     "3139406824": "<color=green>{0}</color> enlevé de <color=white>{1}</color>.",
     "3055272330": "Familiar attempting to prestige must be at max level (<color=white>{0}</color>) or requires <color=#ffd9eb>{1}</color><color=yellow>x</color><color=white>{2}</color>.",

--- a/Resources/Localization/Messages/German.json
+++ b/Resources/Localization/Messages/German.json
@@ -324,6 +324,7 @@
     "4226920647": "<color=white>{0}</color> ist nicht pro konfigurierten vertrauten Verboten verfügbar!",
     "1695244872": "<color=white>{0}</color> ist bereits entriegelt!",
     "2428442751": "Neue Einheit entsperrt: <color=green>{0}</color>",
+    "1271017097": "New <color=#00FFFF>shiny</color> unit unlocked: <color=green>{0}</color>",
     "3938781329": "Not enough <color=#ffd9eb>{0}</color>x<color=white>{1}</color> for {2}!",
     "3139406824": "<color=green>{0}</color> removed from <color=white>{1}</color>.",
     "3055272330": "Familiar attempting to prestige must be at max level (<color=white>{0}</color>) or requires <color=#ffd9eb>{1}</color><color=yellow>x</color><color=white>{2}</color>.",

--- a/Resources/Localization/Messages/Hungarian.json
+++ b/Resources/Localization/Messages/Hungarian.json
@@ -324,6 +324,7 @@
     "4226920647": "<color=white>{0}</color> is not available per configured familiar bans!",
     "1695244872": "<color=white>{0}</color> is already unlocked!",
     "2428442751": "New unit unlocked: <color=green>{0}</color>",
+    "1271017097": "New <color=#00FFFF>shiny</color> unit unlocked: <color=green>{0}</color>",
     "3938781329": "Not enough <color=#ffd9eb>{0}</color>x<color=white>{1}</color> for {2}!",
     "3139406824": "<color=green>{0}</color> removed from <color=white>{1}</color>.",
     "3055272330": "Familiar attempting to prestige must be at max level (<color=white>{0}</color>) or requires <color=#ffd9eb>{1}</color><color=yellow>x</color><color=white>{2}</color>.",

--- a/Resources/Localization/Messages/Italian.json
+++ b/Resources/Localization/Messages/Italian.json
@@ -324,6 +324,7 @@
     "4226920647": "<color=white>{0}</color> is not available per configured familiar bans!",
     "1695244872": "<color=white>{0}</color> è già sbloccato!",
     "2428442751": "Nuova unità sbloccata: <color=green>{0}</color>",
+    "1271017097": "New <color=#00FFFF>shiny</color> unit unlocked: <color=green>{0}</color>",
     "3938781329": "<color=#ffd9eb>{0}</color><color=white>{1}</color> per {2}!",
     "3139406824": "<color=green>{0}</color> rimosso da <color=white>{1}</color>.",
     "3055272330": "Familiar attempting to prestige must be at max level (<color=white>{0}</color>) or requires <color=#ffd9eb>{1}</color><color=yellow>x</color><color=white>{2}</color>.",

--- a/Resources/Localization/Messages/Japanese.json
+++ b/Resources/Localization/Messages/Japanese.json
@@ -324,6 +324,7 @@
     "4226920647": "<color=white>{0}</color>は、設定された馴染みの禁止ごとに利用できません!",
     "1695244872": "<color=white>{0}</color>は既に解除されています!",
     "2428442751": "<color=green>{0}</color>の新規ユニットをロック解除",
+    "1271017097": "New <color=#00FFFF>shiny</color> unit unlocked: <color=green>{0}</color>",
     "3938781329": "<color=#ffd9eb>{0}</color>x<color=white>{1}</color>の{2}の{2}の{2}の</color>の{2}のトークン、トークン、",
     "3139406824": "<color=green>{0}</color>から削除された<color=white>{1}</color>。",
     "3055272330": "仮説しようとするファミリアは、最大レベル(<color=white>{0}</color>)で、または<color=#ffd9eb>{1}</color><color=yellow>x</color><color=white>{2}</color>でなければならない。",

--- a/Resources/Localization/Messages/Korean.json
+++ b/Resources/Localization/Messages/Korean.json
@@ -324,6 +324,7 @@
     "4226920647": "<color=white>{0}</color> 은 익숙한 금지에 대해 사용할 수 없습니다!",
     "1695244872": "<color=white>{0}</color> 이미 잠금 해제!",
     "2428442751": "새로운 단위 잠금 해제: <color=green>{0}</color>",
+    "1271017097": "New <color=#00FFFF>shiny</color> unit unlocked: <color=green>{0}</color>",
     "3938781329": "<color=#ffd9eb>{0}</color>x<color=white>{1}</color>{2}",
     "3139406824": "<color=green>{0}</color><color=white>{1}</color></color></color></color></color></color></color></color></color></color></color></color></color></color>TOKEN_<color=white>TOKEN_<color=white>TOKEN_<color=white>",
     "3055272330": "<color=white>{0}</color><color=#ffd9eb><color=#ffd9eb>{1}</color><color=yellow>x</color><color=white>{2}</color></color></color></color>{2}</color></color>{2} TOKEN_{2} TOKEN_{2}{2}{2} TOKEN_TOKEN_TOKEN_{2}{2}",

--- a/Resources/Localization/Messages/Latam.json
+++ b/Resources/Localization/Messages/Latam.json
@@ -324,6 +324,7 @@
     "4226920647": "<color=white>{0}</color> no está disponible por las prohibiciones familiares configuradas!",
     "1695244872": "<color=white>{0}</color> ya está desbloqueado!",
     "2428442751": "Nueva unidad desbloqueada: <color=green>{0}</color>",
+    "1271017097": "New <color=#00FFFF>shiny</color> unit unlocked: <color=green>{0}</color>",
     "3938781329": "<color=#ffd9eb>{0}</color>x<color=white>{1}</color></color>{2}!",
     "3139406824": "<color=green>{0}</color><color=white>{1}</color>.",
     "3055272330": "Familiar attempting to prestige must be at max level (<color=white>{0}</color>) or requires <color=#ffd9eb>{1}</color><color=yellow>x</color><color=white>{2}</color>.",

--- a/Resources/Localization/Messages/Polish.json
+++ b/Resources/Localization/Messages/Polish.json
@@ -324,6 +324,7 @@
     "4226920647": "<color=white>{0}</color> nie jest dostępny dla konfigurowanych, znanych zakazów!",
     "1695244872": "<color=white>{0}</color> jest już otwarty!",
     "2428442751": "<color=green>{0}</color>",
+    "1271017097": "New <color=#00FFFF>shiny</color> unit unlocked: <color=green>{0}</color>",
     "3938781329": "Za mało <color=#ffd9eb>{0}</color> x <color=white>{1}</color> dla {2}!",
     "3139406824": "<color=green>{0}</color> usunięte z <color=white>{1}</color>.",
     "3055272330": "Familiar attempting to prestige must be at max level (<color=white>{0}</color>) or requires <color=#ffd9eb>{1}</color><color=yellow>x</color><color=white>{2}</color>.",

--- a/Resources/Localization/Messages/Russian.json
+++ b/Resources/Localization/Messages/Russian.json
@@ -324,6 +324,7 @@
     "4226920647": "<color=white>{0}</color> is not available per configured familiar bans!",
     "1695244872": "<color=white>{0}</color> is already unlocked!",
     "2428442751": "New unit unlocked: <color=green>{0}</color>",
+    "1271017097": "New <color=#00FFFF>shiny</color> unit unlocked: <color=green>{0}</color>",
     "3938781329": "Not enough <color=#ffd9eb>{0}</color>x<color=white>{1}</color> for {2}!",
     "3139406824": "<color=green>{0}</color> removed from <color=white>{1}</color>.",
     "3055272330": "Familiar attempting to prestige must be at max level (<color=white>{0}</color>) or requires <color=#ffd9eb>{1}</color><color=yellow>x</color><color=white>{2}</color>.",

--- a/Resources/Localization/Messages/SChinese.json
+++ b/Resources/Localization/Messages/SChinese.json
@@ -324,6 +324,7 @@
     "4226920647": "<color=white>{0}</color> 按配置的熟悉禁令不可用!",
     "1695244872": "<color=white>{0}</color> 已经解锁了!",
     "2428442751": "新单元解锁: <color=green>{0} </color>",
+    "1271017097": "New <color=#00FFFF>shiny</color> unit unlocked: <color=green>{0}</color>",
     "3938781329": "<color=#ffd9eb>{0}</color>x <color=white>{1}</color>,用于{2}!",
     "3139406824": "<color=green>{0}</color>从<color=white>{1}</color>中移除。",
     "3055272330": "试图获得声望的熟悉者必须达到最高水平(<color=white>{0}</color>),或要求<color=#ffd9eb>{1}</color><color=yellow>x</color><color=white>{2}</color>。",

--- a/Resources/Localization/Messages/Spanish.json
+++ b/Resources/Localization/Messages/Spanish.json
@@ -324,6 +324,7 @@
     "4226920647": "<color=white>{0}</color> no está disponible por las prohibiciones familiares configuradas!",
     "1695244872": "<color=white>{0}</color> ya está desbloqueado!",
     "2428442751": "Nueva unidad desbloqueada: <color=green>{0}</color>",
+    "1271017097": "New <color=#00FFFF>shiny</color> unit unlocked: <color=green>{0}</color>",
     "3938781329": "<color=#ffd9eb>{0}</color>x<color=white>{1}</color></color>{2}!",
     "3139406824": "<color=green>{0}</color><color=white>{1}</color>.",
     "3055272330": "Familiar attempting to prestige must be at max level (<color=white>{0}</color>) or requires <color=#ffd9eb>{1}</color><color=yellow>x</color><color=white>{2}</color>.",

--- a/Resources/Localization/Messages/TChinese.json
+++ b/Resources/Localization/Messages/TChinese.json
@@ -324,6 +324,7 @@
     "4226920647": "<color=white>{0}</color>不可用每一個設定的熟悉的禁止!",
     "1695244872": "<color=white>{0}</color> 已經解鎖了!",
     "2428442751": "新單位解鎖 : <color=green> {0} </color>",
+    "1271017097": "New <color=#00FFFF>shiny</color> unit unlocked: <color=green>{0}</color>",
     "3938781329": "Not enough <color=#ffd9eb>{0}</color>x<color=white>{1}</color> for {2}!",
     "3139406824": "<color=green>{0}</color> 被移出<color=white>{1}</color>。",
     "3055272330": "想要聲望的熟人必須在最大水平(<color=white>{0}</color>)或需要<color=#ffd9eb>{1}</color><color=yellow>x</color><color=white>{2}</color>)。",

--- a/Resources/Localization/Messages/Thai.json
+++ b/Resources/Localization/Messages/Thai.json
@@ -324,6 +324,7 @@
     "4226920647": "<color=white>{0}</color> is not available per configured familiar bans!",
     "1695244872": "<color=white>{0}</color> is already unlocked!",
     "2428442751": "New unit unlocked: <color=green>{0}</color>",
+    "1271017097": "New <color=#00FFFF>shiny</color> unit unlocked: <color=green>{0}</color>",
     "3938781329": "Not enough <color=#ffd9eb>{0}</color>x<color=white>{1}</color> for {2}!",
     "3139406824": "<color=green>{0}</color> removed from <color=white>{1}</color>.",
     "3055272330": "Familiar attempting to prestige must be at max level (<color=white>{0}</color>) or requires <color=#ffd9eb>{1}</color><color=yellow>x</color><color=white>{2}</color>.",

--- a/Resources/Localization/Messages/Turkish.json
+++ b/Resources/Localization/Messages/Turkish.json
@@ -324,6 +324,7 @@
     "4226920647": "<color=white>{0}</color> is not available per configured familiar bans!",
     "1695244872": "<color=white>{0}</color> is already unlocked!",
     "2428442751": "Yeni bir birim ortaya çıktı: <color=green>{0}</color>).",
+    "1271017097": "New <color=#00FFFF>shiny</color> unit unlocked: <color=green>{0}</color>",
     "3938781329": "Not enough <color=#ffd9eb>{0}</color>x<color=white>{1}</color> for {2}!",
     "3139406824": "<color=green>{0}</color> removed from <color=white>{1}</color>.",
     "3055272330": "Familiar attempting to prestige must be at max level (<color=white>{0}</color>) or requires <color=#ffd9eb>{1}</color><color=yellow>x</color><color=white>{2}</color>.",

--- a/Resources/Localization/Messages/Ukrainian.json
+++ b/Resources/Localization/Messages/Ukrainian.json
@@ -324,6 +324,7 @@
     "4226920647": "<color=white>{0}</color> не доступний для налаштованих знайомих банок!",
     "1695244872": "<color=white>{0}</color> вже розблоковано!",
     "2428442751": "<color=green>{0}</color>",
+    "1271017097": "New <color=#00FFFF>shiny</color> unit unlocked: <color=green>{0}</color>",
     "3938781329": "<color=#ffd9eb>{0}</color> кс<color=white>{1}</color></color>{2}!",
     "3139406824": "<color=green>{0}</color><color=white>{1}</color>.",
     "3055272330": "Фамілярна спроба престижу повинна бути на максимальному рівні (<color=white>{0}</color>) або вимагає <color=#ffd9eb>{1}</color><color=yellow> кс</color><color=white>{2}{2}</color>.",

--- a/Resources/Localization/Messages/Vietnamese.json
+++ b/Resources/Localization/Messages/Vietnamese.json
@@ -324,6 +324,7 @@
     "4226920647": "<color=white>{0}</color> is not available per configured familiar bans!",
     "1695244872": "<color=white>{0}</color> is already unlocked!",
     "2428442751": "New unit unlocked: <color=green>{0}</color>",
+    "1271017097": "New <color=#00FFFF>shiny</color> unit unlocked: <color=green>{0}</color>",
     "3938781329": "Not enough <color=#ffd9eb>{0}</color>x<color=white>{1}</color> for {2}!",
     "3139406824": "<color=green>{0}</color> removed from <color=white>{1}</color>.",
     "3055272330": "Familiar attempting to prestige must be at max level (<color=white>{0}</color>) or requires <color=#ffd9eb>{1}</color><color=yellow>x</color><color=white>{2}</color>.",

--- a/Systems/Familiars/FamiliarUnlockSystem.cs
+++ b/Systems/Familiars/FamiliarUnlockSystem.cs
@@ -25,6 +25,9 @@ internal static class FamiliarUnlockSystem
     static readonly bool _shareUnlocks = ConfigService.ShareUnlocks;
     static readonly bool _allowVBloods = ConfigService.AllowVBloods;
 
+    public const string NEW_UNIT_UNLOCKED_MESSAGE = "New unit unlocked: <color=green>{0}</color>";
+    public const string NEW_SHINY_UNIT_UNLOCKED_MESSAGE = "New <color=#00FFFF>shiny</color> unit unlocked: <color=green>{0}</color>";
+
     static readonly PrefabGUID _familiarUnlockBuff = PrefabGUIDs.AB_HighLordSword_SelfStun_DeadBuff;
 
     public static readonly HashSet<PrefabGUID> ConfiguredPrefabGuidBans = [];
@@ -169,11 +172,11 @@ internal static class FamiliarUnlockSystem
 
             if (!isShiny)
             {
-                LocalizationService.Reply(EntityManager, user, "New unit unlocked: <color=green>{0}</color>", targetPrefabGuid.GetLocalizedName());
+                LocalizationService.Reply(EntityManager, user, NEW_UNIT_UNLOCKED_MESSAGE, targetPrefabGuid.GetLocalizedName());
             }
             else if (isShiny)
             {
-                LocalizationService.Reply(EntityManager, user, "New <color=#00FFFF>shiny</color> unit unlocked: <color=green>{0}</color>", targetPrefabGuid.GetLocalizedName());
+                LocalizationService.Reply(EntityManager, user, NEW_SHINY_UNIT_UNLOCKED_MESSAGE, targetPrefabGuid.GetLocalizedName());
             }
         }
         else if (isShiny)


### PR DESCRIPTION
## Summary
- define constants for normal and shiny familiar unlock messages
- add shiny unlock template to all localization files
- use constants instead of inline strings

## Testing
- `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- generate-messages`
- `python Tools/translate_argos.py Resources/Localization/Messages/Brazilian.json --to pt --batch-size 100 --max-retries 3 --verbose --log-file translate.log --report-file skipped.csv --overwrite` *(fails: 'NoneType' object has no attribute 'get_translation')*
- `python Tools/fix_tokens.py Resources/Localization/Messages/Brazilian.json`
- `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations --show-text` *(flags untranslated strings)*

------
https://chatgpt.com/codex/tasks/task_e_689cc1aa7500832d9cf6990699b3f852