### PR TITLE
refactor: batch blood commands

### DIFF
--- a/Commands/BloodCommands.cs
+++ b/Commands/BloodCommands.cs
@@ -24,6 +24,9 @@ internal static class BloodCommands
     static EntityManager EntityManager => Core.EntityManager;
     static ServerGameManager ServerGameManager => Core.ServerGameManager;
 
+    private const int STATS_BATCH_SIZE = 6;
+    private const int LIST_BATCH_SIZE = 4;
+
     [Command(name: "get", adminOnly: false, usage: ".bl get [BloodType]", description: "Display current blood legacy details.")]
     public static void GetLegacyCommand(ChatCommandContext ctx, string blood = null)
     {
@@ -78,9 +81,8 @@ internal static class BloodCommands
                     bloodLegacyStats.Add(new KeyValuePair<BloodStatType, string>(bloodStatType, bloodStatString));
                 }
 
-                for (int i = 0; i < bloodLegacyStats.Count; i += 6)
+                foreach (var batch in bloodLegacyStats.Batch(STATS_BATCH_SIZE))
                 {
-                    var batch = bloodLegacyStats.Skip(i).Take(6);
                     string bonuses = string.Join(", ", batch.Select(stat => $"<color=#00FFFF>{stat.Key}</color>: <color=white>{stat.Value}</color>"));
                     LocalizationService.HandleReply(ctx, $"<color=red>{bloodType}</color> Stats: {bonuses}");
                 }
@@ -264,9 +266,8 @@ internal static class BloodCommands
         }
         else
         {
-            for (int i = 0; i < bloodStatsWithCaps.Count; i += 4)
+            foreach (var batch in bloodStatsWithCaps.Batch(LIST_BATCH_SIZE))
             {
-                var batch = bloodStatsWithCaps.Skip(i).Take(4);
                 string replyMessage = string.Join(", ", batch);
                 LocalizationService.HandleReply(ctx, replyMessage);
             }


### PR DESCRIPTION
## Summary
- add STATS_BATCH_SIZE and LIST_BATCH_SIZE constants to BloodCommands
- use Batch extension to send stats and list messages in batches

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-6.0` *(fails: package has no installation candidate)*

------
https://chatgpt.com/codex/tasks/task_e_68a0dc6a28f0832d81245943cd795de1