### PR TITLE
feat: support metrics path creation

### DIFF
--- a/Tools/fix_tokens.py
+++ b/Tools/fix_tokens.py
@@ -190,7 +190,8 @@ def main() -> None:
 
     metrics_path = None
     if args.metrics_file:
-        metrics_path = Path(args.metrics_file)
+        metrics_path = Path(args.metrics_file).resolve()
+        metrics_path.parent.mkdir(parents=True, exist_ok=True)
         with open(metrics_path, "w", encoding="utf-8") as f:
             json.dump(
                 {


### PR DESCRIPTION
## Summary
- ensure fix_tokens metrics file path is absolute and parent directories exist

## Testing
- `pytest -q Tools/test_fix_tokens.py`

------
https://chatgpt.com/codex/tasks/task_e_689fdcd83d64832d9d8a912345845bee