### PR TITLE
Add logging and metrics to localization pipeline

### DIFF
--- a/Tools/localization_pipeline.py
+++ b/Tools/localization_pipeline.py
@@ -10,13 +10,14 @@ If no languages are provided, all available languages are processed.
 from __future__ import annotations
 
 import argparse
+import csv
 import json
+import logging
 import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict
-import csv
-from collections import Counter
 
 ROOT = Path(__file__).resolve().parents[1]
 MESSAGES_DIR = ROOT / "Resources" / "Localization" / "Messages"
@@ -44,9 +45,23 @@ LANGUAGE_CODES: Dict[str, str] = {
 }
 
 
+logger = logging.getLogger("localization_pipeline")
+
+
+def setup_logging(debug: bool) -> None:
+    """Configure root logging for the script."""
+    level = logging.DEBUG if debug else logging.INFO
+    logging.basicConfig(level=level, format="%(asctime)s [%(levelname)s] %(message)s")
+
+
+def timestamp() -> str:
+    """Return the current UTC time in ISO format."""
+    return datetime.now(timezone.utc).isoformat()
+
+
 def run(cmd: list[str], *, check: bool = True) -> subprocess.CompletedProcess:
     """Run a subprocess, returning the completed process."""
-    print("+", " ".join(str(c) for c in cmd))
+    logger.debug("+ %s", " ".join(str(c) for c in cmd))
     return subprocess.run(cmd, check=check, cwd=ROOT)
 
 
@@ -75,12 +90,17 @@ def main() -> None:
         description="Run the full localization pipeline",
         epilog="Languages default to all available message files",
     )
+    ap.add_argument("--debug", action="store_true", help="Enable debug logging")
     ap.add_argument(
         "languages",
         nargs="*",
         help="Languages to process (e.g. French German). Default: all",
     )
     args = ap.parse_args()
+
+    setup_logging(args.debug)
+
+    metrics: Dict[str, Dict] = {"steps": {}, "languages": {}}
 
     available = {p.stem: p for p in MESSAGES_DIR.glob("*.json") if p.name != "English.json"}
     if args.languages:
@@ -93,20 +113,35 @@ def main() -> None:
         targets = available
 
     # Step 1: regenerate English messages
-    run(["dotnet", "run", "--project", "Bloodcraft.csproj", "-p:RunGenerateREADME=false", "--", "generate-messages"])
+    metrics["steps"]["generation"] = {"start": timestamp()}
+    run([
+        "dotnet",
+        "run",
+        "--project",
+        "Bloodcraft.csproj",
+        "-p:RunGenerateREADME=false",
+        "--",
+        "generate-messages",
+    ])
+    metrics["steps"]["generation"]["end"] = timestamp()
 
     # Step 2: propagate new hashes
+    metrics["steps"]["propagation"] = {"start": timestamp()}
     for path in targets.values():
         propagate_hashes(path)
+    metrics["steps"]["propagation"]["end"] = timestamp()
 
-    # Step 3-4: translate and fix tokens per language
-    failure_counts: Counter[str] = Counter()
-    overall_ok = True
+    # Step 3: translate per language
+    metrics["steps"]["translation"] = {"start": timestamp()}
     for name, path in targets.items():
+        lang_metrics = metrics["languages"].setdefault(name, {"skipped_hashes": {}})
         code = LANGUAGE_CODES.get(name)
         if not code:
-            print(f"Skipping {name}: no translation code configured")
+            logger.warning("Skipping %s: no translation code configured", name)
+            lang_metrics["skipped"] = True
             continue
+        lang_metrics["skipped"] = False
+        t_start = timestamp()
         result = run(
             [
                 sys.executable,
@@ -127,26 +162,81 @@ def main() -> None:
             ],
             check=False,
         )
+        t_end = timestamp()
+        lang_metrics["translation"] = {
+            "start": t_start,
+            "end": t_end,
+            "returncode": result.returncode,
+        }
         report = ROOT / "skipped.csv"
+        skipped_counts: Dict[str, int] = {}
         if report.is_file():
             with report.open("r", encoding="utf-8") as fp:
                 reader = csv.DictReader(fp)
                 for row in reader:
-                    failure_counts[row.get("reason", "")] += 1
+                    reason = row.get("reason", "")
+                    skipped_counts[reason] = skipped_counts.get(reason, 0) + 1
             report.unlink()
-        overall_ok &= result.returncode == 0
-        run([sys.executable, "Tools/fix_tokens.py", str(path.relative_to(ROOT))])
+        lang_metrics["skipped_hashes"] = skipped_counts
+    metrics["steps"]["translation"]["end"] = timestamp()
 
-    if failure_counts:
-        print("Skipped translation summary:")
-        for reason, count in failure_counts.most_common():
-            print(f"  {reason}: {count}")
-        raise SystemExit(1)
-    if not overall_ok:
-        raise SystemExit(1)
+    # Step 4: fix tokens per language
+    metrics["steps"]["token_fix"] = {"start": timestamp()}
+    for name, path in targets.items():
+        lang_metrics = metrics["languages"].get(name)
+        if not lang_metrics or lang_metrics.get("skipped"):
+            continue
+        t_start = timestamp()
+        result = run(
+            [sys.executable, "Tools/fix_tokens.py", str(path.relative_to(ROOT))],
+            check=False,
+        )
+        t_end = timestamp()
+        lang_metrics["token_fix"] = {
+            "start": t_start,
+            "end": t_end,
+            "returncode": result.returncode,
+        }
+    metrics["steps"]["token_fix"]["end"] = timestamp()
+
+    overall_ok = True
+    for lang_metrics in metrics["languages"].values():
+        if lang_metrics.get("skipped"):
+            continue
+        translation_ok = lang_metrics["translation"]["returncode"] == 0
+        token_ok = lang_metrics["token_fix"]["returncode"] == 0
+        skipped_total = sum(lang_metrics["skipped_hashes"].values())
+        lang_metrics["skipped_hash_count"] = skipped_total
+        success = translation_ok and token_ok and skipped_total == 0
+        lang_metrics["success"] = success
+        overall_ok &= success
 
     # Step 5: verify translations
-    run(["dotnet", "run", "--project", "Bloodcraft.csproj", "-p:RunGenerateREADME=false", "--", "check-translations"])
+    metrics["steps"]["verification"] = {"start": timestamp()}
+    verify_proc = run(
+        [
+            "dotnet",
+            "run",
+            "--project",
+            "Bloodcraft.csproj",
+            "-p:RunGenerateREADME=false",
+            "--",
+            "check-translations",
+        ],
+        check=False,
+    )
+    metrics["steps"]["verification"].update(
+        {"end": timestamp(), "returncode": verify_proc.returncode}
+    )
+    overall_ok &= verify_proc.returncode == 0
+
+    metrics_path = ROOT / "localization_metrics.json"
+    with metrics_path.open("w", encoding="utf-8") as f:
+        json.dump(metrics, f, indent=2, ensure_ascii=False)
+    print(metrics_path)
+
+    if not overall_ok:
+        raise SystemExit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add debug-enabled logging helper
- capture timing and per-language metrics for localization steps
- emit JSON summary of pipeline results

## Testing
- `python -m pytest Tools`
- `dotnet test Bloodcraft.Tests/Bloodcraft.Tests.csproj` *(fails: You must install or update .NET to run this application)*

------
https://chatgpt.com/codex/tasks/task_e_689f86d31778832db75d2194d91dc657