### PR TITLE
docs: document hash propagation in localization guide

### DIFF
--- a/Docs/Localization.md
+++ b/Docs/Localization.md
@@ -20,6 +20,14 @@ LocalizationService.Reply(ctx, "You're level {0}", level);
 
 When you add or change a message, update every JSON file under `Resources/Localization/Messages` to include the same numbered placeholders `{0}`, `{1}`, etc. so translations match the English template.
 
+Propagate hash keys from the English source into each language file by running:
+
+```bash
+python Tools/propagate_hashes.py Resources/Localization/Messages/<Language>.json
+```
+
+The script preserves existing translations, adds any new English hashes, and removes obsolete ones. See [`Tools/propagate_hashes.py`](../Tools/propagate_hashes.py) for details.
+
 ## Automated Translation for Messages
 
 Only the JSON files in `Resources/Localization/Messages` contain user-facing messages. Use Argos Translate to automate translating these files:


### PR DESCRIPTION
## Summary
- clarify how to run Tools/propagate_hashes.py when updating language JSONs
- explain that propagate_hashes preserves translations, adds new hashes, and removes obsolete ones
- link directly to helper script for quick reference

## Testing
- `dotnet test Bloodcraft.Tests/Bloodcraft.Tests.csproj` *(fails: You must install or update .NET to run this application. Framework 'Microsoft.NETCore.App', version '6.0.0' was not found)*

------
https://chatgpt.com/codex/tasks/task_e_689deebe419c832da18f7d6de6f55339