### PR TITLE
refactor: localize quest messages

### DIFF
--- a/Utilities/Quests.cs
+++ b/Utilities/Quests.cs
@@ -17,6 +17,16 @@ internal static class Quests
 
     const float MAX_DISTANCE = 2000f;
 
+    const string TARGETS_KILLED_REROLL_MESSAGE = "Targets have all been killed, give them a chance to respawn! If this doesn't seem right consider rerolling your {0}.";
+    const string TARGETS_KILLED_MESSAGE = "Targets have all been killed, give them a chance to respawn!";
+    const string TRACK_VBLOOD_MENU_MESSAGE = "Use the VBlood menu to track bosses!";
+    const string NEAREST_TARGET_MESSAGE = "Nearest <color=white>{0}</color> was <color=#00FFFF>{1}</color>f away to the {2}!";
+    const string TRACKING_INCOMPLETE_KILL_MESSAGE = "Tracking is only available for incomplete kill quests.";
+    const string QUEST_OBJECTIVE_PROGRESS_MESSAGE = "{0}: <color=green>{1}</color> <color=white>{2}</color>x<color=#FFC0CB>{3}</color> [<color=white>{4}</color>/<color=yellow>{3}</color>]";
+    const string QUEST_TIME_UNTIL_RESET_PREFAB_MESSAGE = "Time until {0} reset - <color=yellow>{1}</color> | {2} Prefab: <color=white>{3}</color>";
+    const string QUEST_COMPLETED_MESSAGE = "You've already completed your {0}! Time until {1} reset - <color=yellow>{2}</color>";
+    const string QUEST_NOT_FOUND_MESSAGE = "You don't have a {0}.";
+
     public static readonly Dictionary<QuestType, string> QuestTypeColor = new()
     {
         { QuestType.Daily, "<color=#00FFFF>Daily Quest</color>" },
@@ -44,7 +54,7 @@ internal static class Quests
 
             if (!targetCache.IsCreated || !targetCache.ContainsKey(questObjective.Objective.Target))
             {
-                LocalizationService.Reply(ctx, "Targets have all been killed, give them a chance to respawn! If this doesn't seem right consider rerolling your {0}.", QuestTypeColor[questType]);
+                LocalizationService.Reply(ctx, TARGETS_KILLED_REROLL_MESSAGE, QuestTypeColor[questType]);
                 return;
             }
 
@@ -77,13 +87,13 @@ internal static class Quests
 
             if (!closest.Exists())
             {
-                LocalizationService.Reply(ctx, "Targets have all been killed, give them a chance to respawn!");
+                LocalizationService.Reply(ctx, TARGETS_KILLED_MESSAGE);
                 return;
             }
 
             if (closest.IsVBloodOrGateBoss())
             {
-                LocalizationService.Reply(ctx, "Use the VBlood menu to track bosses!");
+                LocalizationService.Reply(ctx, TRACK_VBLOOD_MENU_MESSAGE);
                 return;
             }
 
@@ -92,11 +102,11 @@ internal static class Quests
             float3 direction = math.normalize(targetPosition - userPosition);
             string cardinalDirection = string.Format("<color=yellow>{0}</color>", GetCardinalDirection(direction));
 
-            LocalizationService.Reply(ctx, "Nearest <color=white>{0}</color> was <color=#00FFFF>{1}</color>f away to the {2}!", questObjective.Objective.Target.GetLocalizedName(), (int)distance, cardinalDirection);
+            LocalizationService.Reply(ctx, NEAREST_TARGET_MESSAGE, questObjective.Objective.Target.GetLocalizedName(), (int)distance, cardinalDirection);
         }
         else
         {
-            LocalizationService.Reply(ctx, "Tracking is only available for incomplete kill quests.");
+            LocalizationService.Reply(ctx, TRACKING_INCOMPLETE_KILL_MESSAGE);
         }
     }
     public static void QuestObjectiveReply(ChatCommandContext ctx, Dictionary<QuestType, (QuestObjective Objective, int Progress, DateTime LastReset)> questData, QuestType questType)
@@ -105,14 +115,14 @@ internal static class Quests
         {
             string timeLeft = GetTimeUntilReset(questObjective, questType);
             LocalizationService.Reply(ctx,
-                "{0}: <color=green>{1}</color> <color=white>{2}</color>x<color=#FFC0CB>{3}</color> [<color=white>{4}</color>/<color=yellow>{3}</color>]",
+                QUEST_OBJECTIVE_PROGRESS_MESSAGE,
                 QuestTypeColor[questType],
                 questObjective.Objective.Goal,
                 questObjective.Objective.Target.GetLocalizedName(),
                 questObjective.Objective.RequiredAmount,
                 questObjective.Progress);
             LocalizationService.Reply(ctx,
-                "Time until {0} reset - <color=yellow>{1}</color> | {2} Prefab: <color=white>{3}</color>",
+                QUEST_TIME_UNTIL_RESET_PREFAB_MESSAGE,
                 questType,
                 timeLeft,
                 _questTargetType[questObjective.Objective.Goal],
@@ -121,11 +131,11 @@ internal static class Quests
         else if (questObjective.Objective.Complete)
         {
             string timeLeft = GetTimeUntilReset(questObjective, questType);
-            LocalizationService.Reply(ctx, "You've already completed your {0}! Time until {1} reset - <color=yellow>{2}</color>", QuestTypeColor[questType], questType, timeLeft);
+            LocalizationService.Reply(ctx, QUEST_COMPLETED_MESSAGE, QuestTypeColor[questType], questType, timeLeft);
         }
         else
         {
-            LocalizationService.Reply(ctx, "You don't have a {0}.", QuestTypeColor[questType]);
+            LocalizationService.Reply(ctx, QUEST_NOT_FOUND_MESSAGE, QuestTypeColor[questType]);
         }
     }
     static string GetTimeUntilReset((QuestObjective Objective, int Progress, DateTime LastReset) questObjective, QuestType questType)


### PR DESCRIPTION
## Summary
- centralize quest response strings for localization

## Testing
- `python Tools/fix_tokens.py --check-only`
- `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations --show-text` *(fails: `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations --show-text | rg "1218917876" -n` output used to demonstrate run)*
- `python Tools/translate_argos.py Resources/Localization/Messages/German.json --to de --batch-size 100 --max-retries 3 --verbose --log-file translate.log --report-file skipped.csv --overwrite` *(fails: 'AttributeError: 'NoneType' object has no attribute 'get_translation')*

------
https://chatgpt.com/codex/tasks/task_e_689d2f4b1564832dba97fd1b6eddcb7a