### PR TITLE
Reuse executor for batch translation

### DIFF
--- a/Tools/translate_argos.py
+++ b/Tools/translate_argos.py
@@ -109,9 +109,9 @@ def translate_batch(
     """
     results: List[str] = []
     timed_out: List[int] = []
-    for idx, line in enumerate(lines):
-        for attempt in range(1, max_retries + 1):
-            with ThreadPoolExecutor(max_workers=1) as executor:
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        for idx, line in enumerate(lines):
+            for attempt in range(1, max_retries + 1):
                 future = executor.submit(translator.translate, line)
                 try:
                     results.append(future.result(timeout=timeout))


### PR DESCRIPTION
## Summary
- reuse a shared ThreadPoolExecutor across line translations
- keep per-line timeouts via `future.result(timeout)`

## Testing
- `pytest Tools/test_translate_argos.py Tools/test_language_utils.py`
- `dotnet test Bloodcraft.Tests/Bloodcraft.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689d7766ec24832db2557aa2a5a36c92