### PR TITLE
Localize shapeshift energy warning

### DIFF
--- a/Resources/Localization/MessageKeys.cs
+++ b/Resources/Localization/MessageKeys.cs
@@ -6,6 +6,7 @@ internal static class MessageKeys
     public const string EMOTE_ACTIONS_BAT_FORM = "You can't use emote actions when using bat form!";
     public const string FAMILIAR_INTERACT_COMBAT = "You can't interact with your familiar during combat!";
     public const string SHAPESHIFT_SELECT_FORM = "Select a form you've unlocked first! ('<color=white>.prestige sf [<color=orange>EvolvedVampire|CorruptedSerpent</color>]</color>')";
+    public const string SHAPESHIFT_NOT_ENOUGH_ENERGY = "Not enough energy to maintain form... (<color=yellow>{0}</color>)";
     public const string FAMILIAR_CALL_PVP_COMBAT = "You can't call your familiar during PvP combat!";
     public const string FAMILIAR_ACTIVE_NOT_EXIST = "Active familiar doesn't exist! If that doesn't seem right try using '<color=white>.fam reset</color>'.";
     public const string FAMILIAR_NOT_FOUND = "Couldn't find active familiar...";

--- a/Resources/Localization/Messages/Brazilian.json
+++ b/Resources/Localization/Messages/Brazilian.json
@@ -404,6 +404,7 @@
     "emote-actions-bat-form": "Você não pode usar ações emotivas quando usa forma de morcego!",
     "familiar-interact-combat": "Você não pode interagir com seu familiar durante o combate!",
     "shapeshift-select-form": "Selecione um formulário que você destrancou primeiro! <color=white>. Prestige sf <color=orange> Evoluído Vampire CorrompidoSerpente</color></color>'",
+    "shapeshift-not-enough-energy": "Not enough energy to maintain form... (<color=yellow>{0}</color>)",
     "familiar-call-pvp-combat": "Você não pode chamar seu familiar durante o combate PvP!",
     "familiar-active-not-exist": "Ativo familiar não existe! Se isso não parece certo tente usar '<color=white>.fam reset</color>'.",
     "familiar-not-found": "Não achei familiar...",

--- a/Resources/Localization/Messages/English.json
+++ b/Resources/Localization/Messages/English.json
@@ -404,6 +404,7 @@
     "emote-actions-bat-form": "You can't use emote actions when using bat form!",
     "familiar-interact-combat": "You can't interact with your familiar during combat!",
     "shapeshift-select-form": "Select a form you've unlocked first! ('<color=white>.prestige sf [<color=orange>EvolvedVampire|CorruptedSerpent</color>]</color>')",
+    "shapeshift-not-enough-energy": "Not enough energy to maintain form... (<color=yellow>{0}</color>)",
     "familiar-call-pvp-combat": "You can't call your familiar during PvP combat!",
     "familiar-active-not-exist": "Active familiar doesn't exist! If that doesn't seem right try using '<color=white>.fam reset</color>'.",
     "familiar-not-found": "Couldn't find active familiar...",

--- a/Resources/Localization/Messages/French.json
+++ b/Resources/Localization/Messages/French.json
@@ -404,6 +404,7 @@
     "emote-actions-bat-form": "Vous ne pouvez pas utiliser les actions EMOTE lors de l'utilisation du formulaire de chauve-souris!",
     "familiar-interact-combat": "Vous ne pouvez pas interagir avec votre familier pendant le combat!",
     "shapeshift-select-form": "Sélectionnez un formulaire que vous avez déverrouillé en premier! ('<color=white>. Prestige sf <color=orange> evolvedVampire | corruptedSerper </color>] </color>')",
+    "shapeshift-not-enough-energy": "Not enough energy to maintain form... (<color=yellow>{0}</color>)",
     "familiar-call-pvp-combat": "Vous ne pouvez pas appeler votre familier pendant le combat PVP!",
     "familiar-active-not-exist": "Un familier actif n'existe pas! Si cela ne semble pas juste, essayez d'utiliser '<color=white>. Fam réinitialisation </color>'.",
     "familiar-not-found": "Je ne pouvais pas trouver actif familier ...",

--- a/Resources/Localization/Messages/German.json
+++ b/Resources/Localization/Messages/German.json
@@ -404,6 +404,7 @@
     "emote-actions-bat-form": "Sie können keine Emote -Aktionen verwenden, wenn Sie Fledermausform verwenden!",
     "familiar-interact-combat": "Sie können im Kampf nicht mit Ihrem Vertrauten interagieren!",
     "shapeshift-select-form": "Wählen Sie ein Formular aus, das Sie zuerst entsperrt haben! ('<color=white>. Prestige SF <color=orange> EvolvedVampire | beschädigt </color> </color>')",
+    "shapeshift-not-enough-energy": "Not enough energy to maintain form... (<color=yellow>{0}</color>)",
     "familiar-call-pvp-combat": "Sie können Ihren Vertrauten während des PVP -Kampfes nicht nennen!",
     "familiar-active-not-exist": "Active vertraut existiert nicht! Wenn das nicht richtig erscheint, versuchen Sie es mit '<color=white>. Fam Reset </color>'.",
     "familiar-not-found": "Konnte nicht aktiv vertraut finden ...",

--- a/Resources/Localization/Messages/Hungarian.json
+++ b/Resources/Localization/Messages/Hungarian.json
@@ -404,6 +404,7 @@
     "emote-actions-bat-form": "Nem használhatja az Emote műveleteket a BAT forma használatakor!",
     "familiar-interact-combat": "A harc során nem léphet kapcsolatba az ismerőseivel!",
     "shapeshift-select-form": "Válassza ki az első kinyitott űrlapot! ('<color=white>. Prestige sf <color=orange> evolvedvampire | CruptedSerpent </color>]] </color>')",
+    "shapeshift-not-enough-energy": "Not enough energy to maintain form... (<color=yellow>{0}</color>)",
     "familiar-call-pvp-combat": "Nem hívhatja meg ismerősedet a PVP -harc során!",
     "familiar-active-not-exist": "Az aktív ismerős nem létezik! Ha ez nem tűnik helyesnek, próbálja meg használni a '<color=white>. Fam reset </color>' használatát.",
     "familiar-not-found": "Nem találtak aktív ismerősöket ...",

--- a/Resources/Localization/Messages/Italian.json
+++ b/Resources/Localization/Messages/Italian.json
@@ -404,6 +404,7 @@
     "emote-actions-bat-form": "Non puoi usare le azioni Emote quando si utilizza il modulo BAT!",
     "familiar-interact-combat": "Non puoi interagire con il tuo familiare durante il combattimento!",
     "shapeshift-select-form": "Seleziona un modulo che hai sbloccato per primo! ;",
+    "shapeshift-not-enough-energy": "Not enough energy to maintain form... (<color=yellow>{0}</color>)",
     "familiar-call-pvp-combat": "Non puoi chiamare il tuo familiare durante il combattimento PVP!",
     "familiar-active-not-exist": "Active Familial non esiste! Se questo non sembra giusto, prova a usare '<color=white>. FAM RESET </color>'.",
     "familiar-not-found": "Non sono riuscito a trovare familiari attivi ...",

--- a/Resources/Localization/Messages/Japanese.json
+++ b/Resources/Localization/Messages/Japanese.json
@@ -404,6 +404,7 @@
     "emote-actions-bat-form": "BATフォームを使用するとき、Emoteアクションを使用することはできません！",
     "familiar-interact-combat": "戦闘中に馴染みのあるものとやり取りすることはできません！",
     "shapeshift-select-form": "最初にロックを解除したフォームを選択してください！ （ '<color=white>。prestige sf <color=orange> evolvedvampire | corruptedserpent </color>] </color>'）",
+    "shapeshift-not-enough-energy": "Not enough energy to maintain form... (<color=yellow>{0}</color>)",
     "familiar-call-pvp-combat": "PVP戦闘中に馴染みのある電話をかけることはできません！",
     "familiar-active-not-exist": "アクティブななじみは存在しません！それが正しくないように見える場合は、 '<color=white>。fam reset </color>'を使用してみてください。",
     "familiar-not-found": "アクティブなおなじみを見つけることができませんでした...",

--- a/Resources/Localization/Messages/Korean.json
+++ b/Resources/Localization/Messages/Korean.json
@@ -404,6 +404,7 @@
     "emote-actions-bat-form": "박쥐 형태를 사용할 때 감정 동작을 사용할 수 없습니다!",
     "familiar-interact-combat": "전투 중에 친숙한 것과 상호 작용할 수 없습니다!",
     "shapeshift-select-form": "먼저 잠금 해제 한 양식을 선택하십시오! ( '<color=white>. Prestige SF <color=orange>] EvolvedVampire | FruptedSerpent </color> </color>')",
+    "shapeshift-not-enough-energy": "Not enough energy to maintain form... (<color=yellow>{0}</color>)",
     "familiar-call-pvp-combat": "PVP 전투 중에 친숙한 전화를 할 수 없습니다!",
     "familiar-active-not-exist": "활성 친숙한 존재가 존재하지 않습니다! 그것이 올바르게 보이지 않는 경우 '<color=white>. Fam Reset </color>'을 사용해보십시오.",
     "familiar-not-found": "친숙한 친숙한 것을 찾을 수 없었습니다 ...",

--- a/Resources/Localization/Messages/Latam.json
+++ b/Resources/Localization/Messages/Latam.json
@@ -404,6 +404,7 @@
     "emote-actions-bat-form": "¡No puedes usar acciones de emote al usar Forma BAT!",
     "familiar-interact-combat": "¡No puedes interactuar con tu familiar durante el combate!",
     "shapeshift-select-form": "¡Seleccione un formulario que haya desbloqueado primero! ('<color=white>. Prestige SF <color=orange> EvolvedVampire | CorruptedSerpent </color>] </color>'))",
+    "shapeshift-not-enough-energy": "Not enough energy to maintain form... (<color=yellow>{0}</color>)",
     "familiar-call-pvp-combat": "¡No puede llamar a su familiar durante el combate PVP!",
     "familiar-active-not-exist": "¡No existe un familiar activo! Si eso no parece correcto, intente usar '<color=white>. FAM Reset </color>'.",
     "familiar-not-found": "No pude encontrar un familiar activo ...",

--- a/Resources/Localization/Messages/Polish.json
+++ b/Resources/Localization/Messages/Polish.json
@@ -404,6 +404,7 @@
     "emote-actions-bat-form": "Nie możesz używać działań emote podczas korzystania z formularza nietoperza!",
     "familiar-interact-combat": "Nie możesz wchodzić w interakcje ze swoim znajomym podczas walki!",
     "shapeshift-select-form": "Najpierw wybierz formę, którą odblokowałeś! ('<color=white>.prestige sf [<color=orange>EvolvedVampire|CorruptedSerpent</color>]</color>')",
+    "shapeshift-not-enough-energy": "Not enough energy to maintain form... (<color=yellow>{0}</color>)",
     "familiar-call-pvp-combat": "Nie możesz zadzwonić do swojego znajomego podczas walki z PVP!",
     "familiar-active-not-exist": "Aktywny znajomy nie istnieje! Jeśli to nie wydaje się właściwe, spróbuj użyć „<color=white>. Fam reset </color>”.",
     "familiar-not-found": "Nie mogłem znaleźć aktywnego znajomego ...",

--- a/Resources/Localization/Messages/Russian.json
+++ b/Resources/Localization/Messages/Russian.json
@@ -404,6 +404,7 @@
     "emote-actions-bat-form": "Вы не можете использовать эмоциональные действия при использовании формы летучей мыши!",
     "familiar-interact-combat": "Вы не можете взаимодействовать со своим знакомым во время боя!",
     "shapeshift-select-form": "Выберите форму, которую вы разблокировали в первую очередь! ('<color=white>. Prestige sf <color=orange> evolvedvampire | corruptedSerpent </color>] </color>')",
+    "shapeshift-not-enough-energy": "Not enough energy to maintain form... (<color=yellow>{0}</color>)",
     "familiar-call-pvp-combat": "Вы не можете назвать свое знакомое во время Pvp Combat!",
     "familiar-active-not-exist": "Активного знакомства не существует! Если это не кажется правильным, попробуйте использовать '<color=white>. Fam reset </color>'.",
     "familiar-not-found": "Не мог найти активного знакомого ...",

--- a/Resources/Localization/Messages/SChinese.json
+++ b/Resources/Localization/Messages/SChinese.json
@@ -404,6 +404,7 @@
     "emote-actions-bat-form": "使用蝙蝠表单时，您不能使用表情动作！",
     "familiar-interact-combat": "您无法在战斗中与熟悉的互动！",
     "shapeshift-select-form": "请先选择您已解锁的形态！（'<color=white>.prestige sf [<color=orange>EvolvedVampire|CorruptedSerpent</color>]</color>')",
+    "shapeshift-not-enough-energy": "Not enough energy to maintain form... (<color=yellow>{0}</color>)",
     "familiar-call-pvp-combat": "您不能在PVP战斗中打电话给您的熟悉！",
     "familiar-active-not-exist": "主动熟悉不存在！如果这似乎不正确，请尝试使用'<color=white>。fam reset </color>'。",
     "familiar-not-found": "找不到熟悉的活跃...",

--- a/Resources/Localization/Messages/Spanish.json
+++ b/Resources/Localization/Messages/Spanish.json
@@ -404,6 +404,7 @@
     "emote-actions-bat-form": "¡No puedes usar acciones de emote al usar Forma BAT!",
     "familiar-interact-combat": "¡No puedes interactuar con tu familiar durante el combate!",
     "shapeshift-select-form": "¡Seleccione un formulario que haya desbloqueado primero! ('<color=white>. Prestige SF <color=orange> EvolvedVampire | CorruptedSerpent </color>] </color>'))",
+    "shapeshift-not-enough-energy": "Not enough energy to maintain form... (<color=yellow>{0}</color>)",
     "familiar-call-pvp-combat": "¡No puede llamar a su familiar durante el combate PVP!",
     "familiar-active-not-exist": "¡No existe un familiar activo! Si eso no parece correcto, intente usar '<color=white>. FAM Reset </color>'.",
     "familiar-not-found": "No pude encontrar un familiar activo ...",

--- a/Resources/Localization/Messages/TChinese.json
+++ b/Resources/Localization/Messages/TChinese.json
@@ -404,6 +404,7 @@
     "emote-actions-bat-form": "使用蝙蝠表單時，您不能使用表情動作！",
     "familiar-interact-combat": "您無法在戰鬥中與熟悉的互動！",
     "shapeshift-select-form": "請先選擇您已解鎖的形態！('<color=white>.prestige sf [<color=orange>EvolvedVampire|CorruptedSerpent</color>]</color>')",
+    "shapeshift-not-enough-energy": "Not enough energy to maintain form... (<color=yellow>{0}</color>)",
     "familiar-call-pvp-combat": "您不能在PVP戰鬥中打電話給您的熟悉！",
     "familiar-active-not-exist": "主動熟悉不存在！如果這似乎不正確，請嘗試使用'<color=white>。 fam reset </color>'。",
     "familiar-not-found": "找不到熟悉的活躍...",

--- a/Resources/Localization/Messages/Thai.json
+++ b/Resources/Localization/Messages/Thai.json
@@ -404,6 +404,7 @@
     "emote-actions-bat-form": "คุณไม่สามารถใช้การกระทำ EMOTE เมื่อใช้แบบฟอร์ม BAT!",
     "familiar-interact-combat": "คุณไม่สามารถโต้ตอบกับความคุ้นเคยระหว่างการต่อสู้ได้!",
     "shapeshift-select-form": "เลือกแบบฟอร์มที่คุณปลดล็อคก่อน! ('<color=white>. Prestige SF [<color=orange> EvolvedVampire | Corruptedserpent </color>] </color>') ')",
+    "shapeshift-not-enough-energy": "Not enough energy to maintain form... (<color=yellow>{0}</color>)",
     "familiar-call-pvp-combat": "คุณไม่สามารถโทรหาที่คุ้นเคยระหว่างการต่อสู้ PVP!",
     "familiar-active-not-exist": "ไม่คุ้นเคยไม่มีอยู่จริง! หากดูเหมือนว่าไม่ถูกต้องลองใช้ '<color=white>. FAM รีเซ็ต </color>'",
     "familiar-not-found": "ไม่พบที่คุ้นเคย ...",

--- a/Resources/Localization/Messages/Turkish.json
+++ b/Resources/Localization/Messages/Turkish.json
@@ -404,6 +404,7 @@
     "emote-actions-bat-form": "BAT formunu kullanırken Emote eylemlerini kullanamazsınız!",
     "familiar-interact-combat": "Savaş sırasında tanıdıklarınızla etkileşime giremezsiniz!",
     "shapeshift-select-form": "Önce kilidini açtığınız bir form seçin! ('<color=white>.",
+    "shapeshift-not-enough-energy": "Not enough energy to maintain form... (<color=yellow>{0}</color>)",
     "familiar-call-pvp-combat": "PVP savaşı sırasında tanıdıklarınızı arayamazsınız!",
     "familiar-active-not-exist": "Aktif tanıdık mevcut değil! Bu doğru görünmüyorsa '<color=white>. Fam sıfırlama </color>' kullanmayı deneyin.",
     "familiar-not-found": "Aktif tanıdık bulamadım ...",

--- a/Resources/Localization/Messages/Ukrainian.json
+++ b/Resources/Localization/Messages/Ukrainian.json
@@ -404,6 +404,7 @@
     "emote-actions-bat-form": "Ви не можете використовувати емоційні дії під час використання форми BAT!",
     "familiar-interact-combat": "Ви не можете взаємодіяти зі своїм знайомим під час бою!",
     "shapeshift-select-form": "Виберіть форму, яку ви розблокували спочатку! ('<color=white>. Prestige sf <color=orange> evolvedvampire | пошкоджений серпен </color>] </color>') ')') '",
+    "shapeshift-not-enough-energy": "Not enough energy to maintain form... (<color=yellow>{0}</color>)",
     "familiar-call-pvp-combat": "Ви не можете зателефонувати своїм знайомим під час бою PVP!",
     "familiar-active-not-exist": "Активний фамільяр не існує! Якщо це здається неправильним, спробуйте використати '<color=white>.fam reset</color>'.",
     "familiar-not-found": "Не міг знайти активного знайомого ...",

--- a/Resources/Localization/Messages/Vietnamese.json
+++ b/Resources/Localization/Messages/Vietnamese.json
@@ -404,6 +404,7 @@
     "emote-actions-bat-form": "Bạn không thể sử dụng các hành động Emote khi sử dụng biểu mẫu Bat!",
     "familiar-interact-combat": "Bạn không thể tương tác với quen thuộc của bạn trong khi chiến đấu!",
     "shapeshift-select-form": "Chọn một biểu mẫu bạn đã mở khóa trước! .",
+    "shapeshift-not-enough-energy": "Not enough energy to maintain form... (<color=yellow>{0}</color>)",
     "familiar-call-pvp-combat": "Bạn không thể gọi quen thuộc của bạn trong chiến đấu PVP!",
     "familiar-active-not-exist": "Hoạt động quen thuộc không tồn tại! Nếu điều đó có vẻ không đúng, hãy thử sử dụng '<color=white>. Fam reset </color>'.",
     "familiar-not-found": "Không thể thấy hoạt động quen thuộc ...",

--- a/Utilities/Shapeshifts.cs
+++ b/Utilities/Shapeshifts.cs
@@ -1,5 +1,6 @@
 ﻿using Bloodcraft.Interfaces;
 using Bloodcraft.Resources;
+using Bloodcraft.Resources.Localization;
 using Bloodcraft.Services;
 using ProjectM;
 using ProjectM.Gameplay.Scripting;
@@ -112,7 +113,7 @@ internal static class Shapeshifts
     {
         string timeRemaining = GetTimeUntilCharged(steamId, value);
 
-        if (!string.IsNullOrEmpty(timeRemaining)) LocalizationService.Reply(EntityManager, user, "Not enough energy to maintain form... (<color=yellow>{0}</color>)", timeRemaining);
+        if (!string.IsNullOrEmpty(timeRemaining)) LocalizationService.Reply(EntityManager, user, MessageKeys.SHAPESHIFT_NOT_ENOUGH_ENERGY, timeRemaining);
     }
     static string GetTimeUntilCharged(ulong steamId, float value)
     {


### PR DESCRIPTION
## Summary
- replace shapeshift energy warning with localization key
- add message to all locale files

## Testing
- `python Tools/translate_argos.py Resources/Localization/Messages/Brazilian.json --to pt --batch-size 100 --max-retries 3 --verbose --log-file translate.log --report-file skipped.csv --overwrite` *(fails: AttributeError: 'NoneType' object has no attribute 'get_translation')*
- `python Tools/fix_tokens.py --check-only Resources/Localization/Messages/Brazilian.json`
- `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations --show-text`


------
https://chatgpt.com/codex/tasks/task_e_689d418dc22c832da262041f5be49d9e