### PR TITLE
Handle split token markers

### DIFF
--- a/Tools/test_fix_tokens.py
+++ b/Tools/test_fix_tokens.py
@@ -2,6 +2,7 @@ import json
 import sys
 
 import fix_tokens
+import translate_argos
 
 
 def test_reorder_option(tmp_path, monkeypatch):
@@ -31,3 +32,13 @@ def test_reorder_option(tmp_path, monkeypatch):
     fix_tokens.main()
     data = json.loads(target.read_text())
     assert data["Messages"]["hash"] == "{a} {b}"
+
+
+def test_normalize_tokens_merge_with_space():
+    raw = "[[TOKEN_1 0]]"
+    assert translate_argos.normalize_tokens(raw) == "[[TOKEN_10]]"
+
+
+def test_normalize_tokens_merge_adjacent():
+    raw = "[[TOKEN_1]][[TOKEN_0]]"
+    assert translate_argos.normalize_tokens(raw) == "[[TOKEN_10]]"


### PR DESCRIPTION
## Summary
- merge split multi-digit token markers in `normalize_tokens`
- add regression tests for combined token patterns

## Testing
- `pytest Tools/test_fix_tokens.py Tools/test_translate_argos.py::test_normalize_and_reorder_many_tokens -q`


------
https://chatgpt.com/codex/tasks/task_e_689e0b215c2c832da6e86d86af0255cf