### PR TITLE
Limit fix_tokens scope to current language

### DIFF
--- a/Tools/localization_pipeline.py
+++ b/Tools/localization_pipeline.py
@@ -120,7 +120,7 @@ def main() -> None:
             "skipped.csv",
             "--overwrite",
         ])
-        run([sys.executable, "Tools/fix_tokens.py"])
+        run([sys.executable, "Tools/fix_tokens.py", str(path.relative_to(ROOT))])
 
     # Step 5: verify translations
     run(["dotnet", "run", "--project", "Bloodcraft.csproj", "-p:RunGenerateREADME=false", "--", "check-translations"])


### PR DESCRIPTION
## Summary
- ensure localization pipeline runs fix_tokens only on the current language file

## Testing
- `pytest`
- `dotnet test Bloodcraft.Tests/Bloodcraft.Tests.csproj` *(fails: You must install or update .NET to run this application)*

------
https://chatgpt.com/codex/tasks/task_e_689d74ab7830832dbc4b56f49cc55a20