### PR TITLE
Add JSON summary for translation checks

### DIFF
--- a/Docs/Localization.md
+++ b/Docs/Localization.md
@@ -85,10 +85,10 @@ Only the JSON files in `Resources/Localization/Messages` contain user-facing mes
 After updating the files, run:
 
 ```bash
-dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations
+dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations --summary-json summary.json
 ```
 
-The command should report no hash changes, confirming placeholders are aligned across languages.
+The command should report no hash changes, confirming placeholders are aligned across languages. Use `--summary-json <path>` to capture aggregate counts per language.
 
 ## Automated validation
 

--- a/GenerateREADME.cs
+++ b/GenerateREADME.cs
@@ -45,16 +45,19 @@ internal static class GenerateREADME
         {
             string root = Directory.GetCurrentDirectory();
             bool showText = false;
+            string? summaryJson = null;
             for (int i = 1; i < args.Length; i++)
             {
                 string arg = args[i];
                 if (arg.Equals("--show-text", StringComparison.OrdinalIgnoreCase) || arg.Equals("--verbose", StringComparison.OrdinalIgnoreCase))
                     showText = true;
+                else if (arg.Equals("--summary-json", StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length)
+                    summaryJson = args[++i];
                 else if (!arg.StartsWith("-"))
                     root = arg;
             }
 
-            Tools.CheckTranslations.Run(root, showText);
+            Tools.CheckTranslations.Run(root, showText, summaryJson);
             return;
         }
 

--- a/README.md
+++ b/README.md
@@ -820,8 +820,8 @@ This process applies only to files under `Resources/Localization/Messages`.
    ```
    Running with `--check-only` fails fast if tokens were altered.
 5. **Verify translations.**
-   `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations --show-text`
-   This command confirms every hash exists and no English text remains.
+   `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations --show-text --summary-json summary.json`
+   This command confirms every hash exists and no English text remains. Use `--summary-json <path>` to write aggregate counts for each language.
 
    The CI pipeline also enforces this by running:
 


### PR DESCRIPTION
## Summary
- track missing and English-like translations per language
- add `--summary-json` flag to output aggregate counts and exit non-zero when issues are found
- document new summary flag in translation workflow guides

## Testing
- `dotnet test Bloodcraft.Tests/Bloodcraft.Tests.csproj` *(fails: requires .NET 6 runtime)*
- `dotnet build -p:RunGenerateREADME=false`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fe8a269d8832daaba268690ee6958