### PR TITLE
Add message key catalog and generator

### DIFF
--- a/Docs/Localization.md
+++ b/Docs/Localization.md
@@ -2,6 +2,12 @@
 
 Bloodcraft uses hash-based localization. Follow these steps when adding or editing messages.
 
+Before introducing a new message, check the catalog in
+`Docs/MessageKeys.md` to avoid creating duplicate entries. Run
+`python Tools/generate_message_catalog.py` if you change
+`Resources/Localization/Messages/English.json` so the catalog stays
+current.
+
 ## Replace interpolated strings
 
 Instead of C# string interpolation, use `LocalizationService.Reply` with numbered placeholders:

--- a/Docs/MessageKeys.md
+++ b/Docs/MessageKeys.md
@@ -1,0 +1,428 @@
+# Message Key Catalog
+
+Auto-generated from `Resources/Localization/Messages/English.json`.
+
+| Key | Description |
+| --- | --- |
+| `101395383` | Exo prestiging is not enabled. |
+| `1014495694` | Familiar disabled! |
+| `1057363547` | Invalid choice, please use 1 to {familiarSet.Count} (Current... |
+| `1066178325` | No active box! Try using '.fam sb [Name]'... |
+| `107297214` | Level logging {(GetPlayerBool(steamId, EXPERIENCE_LOG_KEY) ? "enabled" : "disabled")}. |
+| `1076291728` | Use the VBlood menu to track bosses! |
+| `1081599663` | No active battle group selected! Use .fam cbg... |
+| `1095669519` | Level logging {(GetPlayerBool(SteamID, EXPERIENCE_LOG_KEY) ? "enabled" : "disabled")}. |
+| `1105957988` | Nearest … was …f away to the …! |
+| `1106946472` | {replyMessage} |
+| `1108347105` | Level must be between 0 and {ConfigService.MaxBloodLevel}. |
+| `11642316` | Current Exo Prestige Level: {exoLevel}/{PrestigeTypeToMaxPrestiges[parsedPrestigeType]} \| Max Form... |
+| `1178832936` | You have prestiged in Experience[…]! Growth rates for... |
+| `1182925736` | No players have prestiged in {parsedPrestigeType} yet! |
+| `1201875369` | No progress in {professionHandler.GetProfessionName()} yet! |
+| `121410310` | Spells locked. |
+| `1218917876` | Targets have all been killed, give them a... |
+| `1223341524` | …[…] prestiged successfully! Growth rate reduced by …... |
+| `1228611582` | Familiar Battle Groups: |
+| `1231839381` | Challenged {playerInfo.User.CharacterName.Value} to a battle! (30s until it... |
+| `1248377615` | Familiar enabled! |
+| `1254994229` | Couldn't find experience data for {foundUser.CharacterName.Value} |
+| `1271017097` | New shiny unit unlocked: … |
+| `1282509635` | You have class buffs enabled, use '.class passives'... |
+| `1286090332` | You're level [{data.Key}][{prestigeLevel}] with {progress} essence ({BloodSystem.GetLevelProgress(ctx.Event.User.PlatformId, handler)}%)... |
+| `1293896668` | No stat synergies found for {FormatClassName(playerClass)}. |
+| `1298892920` | No legacy available for {bloodType}. |
+| `1315865629` | You couldn't afford to reroll your wekly... (…... |
+| `1318067012` | Invalid index, use 1-…! (Active Box - …) |
+| `132267140` | Growth rate reduction for experience: … |
+| `134200388` | Invalid profession. |
+| `1345204457` | This command should only be used as required... |
+| `1354182381` | Valid options: {validOptions} |
+| `1369871380` | Available Weapon Expertises: … |
+| `1381058165` | Familiars are not enabled. |
+| `1391708521` | Your familiar has prestiged [{prestigeLevel}]! |
+| `1411528307` | {parsedPrestigeType} prestige reset for {playerInfo.User.CharacterName.Value}. |
+| `1420278477` | Tracking is only available for incomplete kill quests. |
+| `1440482998` | {playerInfo.User.CharacterName.Value} added to the ignore prestige leaderboard list! |
+| `1440602422` | Active familiar for {user.CharacterName.Value} has been set to... |
+| `1443941563` | Removed prestige buffs from all players. |
+| `1446811317` | … removed from the ignore shared experience list! |
+| `1449977777` | You do not have the required item to... |
+| `1454481026` | You don't have the required item to reset... |
+| `145841390` | You must reach the maximum level in Experience... |
+| `1465975319` | Reminders …. |
+| `1469754031` | Looks like your familiar is still able to... |
+| `1496603105` | Leveling is not enabled. |
+| `1516467471` | You haven't unlocked any familiars yet! |
+| `1548584430` | Profession logging is now {(GetPlayerBool(steamId, PROFESSION_LOG_KEY) ? "enabled"... |
+| `1562141642` | You don't have the required prestige level for... |
+| `1575879194` | Couldn't find box to rename or there's already... |
+| `1581983564` | Shiny added! Rebind familiar to see effects. Use... |
+| `1597216248` | Invalid class, use '.class l' to see options. |
+| `1601487032` | First unarmed slot set to … for …. |
+| `160628229` | {playerInfo.User.CharacterName.Value} added to the ignore shared experience list! |
+| `1641131342` | Invalid prestige, use '.prestige l' to see valid... |
+| `1641855254` | You haven't gained any expertise for … yet! |
+| `1651916565` | … scrolling text …. |
+| `1669157395` | Your bag feels slightly heavier... |
+| `167244174` | Classes are not enabled and spells can't be... |
+| `1677522996` | You've already completed your Weekly Quest. Check back... |
+| `1680589832` | No blood stats available at this time. |
+| `1687700552` | You must consume at least one primordial essence... |
+| `1689690159` | Couldn't find player. |
+| `1690022722` | Your blood stats have been reset for {bloodType}. |
+| `1695244872` | … is already unlocked! |
+| `1711247206` | You are not yet worthy... |
+| `1711931034` | {bloodType} Stats: {bonuses} |
+| `1716911803` | {box}: |
+| `1725928464` | {playerInfo.User.CharacterName.Value} removed from the ignore shared experience list! |
+| `173404118` | Shift spells are not enabled. |
+| `1740355579` | Your blood stats have been reset for {bloodType}! |
+| `1744159514` | Can't unbind familiar right now! (dismissed) |
+| `1757634753` | You do not have enough of the required... |
+| `1762641650` | You already have an active familiar! Unbind that... |
+| `1763729577` | Exo form emote action (taunt) {(GetPlayerBool(steamId, SHAPESHIFT_KEY) ?... |
+| `1769980541` | Couldn't find bool key from scrolling text type... |
+| `179462471` | Can't unbind familiar right now! (interacting) |
+| `1797973559` | Permashroud disabled! |
+| `1809964020` | Unable to verify tier for {vBloodPrefabGuid.GetPrefabName()}! Shouldn't really... |
+| `1826355702` | Second unarmed slot set to {new PrefabGUID(ability).GetPrefabName()} for... |
+| `1836101498` | Quests are not enabled. |
+| `18401539` | Invalid blood legacy. |
+| `1846116445` | Extra spell slots for unarmed are not enabled. |
+| `1880632188` | {finalWeaponStat} has been chosen for {finalWeaponType}! |
+| `1884272339` | You must consume Dracula's essence before manifesting his... |
+| `1894878159` | Familiar assigned to {groupName} in slot {slotIndex}. |
+| `1897692916` | You must reach max level before Exo prestiging... |
+| `1899346128` | Total change in growth rate including leveling prestige... |
+| `1904876515` | Quest logging is now {(GetPlayerBool(steamId, QUEST_LOG_KEY) ? "enabled"... |
+| `1939118629` | You don't have any unlocked familiars yet. |
+| `1945389717` | … scrolling text …. |
+| `1952946751` | You've already completed your Daily Quest today. Check... |
+| `1955962459` | Invalid quest type. (daily/weekly or d/w) |
+| `1976698463` | Multiple matches, please be more specific! |
+| `1977482431` | Familiar Boxes: |
+| `1985982508` | You couldn't afford to reroll your daily... ({item.GetLocalizedName()}... |
+| `2001389111` | Invalid spell, use '.class lsp' to see options. |
+| `2008856310` | Invalid weapon choice, use '.wep lst' to see... |
+| `203356865` | Growth rate increase for expertise and legacies: … |
+| `2051256929` | {roundedXP} bonus experience remaining from resting~ |
+| `2069903402` | Starter kit is not enabled. |
+| `2076214502` | Exo prestiging is not enabled. |
+| `20873033` | You haven't selected a class or you haven't... |
+| `2095668308` | Level must be between 0 and {MAX_PROFESSION_LEVEL}. |
+| `210979117` | You can't call a familiar when using dominating... |
+| `2121377442` | Your familiar has already prestiged the maximum number... |
+| `2128999876` | Level must be between 0 and {ConfigService.MaxExpertiseLevel}. |
+| `2129553669` | You're not currently queued for battle! Use '.fam... |
+| `2137562404` | Quest logging is now …. |
+| `2147420594` | {FormatClassName(playerClass)} stat synergies [x{ConfigService.SynergyMultiplier}]: |
+| `2155028867` | Invalid prefab (not an integer) or name (does... |
+| `2164633984` | Couldn't find stat synergies for {FormatClassName(playerClass)}... |
+| `2165480178` | Couldn't find matching shinyBuff from entered spell school.... |
+| `216725398` | You're level [{data.Key}] and have {progress} proficiency ({ProfessionSystem.GetLevelProgress(steamId,... |
+| `2169578147` | Invalid unit name (match found but does not... |
+| `2169705185` | Couldn't find active familiar for prestiging! |
+| `2174214346` | Completed … for …! |
+| `2178615132` | Permashroud enabled! |
+| `2179875375` | VBlood purchasing is not enabled. |
+| `2191580006` | Not enough {exoItem.GetLocalizedName()}x{factoredCost} for {vBloodPrefabGuid.GetPrefabName()}! |
+| `2194796157` | Invalid blood stat, use '.bl lst' to see... |
+| `2196432591` | {BloodHandler.GetBloodType()} legacy set to [{level}] for {foundUser.CharacterName} |
+| `2202242526` | Extra spell slots are not enabled. |
+| `2213724716` | Deleted box - {name} |
+| `2214985381` | … Prestige Info: |
+| `2228202821` | {playerInfo.User.CharacterName} is already queued for battle! |
+| `223311103` | Invalid unit name (no full or partial matches). |
+| `2252129438` | Invalid weapon type. |
+| `226227140` | No progress in {handler.GetBloodType()} yet. |
+| `2271729042` | Quest logging is now {(GetPlayerBool(steamId, QUEST_LOG_KEY) ? "enabled"... |
+| `2272306226` | … moved - … |
+| `2286869349` | Your Daily Quest has been rerolled for …... |
+| `2303740299` | You've already used your starting kit! |
+| `2316242941` | Current Prestige Level: …/… |
+| `2316405313` | … |
+| `2320898349` | Shift spell disabled! |
+| `2321621014` | {fams} |
+| `2323778454` | No stat synergies found for …. |
+| `2332227846` | You have not prestiged in Exo yet. |
+| `2346236465` | Something fell out of your bag! |
+| `2350508902` | Invalid prestige type, use '.prestige l' to see... |
+| `2383766993` | Stat bonuses improvement: … |
+| `2402733055` | {parsedPrestigeType}[{exoPrestiges}] prestige complete! You have also been awarded... |
+| `2402916111` | No weekly reroll item configured or couldn't find... |
+| `2410464917` | Classes are not enabled. |
+| `2421466322` | … spells: |
+| `2428442751` | New unit unlocked: … |
+| `2437634726` | Level set to {level} for {foundUser.CharacterName.Value}! |
+| `2461283441` | Prestiges: |
+| `2462277004` | Couldn't find active box! |
+| `2465841402` | Couldn't find box! |
+| `2471836655` | Couldn't find familiar to unbind! If this doesn't... |
+| `2474938940` | Couldn't find matching familiar in boxes. |
+| `2480816305` | {expertiseHandler.GetWeaponType()} expertise set to [{level}] for {playerInfo.User.CharacterName.Value} |
+| `2486628899` | You don't have the required amount of {_vampiricDust.GetLocalizedName()}!... |
+| `2495105303` | You can't bind in combat or when using... |
+| `24953571` | Can't change or activate class spells when inventory... |
+| `2497805382` | No spells for {FormatClassName(playerClass.Value)} configured! |
+| `2508084566` | Level must be between 0 and …. |
+| `2511919794` | {count}\| {famName}{(familiarBuffsData.FamiliarBuffs.ContainsKey(famKey) ? $"{colorCode}* {levelAndPrestiges}" : $" {levelAndPrestiges}")} |
+| `2526362535` | Couldn't find active familiar.... |
+| `2537547396` | … bonus experience remaining from resting~ |
+| `2554001784` | {professionHandler.GetProfessionName()} set to [{level}] for {playerInfo.User.CharacterName.Value} |
+| `2557313311` | Familiar arena position changed! (only one arena currently... |
+| `2563987683` | Target cache isn't ready yet, check back shortly! |
+| `2577116713` | Couldn't find familiar actives or familiar already active!... |
+| `2615857787` | You've already completed your …! Time until …... |
+| `2637421818` | Couldn't find stat synergies for …... |
+| `2645405211` | Invalid spell, use '.class lsp' to see options. |
+| `2648123409` | VBlood familiars are not enabled. |
+| `2659109549` | {playerInfo.User.CharacterName.Value} removed from the ignore prestige leaderboard list! |
+| `2673031653` | Battle Group - … |
+| `2682530289` | You don't have the required amount of {_vampiricDust.GetLocalizedName()}!... |
+| `2687655344` | Your weapon stats have been reset for …! |
+| `2689850927` | Invalid familiar prestige stat type, use '.fam lst'... |
+| `2698551496` | Quests for … have been refreshed. |
+| `2709293439` | Your familiar is level [{xpData.Key}][{prestigeLevel}] and has {progress}... |
+| `2712082651` | Radius must be positive! |
+| `2712718738` | Your familiar has prestiged [{prestigeLevel}]; the accumulated knowledge... |
+| `2720898024` | You can't toggle combat for a familiar in... |
+| `2721627196` | Couldn't find matching vBlood! |
+| `2724064627` | Must have at least one unit unlocked to... |
+| `2740121583` | VBlood emotes disabled. |
+| `2747211297` | Removed all class buffs then applied current class... |
+| `2761429858` | Removed all class buffs for all players. |
+| `2772168133` | …[…] |
+| `2785130336` | {finalBloodStat} selected for {finalBloodType}! |
+| `27929505` | Invalid stat, use '.wep lst' to see valid... |
+| `2794958495` | {line} |
+| `2814501768` | ……* unbound! |
+| `2817263998` | {playerInfo.User.CharacterName} already has a pending challenge! |
+| `2817800174` | You've received a starting kit with: |
+| `2828720719` | Couldn't find experience data for … |
+| `284459823` | Multiple matches found! SmartBind doesn't support this yet...... |
+| `2846646667` | Invalid familiar prestige stat, use '.fam lst' to... |
+| `2881393089` | Expertise logging is now …. |
+| `2925666850` | Couldn't find binding preset, try binding or smartbind... |
+| `2932385107` | Targets have all been killed, give them a... |
+| `2935471585` | Valid professions: {ProfessionFactory.GetProfessionNames()} |
+| `2965167816` | No weapon stats available at this time. |
+| `2967576286` | Shift spell: {spellName} |
+| `2968342812` | You can't challenge another player while queued for... |
+| `2978826451` | {famName}{(buffsData.FamiliarBuffs.ContainsKey(familiarId) ? "{colorCode}*" : "")} [{level}][{prestiges}] added to... |
+| `2979158417` | Prestiging is not enabled. |
+| `2997561401` | … has been chosen for …! |
+| `2998300513` | Invalid slot (1 for Q or 2 for... |
+| `3013651462` | Couldn't find matching save method for weapon type... |
+| `3052690511` | {vBloodPrefabGuid.GetLocalizedName()} is not available per configured familiar bans! |
+| `3055272330` | Familiar attempting to prestige must be at max... |
+| `3055902112` | {parsedPrestigeType} prestiging is not enabled. |
+| `3060695596` | Second unarmed slot set to … for …. |
+| `3066749917` | {famName}{(buffsData.FamiliarBuffs.ContainsKey(familiarId) ? $"{colorCode}*" : "")} [{level}][{prestiges}] added to... |
+| `3084457547` | Available Weapon Expertises: {weaponTypes} |
+| `3097011724` | Invalid class, use '.class l' to see options. |
+| `3097544876` | … added to the ignore shared experience list! |
+| `3112026815` | Profession logging is now {(GetPlayerBool(steamId, PROFESSION_LOG_KEY) ? "enabled"... |
+| `3125006928` | Familiar already has {FamiliarPrestigeStats[value]} ({value + 1}) from... |
+| `3125108847` | You are now prepared for the hunt! |
+| `3133295357` | Your weapon expertise is […][…] and you have... |
+| `313887201` | Change spells to the ones you want in... |
+| `3139406824` | … removed from …. |
+| `3158650477` | No familiars in battle group! |
+| `3170250471` | Expertise handler for weapon is null; this shouldn't... |
+| `3170335283` | Couldn't find active familiar... |
+| `317079168` | Professions are not enabled. |
+| `3182929151` | Slot input out of range! (use 1, 2,... |
+| `318734715` | Familiar battles are not enabled. |
+| `3195375072` | {vBloodPrefabGuid.GetLocalizedName()} is already unlocked! |
+| `321106656` | Box Selected - {name} |
+| `3219279796` | You can't toggle combat for a familiar when... |
+| `3227554981` | … expertise set to […] for … |
+| `3235862068` | Your familiar has prestiged [{prestigeLevel}] and is now... |
+| `3236338434` | Box is full! |
+| `3254231727` | You're level [{data.Key}][{prestigeLevel}] with {progress} essence ({BloodSystem.GetLevelProgress(steamId, handler)}%)... |
+| `327031724` | Active familiar already present in battle group! |
+| `3274700132` | Your weapon stats have been reset for {weaponType}! |
+| `3279926559` | Added box - {name} |
+| `3318828181` | Prestige buffs applied! (if they were missing) |
+| `3320804900` | Available professions: {ProfessionFactory.GetProfessionNames()} |
+| `3320998835` | {prestiges} |
+| `3326145371` | You're level […][…] with … experience (…%)! |
+| `3334433396` | Familiar attempting to prestige must be at max... |
+| `3335571950` | Legacies are not enabled. |
+| `334075444` | Invalid quest type. (Daily/Weekly) |
+| `3343555659` | Player {playerInfo.User.CharacterName.Value} has been set to level {level}... |
+| `3361608225` | Invalid blood, use '.bl l' to see options. |
+| `3380184352` | Unable to verify cost for {vBloodPrefabGuid.GetPrefabName()}! |
+| `3399068440` | VBloods Slain: … \| Units Killed: … \|... |
+| `3402815477` | VBloods Slain: … \| Units Killed: … \|... |
+| `3443164458` | Shiny familiars enabled. |
+| `3466860311` | Failed to remove enough of the item required... |
+| `3468772905` | The maximum level for {parsedPrestigeType} prestige is {PrestigeTypeToMaxPrestiges[parsedPrestigeType]}. |
+| `3489173133` | {weaponType} Stats: {bonuses} |
+| `349267262` | Can't change or active class spells when inventory... |
+| `349704338` | Can't challenge another player until an existing challenge... |
+| `3498334942` | Unable to verify exo prestige reward item! ({exoItem}) |
+| `3499636759` | Time until … reset - … \| …... |
+| `3543031585` | {FormatClassName(playerClass)} passives: |
+| `3546356968` | Invalid unit prefab (match found but does not... |
+| `3587073963` | Current Exoform: {form} |
+| `3591926048` | Your weapon expertise is [{ExpertiseData.Key}][{prestigeLevel}] and you have... |
+| `361092587` | Deleted battle group …! |
+| `3613050716` | … stat synergies [x…]: |
+| `3628025920` | Active battle group set to {groupName}. |
+| `3637474013` | …… […][…] added to …! (…) |
+| `3637584655` | Failed to remove enough of the item required... |
+| `3648038609` | Player does not have an active … quest... |
+| `3664649404` | You can't challenge yourself! |
+| `3681675424` | Level must be between 0 and {ConfigService.MaxLevel}! |
+| `3706109126` | You have not prestiged in {parsedPrestigeType}. |
+| `3706417587` | Invalid quest type '{questTypeName}'. Valid values are: {string.Join(",... |
+| `370730849` | Your Weekly Quest has been rerolled for …... |
+| `3719118489` | Player has no active quests! |
+| `3720524051` | {FormatClassName(playerClass)} passives not found! |
+| `3729714988` | {parsedPrestigeType}[{exoPrestiges}] prestige complete! |
+| `3730830670` | Shift slots are not enabled. |
+| `3732046729` | Combat music cleared! |
+| `3744708697` | Invalid quest type '…'. Valid values are: … |
+| `3751423711` | Player does not have an active {questType} quest... |
+| `3756348742` | Reminders …. |
+| `3761416018` | First unarmed slot set to {new PrefabGUID(ability).GetPrefabName()} for... |
+| `3761848707` | Familiar arena position set, battle service started! (only... |
+| `3819833139` | You have no battle groups. |
+| `3823143990` | You don't have any quests yet, check back... |
+| `3862629133` | Battle group {groupName} created. |
+| `3863739608` | No bonuses from currently equipped weapon. |
+| `3878313095` | Couldn't find player... |
+| `3878896595` | Quests for {playerInfo.User.CharacterName.Value} have been refreshed. |
+| `3882215894` | Invalid shapeshift! Valid options: {shapeshifts} |
+| `3914295487` | … added to …. |
+| `3938051122` | Classes: {classTypes} |
+| `3938781329` | Not enough …x… for …! |
+| `3944404979` | Deleted battle group {groupName}! |
+| `3946665029` | Emote actions {(GetPlayerBool(steamId, EMOTE_ACTIONS_KEY) ? "enabled" : "disabled")}! |
+| `3960937922` | You can't toggle combat for a familiar when... |
+| `3961332984` | {parsedPrestigeType}[{exoPrestiges}] prestige complete! You have been awarded with... |
+| `3987763597` | … unbound! |
+| `400324857` | You haven't earned any experience yet! |
+| `4003734136` | … scrolling text …. |
+| `4007697799` | You don't have any quests yet, check back... |
+| `4009901629` | Your Weekly Quest has been rerolled for {item.GetLocalizedName()}... |
+| `4023020194` | You haven't gained any expertise for {weaponType} yet! |
+| `4049081768` | Your familiar has prestiged […]; the accumulated knowledge... |
+| `4051608029` | Blood Legacy logging {(GetPlayerBool(steamId, BLOOD_LOG_KEY) ? "enabled" :... |
+| `4052025947` | Shiny familiars disabled. |
+| `4052165110` | … (…) added to …. |
+| `4055019293` | Couldn't find any matches... |
+| `4061888430` | Blood Legacies are not enabled. |
+| `4066899438` | Shift spell enabled! |
+| `406861876` | Can't dismiss familiar when binding/unbinding! |
+| `4126149106` | Invalid blood type, use '.bl l' to see... |
+| `4140406916` | You haven't selected a class yet, use '.class... |
+| `4162514026` | Deleted battle group {groupName}. |
+| `4190631897` | … Stats: … |
+| `421960942` | VBlood emotes enabled. |
+| `4226920647` | … is not available per configured familiar bans! |
+| `4255236631` | New unit unlocked: {vBloodPrefabGuid.GetLocalizedName()} |
+| `4258273173` | Invalid blood legacy, use '.bl l' to see... |
+| `4273383622` | You couldn't afford to reroll your daily... (…... |
+| `4289445665` | Box is not empty! |
+| `442755566` | {FormatClassName(playerClass)} spells: |
+| `446698782` | Spells cannot be locked when using exoform. |
+| `460602473` | {FormatClassName(playerClass)} has no spells configured... |
+| `479209254` | Experience rate reduction for leveling no longer applies... |
+| `480925981` | Battle group not found. |
+| `484801240` | You have not reached the required level to... |
+| `488752679` | Level must be between 1 and {ConfigService.MaxFamiliarLevel} |
+| `493237764` | Level logging …. |
+| `501637283` | Class changed to {FormatClassName(playerClass)}! |
+| `508045935` | Emote actions {(GetPlayerBool(steamId, EMOTE_ACTIONS_KEY) ? "enabled" : "disabled")}! |
+| `52573990` | Expertise logging is now {(GetPlayerBool(steamId, WEAPON_LOG_KEY) ? "enabled"... |
+| `53933494` | Shiny changed! Rebind familiar to see effects. Use... |
+| `542066310` | Blood Legacy logging {(GetPlayerBool(steamId, BLOOD_LOG_KEY) ? "enabled" :... |
+| `54858227` | Your familiar has prestiged [{prestigeLevel}] and is now... |
+| `559704045` | … passives: |
+| `563018011` | Invalid quest type '{questTypeName}'. Valid values are: {string.Join( |
+| `566938273` | Level set to … for …! |
+| `608689499` | Growth rate reduction from … prestige level: -… |
+| `615667259` | Couldn't find active familiar box to remove from... |
+| `617911048` | Reminders …. |
+| `625301684` | Can't have more than {MAX_BATTLE_GROUPS} battle groups! |
+| `628275031` | Familiar actives and followers cleared. |
+| `66882170` | You don't have the required amount of …!... |
+| `677404705` | No spell for class default configured! |
+| `677562659` | No daily reroll item configured or couldn't find... |
+| `692006723` | The … quest is already complete for …. |
+| `698362524` | Box {current} renamed - {name} |
+| `701382701` | Familiar prestige is not enabled. |
+| `705325693` | Familiar already has all prestige stats! ('.fam pr'... |
+| `707311945` | You couldn't afford to reroll your wekly... ({item.GetLocalizedName()}... |
+| `714432788` | You've already selected {FormatClassName(currentClass.Value)}, use '.class c [Class]'... |
+| `719993404` | You don't have the required item to reset... |
+| `736301693` | Expertise logging is now {(GetPlayerBool(steamId, WEAPON_LOG_KEY) ? "enabled"... |
+| `743202161` | You don't have a …. |
+| `743696282` | You're level [{level}][{prestigeLevel}] with {progress} experience ({percent}%)! |
+| `744989655` | You can't call a familiar when using batform! |
+| `780970161` | {familiarId.GetLocalizedName()} removed from {activeBox}. |
+| `800655279` | …: … …x… […/…] |
+| `802918832` | Familiar is already at maximum number of prestiges! |
+| `816810753` | You must consume Megara's essence before manifesting her... |
+| `823180732` | {PrefabGUID.GetLocalizedName()} moved - {name} |
+| `830139985` | You have not prestiged in {PrestigeType.Experience}. |
+| `835889078` | Can't have more than … battle groups! |
+| `835968431` | … passives not found! |
+| `836746607` | Enough charge to maintain form for {(int)exoFormData.Value}s |
+| `842146063` | Level must be between 0 and …! |
+| `854134032` | You don't have any unlocks yet! |
+| `85537047` | Available Blood Legacies: {bloodTypesList} |
+| `85794626` | Invalid index for active box, try binding or... |
+| `860320001` | Your Daily Quest has been rerolled for {item.GetLocalizedName()}... |
+| `861952046` | Couldn't find active box! Use '.fam listboxes' and... |
+| `863911874` | {count}\| {famName}{(familiarBuffsData.FamiliarBuffs.ContainsKey(famKey) ? $ |
+| `872190851` | Failed to remove schematics from your inventory! |
+| `881612152` | Exo form emote action (taunt) {(GetPlayerBool(steamId, SHAPESHIFT_KEY) ?... |
+| `885434933` | Shift spell: … |
+| `907868427` | Position in queue: {position} ({Misc.FormatTimespan(timeRemaining)}) |
+| `931800025` | … |
+| `935039462` | Familiar already has … (…) from prestiging, use... |
+| `939340687` | No stats selected for {bloodType}, use '.bl lst'... |
+| `947371822` | You've selected {FormatClassName(playerClass)}! |
+| `947905559` | Leaderboards are not enabled. |
+| `9562573` | … has no spells configured... |
+| `9816116` | You have reached the maximum amount of Exo... |
+| `985830382` | Expertise is not enabled. |
+| `998944061` | The {questType} quest is already complete for {playerInfo.User.CharacterName.Value}. |
+| `999548370` | {FormatClassName(playerClass)} stat synergies[x{ConfigService.SynergyMultiplier}]: |
+| `binding-failed` | Binding failed... |
+| `emote-actions-bat-form` | You can't use emote actions when using bat... |
+| `emote-actions-dominate-form` | You can't use emote actions when using dominate... |
+| `familiar-active-not-exist` | Active familiar doesn't exist! If that doesn't seem... |
+| `familiar-call-pvp-combat` | You can't call your familiar during PvP combat! |
+| `familiar-combat-disabled` | Familiar combat disabled. |
+| `familiar-combat-enabled` | Familiar combat enabled. |
+| `familiar-combat-not-enabled` | Familiar combat is not enabled. |
+| `familiar-combat-toggle-in-combat` | You can't toggle familiar combat mode during PvE/PvP... |
+| `familiar-interact-binding` | Can't interact with familiar when binding/unbinding! |
+| `familiar-interact-combat` | You can't interact with your familiar during combat! |
+| `familiar-interact-dismissed` | Can't interact with familiar when dismissed! |
+| `familiar-not-found` | Couldn't find active familiar... |
+| `profession-bonus-received` | …x… received from … |
+| `profession-bonus-saplings-dropped` | Bonus Saplings(s)x… received from …, but some fell... |
+| `profession-bonus-saplings-received` | Bonus Saplings(s)x… received from …! |
+| `profession-bonus-seeds-dropped` | Bonus Seed(s)x… received from …, but some fell... |
+| `profession-bonus-seeds-received` | Bonus Seed(s)x… received from …! |
+| `profession-gold-ore-dropped` | Gold Orex… received from …, but it dropped... |
+| `profession-gold-ore-received` | Gold Orex… received from … |
+| `profession-improved` | … improved to […] |
+| `profession-mutant-grease-dropped` | Mutant Greasex… received from …, but it dropped... |
+| `profession-mutant-grease-received` | Mutant Greasex… received from … |
+| `profession-proficiency-gain` | +… proficiency in … (…%) |
+| `profession-radiant-fiber-dropped` | Radiant Fiberx… received from …, but it dropped... |
+| `profession-radiant-fiber-received` | Radiant Fiberx… received from … |
+| `quest-daily-refreshed` | Your Daily Quest has been refreshed! |
+| `quest-new-daily` | New Daily Quest available: … …x… […/…] |
+| `quest-reward-dropped` | You've received …x… for completing your …! It... |
+| `quest-reward-received` | You've received …x… for completing your …! |
+| `quest-weekly-refreshed` | Your Weekly Quest has been refreshed! |
+| `shapeshift-not-enough-energy` | Not enough energy to maintain form... (…) |
+| `shapeshift-select-form` | Select a form you've unlocked first! ('.prestige sf... |
+| `welcome` | Welcome to Bloodcraft |

--- a/Tools/generate_message_catalog.py
+++ b/Tools/generate_message_catalog.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Generate a catalog of message keys from English.json.
+
+Regenerates Docs/MessageKeys.md when Resources/Localization/Messages/English.json
+is newer. Run this after modifying English.json to keep the catalog current.
+"""
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGLISH_PATH = ROOT / "Resources" / "Localization" / "Messages" / "English.json"
+DOC_PATH = ROOT / "Docs" / "MessageKeys.md"
+
+
+def summarize(text: str, max_words: int = 8) -> str:
+    # Strip color tags and other markup
+    text = re.sub(r"<[^>]+>", "", text)
+    # Replace placeholders with ellipsis
+    text = re.sub(r"\{\d+\}", "…", text)
+    words = text.split()
+    snippet = " ".join(words[:max_words])
+    if len(words) > max_words:
+        snippet += "..."
+    return snippet
+
+
+def main() -> int:
+    if not ENGLISH_PATH.exists():
+        print(f"Missing {ENGLISH_PATH}")
+        return 1
+
+    english_mtime = ENGLISH_PATH.stat().st_mtime
+    doc_mtime = DOC_PATH.stat().st_mtime if DOC_PATH.exists() else 0
+    if english_mtime <= doc_mtime:
+        return 0  # Up to date
+
+    data = json.loads(ENGLISH_PATH.read_text())
+    messages = data.get("Messages", {})
+
+    lines = [
+        "# Message Key Catalog",
+        "",
+        "Auto-generated from `Resources/Localization/Messages/English.json`.",
+        "",
+        "| Key | Description |",
+        "| --- | --- |",
+    ]
+
+    for key in sorted(messages):
+        desc = summarize(messages[key])
+        desc = desc.replace("|", "\\|")  # escape pipes
+        lines.append(f"| `{key}` | {desc} |")
+
+    DOC_PATH.write_text("\n".join(lines) + "\n")
+    print(f"Wrote {DOC_PATH}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- generate Docs/MessageKeys.md catalog from English.json
- add script to update catalog when messages change
- note in localization guide to consult the catalog first

## Testing
- `dotnet test Bloodcraft.Tests/Bloodcraft.Tests.csproj` *(fails: You must install or update .NET to run this application.)*


------
https://chatgpt.com/codex/tasks/task_e_689d59dda688832db2bba0abd3ef526b