### PR TITLE
docs: document localization metrics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,9 @@ Current PRDs and task lists are stored in `.project-management/current-prd/`, wh
    `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations --show-text`
    This ensures every hash is present and no English text remains.
 
+For debug flags and metrics file examples, see
+[Docs/Localization.md#debugging--metrics](Docs/Localization.md#debugging--metrics).
+
 Before translating, reassemble and install the Argos model for each language under `Resources/Localization/Models`:
 ```bash
 cd Resources/Localization/Models/<LANG>


### PR DESCRIPTION
## Summary
- expand localization guide with debugging flags and metrics file examples for pipeline, translation, and token fix scripts
- link metrics documentation from Translation Workflow section of AGENTS

## Testing
- ⚠️ `dotnet test --no-restore` (no tests executed)
- ✅ `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ffae833c4832d872d668956cd470b