### PR TITLE
Auto-fix token-only translations

### DIFF
--- a/Tools/fix_tokens.py
+++ b/Tools/fix_tokens.py
@@ -157,7 +157,19 @@ def main() -> None:
     ap = argparse.ArgumentParser(description="Fix token placeholders in localization JSON files")
     ap.add_argument("--root", default=Path(__file__).resolve().parents[1], help="Repo root")
     ap.add_argument("--check-only", action="store_true", help="Report issues without modifying files")
-    ap.add_argument("--reorder", action="store_true", help="Reorder tokens when counts match")
+    ap.add_argument(
+        "--reorder",
+        dest="reorder",
+        action="store_true",
+        help="Reorder tokens when counts match (default)",
+    )
+    ap.add_argument(
+        "--no-reorder",
+        dest="reorder",
+        action="store_false",
+        help="Disable token reordering",
+    )
+    ap.set_defaults(reorder=True)
     ap.add_argument("--metrics-file", help="Write JSON metrics to this path")
     ap.add_argument("--baseline-file", default="Resources/Localization/Messages/English.json", help="Baseline English messages file")
     ap.add_argument("paths", nargs="*", help="Specific localization JSON files to process")


### PR DESCRIPTION
## Summary
- Run `fix_tokens.py` with reordering after translations to restore placeholders
- Reorder tokens by default in `fix_tokens.py` and allow opting out via `--no-reorder`
- Treat token-only lines as successful translations and test this behavior

## Testing
- `pytest Tools/test_translate_argos.py Tools/test_fix_tokens.py`

------
https://chatgpt.com/codex/tasks/task_e_68a24ec178f0832d8af7372e12234764