### PR TITLE
Record per-hash token metrics

### DIFF
--- a/Docs/Localization.md
+++ b/Docs/Localization.md
@@ -175,7 +175,7 @@ is specified (default `translate_metrics.json` under `--root`):
 python Tools/translate_argos.py Resources/Localization/Messages/Turkish.json --to tr --metrics-file translate_metrics.json
 ```
 
-An entry summarises successes, timeouts and token reorders:
+An entry summarises successes, timeouts, token reorders and per‑hash token statistics:
 
 ```json
 [
@@ -186,7 +186,14 @@ An entry summarises successes, timeouts and token reorders:
     "successes": 498,
     "timeouts": 2,
     "token_reorders": 1,
-    "failures": {}
+    "failures": {},
+    "hash_stats": {
+      "1234567890": {
+        "original_tokens": 2,
+        "translated_tokens": 2,
+        "reordered": false
+      }
+    }
   }
 ]
 ```

--- a/Tools/test_translate_argos.py
+++ b/Tools/test_translate_argos.py
@@ -769,6 +769,10 @@ def test_metrics_file_records_failure_reason(tmp_path, monkeypatch):
     assert entry["timeouts"] == 0
     assert entry["token_reorders"] == 0
     assert "identical" in entry["failures"]["hash"].lower()
+    stats = entry["hash_stats"]["hash"]
+    assert stats["original_tokens"] == 0
+    assert stats["translated_tokens"] == 0
+    assert not stats["reordered"]
 
 
 def test_metrics_file_records_timeout(tmp_path, monkeypatch):
@@ -829,6 +833,10 @@ def test_metrics_file_records_timeout(tmp_path, monkeypatch):
     assert entry["token_reorders"] == 0
     reason = next(iter(entry["failures"].values()))
     assert "timeout" in reason
+    stats = entry["hash_stats"]["hash"]
+    assert stats["original_tokens"] == 0
+    assert stats["translated_tokens"] == 0
+    assert not stats["reordered"]
 
 
 def test_metrics_file_counts_token_reorders(tmp_path, monkeypatch):
@@ -884,3 +892,7 @@ def test_metrics_file_counts_token_reorders(tmp_path, monkeypatch):
     assert entry["timeouts"] == 0
     assert entry["token_reorders"] == 1
     assert entry["failures"] == {}
+    stats = entry["hash_stats"]["hash"]
+    assert stats["original_tokens"] == 2
+    assert stats["translated_tokens"] == 2
+    assert stats["reordered"]

--- a/translate_metrics.json
+++ b/translate_metrics.json
@@ -8,6 +8,18 @@
     "token_reorders": 0,
     "failures": {
       "2844729307": "token mismatch on strict retry (expected ['0', '1', '2'], got [])"
+    },
+    "hash_stats": {
+      "2844729307": {
+        "original_tokens": 3,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "3981447812": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      }
     }
   },
   {
@@ -17,6 +29,13 @@
     "successes": 1,
     "timeouts": 0,
     "token_reorders": 0,
-    "failures": {}
+    "failures": {},
+    "hash_stats": {
+      "3981447812": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      }
+    }
   }
 ]


### PR DESCRIPTION
## Summary
- Track original and translated token counts per hash during Argos translation
- Emit per-hash token stats and reorder flags via new `hash_stats` field in translation metrics
- Document updated metrics schema with token count examples

## Testing
- `pytest Tools/test_translate_argos.py::test_metrics_file_records_failure_reason Tools/test_translate_argos.py::test_metrics_file_records_timeout Tools/test_translate_argos.py::test_metrics_file_counts_token_reorders -q`
- `pytest Tools/test_translate_argos.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0ad427b14832dba275a063a62f2b6