### PR TITLE
Add translation metrics tracking

### DIFF
--- a/Tools/test_translate_argos.py
+++ b/Tools/test_translate_argos.py
@@ -765,7 +765,7 @@ def test_metrics_file_records_failure_reason(tmp_path, monkeypatch):
     data = json.loads(metrics_path.read_text())
     entry = data[-1]
     assert entry["processed"] == 1
-    assert entry["success"] == 0
+    assert entry["successes"] == 0
     assert entry["timeouts"] == 0
     assert entry["token_reorders"] == 0
     assert "identical" in entry["failures"]["hash"].lower()
@@ -824,7 +824,7 @@ def test_metrics_file_records_timeout(tmp_path, monkeypatch):
     data = json.loads(metrics_path.read_text())
     entry = data[-1]
     assert entry["processed"] == 1
-    assert entry["success"] == 0
+    assert entry["successes"] == 0
     assert entry["timeouts"] == 1
     assert entry["token_reorders"] == 0
     reason = next(iter(entry["failures"].values()))
@@ -880,7 +880,7 @@ def test_metrics_file_counts_token_reorders(tmp_path, monkeypatch):
     data = json.loads(metrics_path.read_text())
     entry = data[-1]
     assert entry["processed"] == 1
-    assert entry["success"] == 1
+    assert entry["successes"] == 1
     assert entry["timeouts"] == 0
     assert entry["token_reorders"] == 1
     assert entry["failures"] == {}

--- a/Tools/translate_argos.py
+++ b/Tools/translate_argos.py
@@ -265,7 +265,7 @@ def _run_translation(args, root: str, log_fp) -> None:
     failures: dict[str, tuple[str, str]] = {}
     report: list[dict[str, str]] = []
     category_counts: Counter[str] = Counter()
-    processed = len(safe_lines)
+    processed_lines = len(safe_lines)
     timeouts_count = 0
     token_reorders = 0
     timed_out_hashes: set[str] = set()
@@ -546,7 +546,7 @@ def _run_translation(args, root: str, log_fp) -> None:
     if not args.verbose:
         print(breakdown_msg)
 
-    successes = processed - len(failures)
+    successes = processed_lines - len(failures)
 
     messages.update(translated)
     target["Messages"] = messages
@@ -590,8 +590,8 @@ def _run_translation(args, root: str, log_fp) -> None:
     metrics_entry = {
         "file": args.target_file,
         "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-        "processed": processed,
-        "success": successes,
+        "processed": processed_lines,
+        "successes": successes,
         "timeouts": timeouts_count,
         "token_reorders": token_reorders,
         "failures": {k: v[0] for k, v in failures.items()},
@@ -608,7 +608,7 @@ def _run_translation(args, root: str, log_fp) -> None:
         json.dump(metrics_log, fp, indent=2, ensure_ascii=False)
 
     summary_line = (
-        f"Summary: {successes}/{processed} translated, {timeouts_count} timeouts, "
+        f"Summary: {successes}/{processed_lines} translated, {timeouts_count} timeouts, "
         f"{token_reorders} token reorders. Metrics written to {args.metrics_file}"
     )
     print(summary_line)


### PR DESCRIPTION
## Summary
- track translation stats and failure reasons in a metrics log
- allow specifying metrics destination with `--metrics-file`
- update unit tests for new metrics fields

## Testing
- `pytest Tools`


------
https://chatgpt.com/codex/tasks/task_e_689fd7a3bdb0832dafac84175806c948