### PR TITLE
Add log parser for token mismatch hashes

### DIFF
--- a/Docs/Localization.md
+++ b/Docs/Localization.md
@@ -57,6 +57,15 @@ Only the JSON files in `Resources/Localization/Messages` contain user-facing mes
 
    Any hashes listed in `skipped.csv` must be translated manually. Re-run the translator until the file is empty.
 
+   To extract hashes that were skipped due to token mismatches, scan the
+   translation log:
+
+   ```bash
+   python Tools/collect_skipped_hashes.py --log-file translate.log --csv mismatches.csv
+   ```
+
+   Omit `--csv` to print the unique hashes to stdout.
+
    ### Interpolation blocks
 
    Entries containing C# interpolation expressions like `{(condition ? "A" : "B")}` are skipped

--- a/Tools/collect_skipped_hashes.py
+++ b/Tools/collect_skipped_hashes.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Extract hash IDs for token mismatch skips from translation logs."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+from pathlib import Path
+from typing import Iterable, Set
+
+ROOT = Path(__file__).resolve().parent.parent
+
+PATTERN = re.compile(r"^(\d+): SKIPPED \(token mismatch")
+
+
+def parse_hashes(path: Path) -> Set[str]:
+    hashes: Set[str] = set()
+    if not path.exists():
+        return hashes
+    with path.open(encoding="utf-8") as fp:
+        for line in fp:
+            match = PATTERN.search(line)
+            if match:
+                hashes.add(match.group(1))
+    return hashes
+
+
+def write_csv(hashes: Iterable[str], path: Path) -> None:
+    with path.open("w", newline="", encoding="utf-8") as fp:
+        writer = csv.writer(fp)
+        writer.writerow(["hash"])
+        for hash_id in sorted(hashes):
+            writer.writerow([hash_id])
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Collect hash IDs from lines marked 'SKIPPED (token mismatch)'"
+    )
+    parser.add_argument(
+        "--log-file",
+        type=Path,
+        default=ROOT / "translate.log",
+        help="Path to translate.log",
+    )
+    parser.add_argument(
+        "--csv",
+        type=Path,
+        help="Optional CSV output file; hashes are printed to stdout when omitted",
+    )
+    args = parser.parse_args()
+
+    hashes = parse_hashes(args.log_file)
+    if args.csv:
+        write_csv(hashes, args.csv)
+    else:
+        for hash_id in sorted(hashes):
+            print(hash_id)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `collect_skipped_hashes.py` to parse translate.log for token mismatch hashes and output unique values
- document how to use the script in the localization guide

## Testing
- `python -m py_compile Tools/collect_skipped_hashes.py`
- `python Tools/collect_skipped_hashes.py --log-file translate.log`
- `dotnet test` *(fails: command not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a129bb2360832d9f0c5d6e99e8c873