### PR TITLE
Add English phrase scanner

### DIFF
--- a/Docs/Localization.md
+++ b/Docs/Localization.md
@@ -46,3 +46,20 @@ python Tools/check_localization_reply.py --update-baseline  # refresh baseline a
 If new string literals are introduced, the build will fail until they are removed or added to the
 baseline.
 
+## Scan source for untranslated strings
+
+Run `scan_english.py` to highlight English phrases in C# files that are not wrapped in
+`LocalizationService` helpers:
+
+```bash
+python Tools/scan_english.py
+```
+
+You can skip directories or file patterns that should not be scanned:
+
+```bash
+python Tools/scan_english.py --whitelist-dir Bloodcraft.Tests --whitelist-pattern "^Generated/"
+```
+
+Use this to quickly locate messages that still need localization.
+

--- a/Tools/scan_english.py
+++ b/Tools/scan_english.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Scan C# files for English strings not using localization helpers.
+
+The script looks for string literals in ``.cs`` files that appear to contain
+English words and are not wrapped in ``LocalizationService`` helpers. This helps
+contributors spot untranslated messages.
+"""
+import argparse
+import re
+from pathlib import Path
+
+from language_utils import contains_english
+
+# Regex to capture C# string literals ("foo" or @"foo") without spanning lines
+STRING_RE = re.compile(r'@?"(?:[^"\\]|\\.)+"')
+
+def extract_strings(text: str):
+    for match in STRING_RE.finditer(text):
+        yield match
+
+def should_skip(path: Path, args) -> bool:
+    for d in args.whitelist_dir:
+        d_path = Path(d)
+        if d_path in path.parents:
+            return True
+    for pattern in args.whitelist_pattern:
+        if re.search(pattern, str(path)):
+            return True
+    return False
+
+def in_localization_context(text: str, start: int) -> bool:
+    context_start = max(0, start - 100)
+    context = text[context_start:start]
+    return "LocalizationService" in context
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Scan .cs files for English phrases not wrapped in localization helpers.")
+    parser.add_argument("paths", nargs="*", default=["."], help="Paths to scan (default: current directory)")
+    parser.add_argument("--whitelist-dir", action="append", default=[], help="Directories to skip (can be used multiple times)")
+    parser.add_argument("--whitelist-pattern", action="append", default=[], help="Regex patterns to skip paths")
+    args = parser.parse_args()
+
+    for root in args.paths:
+        for path in Path(root).rglob("*.cs"):
+            if any(part in {"obj", "bin"} for part in path.parts):
+                continue
+            if should_skip(path, args):
+                continue
+            text = path.read_text(encoding="utf-8", errors="ignore")
+            for match in extract_strings(text):
+                literal = match.group(0)
+                # strip leading @ and quotes
+                stripped = literal.lstrip('@')[1:-1]
+                try:
+                    unescaped = bytes(stripped, "utf-8").decode("unicode_escape")
+                except Exception:
+                    unescaped = stripped
+                if not contains_english(unescaped):
+                    continue
+                if in_localization_context(text, match.start()):
+                    continue
+                line_no = text.count("\n", 0, match.start()) + 1
+                print(f"{path}:{line_no}: {unescaped}")
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `scan_english.py` script to flag English strings outside localization helpers
- document usage of the scanner in `Localization.md`

## Testing
- `pytest`
- `dotnet test Bloodcraft.Tests/Bloodcraft.Tests.csproj` *(fails: You must install or update .NET to run this application; missing Microsoft.NETCore.App 6.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_689d576b3810832d90f6957e09fe4161