### PR TITLE
feat: enhance localization workflow resilience

### DIFF
--- a/Tools/fix_tokens.py
+++ b/Tools/fix_tokens.py
@@ -25,6 +25,18 @@ def replace_placeholders(value: str, tokens: List[str]) -> Tuple[str, bool, bool
     return value, True, mismatch
 
 
+def reorder_tokens_in_text(value: str, tokens: List[str]) -> Tuple[str, bool]:
+    found = TOKEN_PATTERN.findall(value or "")
+    if len(found) != len(tokens):
+        return value, False
+    if found == tokens:
+        return value, False
+    token_iter = iter(tokens)
+    def repl(_m: re.Match) -> str:
+        return next(token_iter)
+    return TOKEN_PATTERN.sub(repl, value, count=len(tokens)), True
+
+
 def load_english_messages(root: Path) -> Dict[str, List[str]]:
     path = root / "Resources" / "Localization" / "Messages" / "English.json"
     with open(path, "r", encoding="utf-8") as f:
@@ -46,7 +58,9 @@ def load_english_nodes(root: Path) -> Dict[str, List[str]]:
     return mapping
 
 
-def process_messages_file(path: Path, baseline: Dict[str, List[str]], check_only: bool) -> bool:
+def process_messages_file(
+    path: Path, baseline: Dict[str, List[str]], check_only: bool, reorder: bool
+) -> bool:
     with open(path, "r", encoding="utf-8") as f:
         data = json.load(f)
     messages = data.get("Messages", {})
@@ -54,11 +68,18 @@ def process_messages_file(path: Path, baseline: Dict[str, List[str]], check_only
     mismatch = False
     for key, text in list(messages.items()):
         new_text, replaced, bad = replace_placeholders(text, baseline.get(key, []))
-        if replaced:
+        reordered = False
+        if reorder and not bad:
+            new_text, reordered = reorder_tokens_in_text(new_text, baseline.get(key, []))
+        if replaced or reordered:
             if bad:
                 print(f"{path}: {key} token count mismatch")
-            else:
+            elif replaced and reordered:
+                print(f"{path}: {key} tokens restored and reordered")
+            elif replaced:
                 print(f"{path}: {key} tokens restored")
+            else:
+                print(f"{path}: {key} tokens reordered")
             if not check_only:
                 messages[key] = new_text
             changed = True
@@ -69,7 +90,9 @@ def process_messages_file(path: Path, baseline: Dict[str, List[str]], check_only
     return changed or mismatch
 
 
-def process_root_file(path: Path, baseline: Dict[str, List[str]], check_only: bool) -> bool:
+def process_root_file(
+    path: Path, baseline: Dict[str, List[str]], check_only: bool, reorder: bool
+) -> bool:
     with open(path, "r", encoding="utf-8") as f:
         data = json.load(f)
     nodes = data.get("nodes") or data.get("Nodes") or []
@@ -84,11 +107,18 @@ def process_root_file(path: Path, baseline: Dict[str, List[str]], check_only: bo
         if not isinstance(text, str):
             continue
         new_text, replaced, bad = replace_placeholders(text, baseline.get(guid, []))
-        if replaced:
+        reordered = False
+        if reorder and not bad:
+            new_text, reordered = reorder_tokens_in_text(new_text, baseline.get(guid, []))
+        if replaced or reordered:
             if bad:
                 print(f"{path}: {guid} token count mismatch")
-            else:
+            elif replaced and reordered:
+                print(f"{path}: {guid} tokens restored and reordered")
+            elif replaced:
                 print(f"{path}: {guid} tokens restored")
+            else:
+                print(f"{path}: {guid} tokens reordered")
             if not check_only:
                 node[text_key] = new_text
             changed = True
@@ -103,6 +133,7 @@ def main() -> None:
     ap = argparse.ArgumentParser(description="Fix token placeholders in localization JSON files")
     ap.add_argument("--root", default=Path(__file__).resolve().parents[1], help="Repo root")
     ap.add_argument("--check-only", action="store_true", help="Report issues without modifying files")
+    ap.add_argument("--reorder", action="store_true", help="Reorder tokens when counts match")
     ap.add_argument("paths", nargs="*", help="Specific localization JSON files to process")
     args = ap.parse_args()
 
@@ -125,9 +156,9 @@ def main() -> None:
     issues = False
     for path in files:
         if path.parent.name == "Messages":
-            issues |= process_messages_file(path, messages_tokens, args.check_only)
+            issues |= process_messages_file(path, messages_tokens, args.check_only, args.reorder)
         else:
-            issues |= process_root_file(path, node_tokens, args.check_only)
+            issues |= process_root_file(path, node_tokens, args.check_only, args.reorder)
 
     if args.check_only and issues:
         raise SystemExit(1)

--- a/Tools/test_fix_tokens.py
+++ b/Tools/test_fix_tokens.py
@@ -1,0 +1,33 @@
+import json
+import sys
+
+import fix_tokens
+
+
+def test_reorder_option(tmp_path, monkeypatch):
+    root = tmp_path
+    messages_dir = root / "Resources" / "Localization" / "Messages"
+    messages_dir.mkdir(parents=True)
+    (messages_dir / "English.json").write_text(
+        json.dumps({"Messages": {"hash": "{a} {b}"}})
+    )
+    # minimal root-level English file for load_english_nodes
+    (root / "Resources" / "Localization" / "English.json").write_text(json.dumps({}))
+    target = messages_dir / "Test.json"
+    target.write_text(json.dumps({"Messages": {"hash": "{b} {a}"}}))
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "fix_tokens.py",
+            "--root",
+            str(root),
+            "--reorder",
+            str(target),
+        ],
+    )
+
+    fix_tokens.main()
+    data = json.loads(target.read_text())
+    assert data["Messages"]["hash"] == "{a} {b}"


### PR DESCRIPTION
## Summary
- add strict token protection and fallback to English in translate_argos
- optionally reorder tokens in fix_tokens
- aggregate and summarize skipped translations in localization pipeline

## Testing
- `pytest Tools/test_language_utils.py Tools/test_translate_argos.py Tools/test_fix_tokens.py`


------
https://chatgpt.com/codex/tasks/task_e_689dc1fd3e94832da8062d57cf3893af