### PR TITLE
chore: update Argos Translate for v6 models

### DIFF
--- a/.codex/install.sh
+++ b/.codex/install.sh
@@ -35,8 +35,8 @@ if ! grep -q "DOTNET_ROOT" "$HOME/.bashrc"; then
     echo "export PATH=\$DOTNET_ROOT:\$PATH:\$HOME/.local/bin" >> "$HOME/.bashrc"
 fi
 
-# Install Argos Translate and expose CLI
-python3 -m pip install --user --no-cache-dir argostranslate==1.8.0
+# Install Argos Translate (CTranslate2 v6 support) and expose CLI
+python3 -m pip install --user --no-cache-dir argostranslate==1.9.6
 mkdir -p "$HOME/.local/bin"
 cat >"$HOME/.local/bin/argos-translate" <<'EOF'
 #!/usr/bin/env bash

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Jairon O.; Odjit; Jera; Kokuren TCG and Gaming Shop; Rexxn; Eduardo G.; DirtyMik
 
 ## Development setup
 
-Run `.codex/install.sh` once to install the .NET SDK, the .NET 6 runtime, and Argos Translate dependencies. After running the script, verify the runtime with `dotnet --list-runtimes` and ensure `Microsoft.NETCore.App 6.0.x` is listed. See
+Run `.codex/install.sh` once to install the .NET SDK, the .NET 6 runtime, and Argos Translate dependencies. The script installs Argos Translate 1.9.6 or later to support CTranslate2 model binary v6. After running the script, verify the runtime with `dotnet --list-runtimes` and ensure `Microsoft.NETCore.App 6.0.x` is listed. See
 [AGENTS.md](AGENTS.md) for the full workflow. For instructions on customizing
 `FROM_LANG` and `TO_LANG`, jump to the [Localization](#localization-wip) section.
 
@@ -788,7 +788,7 @@ Run `.codex/install.sh` once to install the .NET SDK, the .NET 6 runtime, and A
   
 ## Development Setup
 
-Run `.codex/install.sh` once to install the .NET SDK, the .NET 6 runtime, and Argos Translate. The script adds
+Run `.codex/install.sh` once to install the .NET SDK, the .NET 6 runtime, and Argos Translate. The script installs Argos Translate 1.9.6 or later for CTranslate2 v6 model support and adds
 `~/.local/bin` to your `PATH` so the `argos-translate` CLI is available in future sessions. Confirm the runtime with `dotnet --list-runtimes` and look for `Microsoft.NETCore.App 6.0.x`.
 
 ## Localization (WIP)


### PR DESCRIPTION
## Summary
- upgrade Argos Translate to 1.9.6 for CTranslate2 model binary v6 support
- document new Argos Translate requirement in setup instructions

## Testing
- `python3 -c "import importlib.metadata as m; print(m.version('argostranslate'))"`
- `python Tools/translate_argos.py /tmp/French_copy.json --to fr --hash welcome --log-file translate.log --report-file skipped.csv --overwrite --verbose --timeout 120`


------
https://chatgpt.com/codex/tasks/task_e_689f516ba7bc832d949751f5aff128e2