### PR TITLE
feat: keep per-language translation logs

### DIFF
--- a/Tools/archive_translation_logs.py
+++ b/Tools/archive_translation_logs.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 """Archive translation log files with timestamped directories.
 
-This script moves ``translate.log`` and ``skipped.csv`` into a directory
-named ``TranslationLogs/<timestamp>`` relative to the repository root. For
-each archived file an accompanying ``.info`` file is written containing the
-timestamp of the run, providing a clear indicator of when the log was
-generated.
+This script moves translation artifacts matching ``translate_*.log`` and
+``skipped_*.csv`` into a directory named ``TranslationLogs/<timestamp>``
+relative to the repository root. For each archived file an accompanying
+``.info`` file is written containing the timestamp of the run, providing a
+clear indicator of when the log was generated.
 """
 
 from __future__ import annotations
@@ -28,12 +28,11 @@ def archive_logs() -> Path:
     destination = root / "TranslationLogs" / timestamp
     destination.mkdir(parents=True, exist_ok=True)
 
-    for name in ("translate.log", "skipped.csv"):
-        source = root / name
-        if source.exists():
-            target = destination / name
+    for pattern in ("translate_*.log", "skipped_*.csv"):
+        for source in root.glob(pattern):
+            target = destination / source.name
             shutil.move(str(source), target)
-            info = destination / f"{name}.info"
+            info = destination / f"{source.name}.info"
             info.write_text(f"Archived: {timestamp}\n")
 
     return destination

--- a/Tools/test_localization_pipeline_metrics.py
+++ b/Tools/test_localization_pipeline_metrics.py
@@ -69,7 +69,8 @@ def test_exit_code_on_skipped(tmp_path, monkeypatch):
 
     def fake_run(cmd, *, check=True, logger):
         if any("translate_argos.py" in c for c in cmd):
-            report = root / "skipped.csv"
+            report_name = cmd[cmd.index("--report-file") + 1]
+            report = root / report_name
             with report.open("w", newline="", encoding="utf-8") as fp:
                 writer = csv.DictWriter(fp, fieldnames=["hash", "english", "reason"])
                 writer.writeheader()


### PR DESCRIPTION
## Summary
- generate language-scoped translate logs and skipped reports
- allow optional archiving of translation artifacts
- update archive helper and tests for new file naming

## Testing
- `pytest`
- `dotnet test Bloodcraft.Tests/Bloodcraft.Tests.csproj` *(fails: You must install or update .NET to run this application)*

------
https://chatgpt.com/codex/tasks/task_e_68a13d95b274832d965f21c5b4a6da1c