### PR TITLE
Validate localization data in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Check tokens and translations
         run: |
           set -e
-          python Tools/fix_tokens.py --check-only
+          python Tools/fix_tokens.py --check-only Resources/Localization/Messages/*.json
           dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations
 
       - name: GH Release

--- a/Docs/Localization.md
+++ b/Docs/Localization.md
@@ -24,6 +24,15 @@ dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-trans
 
 The command should report no hash changes, confirming placeholders are aligned across languages.
 
+## Automated validation
+
+The CI pipeline runs the following checks and fails if any English text remains or tokens are malformed:
+
+```bash
+python Tools/fix_tokens.py --check-only Resources/Localization/Messages/*.json
+dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations
+```
+
 ## Build-time check
 
 A check runs during the build to ensure `LocalizationService.Reply` does not receive raw string

--- a/README.md
+++ b/README.md
@@ -815,6 +815,13 @@ dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- generate-me
    `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations --show-text`
    This command confirms every hash exists and no English text remains.
 
+   The CI pipeline also enforces this by running:
+
+   ```bash
+   python Tools/fix_tokens.py --check-only Resources/Localization/Messages/*.json
+   dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations
+   ```
+
 ### English detection allowlist
 
 `Tools/language_utils.py` flags untranslated strings by searching for common English stop words.

--- a/Tools/CheckTranslations.cs
+++ b/Tools/CheckTranslations.cs
@@ -20,6 +20,7 @@ internal static class CheckTranslations
         var englishFile = JsonSerializer.Deserialize<MessageFile>(File.ReadAllText(engPath), options) ?? new MessageFile();
         englishFile.Messages ??= new Dictionary<string, string>();
 
+        bool hasIssues = false;
         foreach (string path in Directory.GetFiles(messagesDir, "*.json"))
         {
             if (Path.GetFileName(path).Equals("English.json", StringComparison.OrdinalIgnoreCase))
@@ -40,6 +41,7 @@ internal static class CheckTranslations
 
             if (missing.Count > 0)
             {
+                hasIssues = true;
                 Console.WriteLine($"Missing hashes in {Path.GetFileName(path)}:");
                 foreach (string h in missing)
                 {
@@ -57,6 +59,7 @@ internal static class CheckTranslations
 
             if (englishLike.Count > 0)
             {
+                hasIssues = true;
                 Console.WriteLine($"Potential untranslated strings in {Path.GetFileName(path)}:");
                 foreach (string h in englishLike)
                 {
@@ -73,6 +76,9 @@ internal static class CheckTranslations
                 }
             }
         }
+
+        if (hasIssues)
+            Environment.Exit(1);
     }
 
     class MessageFile


### PR DESCRIPTION
## Summary
- run fix_tokens and translation checker in CI
- make translation checker exit on untranslated strings
- document automated localization validation for contributors

## Testing
- `python Tools/fix_tokens.py --check-only Resources/Localization/Messages/*.json`
- `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations` *(fails: potential untranslated strings)*
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689d5494428c832da2d95f7d2c63a981