### PR TITLE
Ignore placeholders in English detection and expand allowlist

### DIFF
--- a/Tools/english_allowlist.txt
+++ b/Tools/english_allowlist.txt
@@ -1,3 +1,12 @@
 # Words that should not trigger English detection.
 # Add one term per line.
 Bloodcraft
+DLC
+Discord
+GitHub
+HP
+NPC
+PvP
+Steam
+Unity
+XP

--- a/Tools/language_utils.py
+++ b/Tools/language_utils.py
@@ -14,13 +14,17 @@ else:
     ALLOWLIST: Set[str] = set()
 
 _WORD_RE = re.compile(r"\b\w+\b")
+_PLACEHOLDER_RE = re.compile(r"\[\[TOKEN_\d+\]\]|<[^>]+>|\{[^}]+\}")
 
 
 def contains_english(text: str) -> bool:
     """Return True if the text appears to contain English words.
 
-    Words listed in ``english_allowlist.txt`` are ignored.
+    Placeholder patterns like ``[[TOKEN_n]]``, ``<...>``, and ``{...}`` are
+    removed before scanning. Words listed in ``english_allowlist.txt`` are
+    ignored.
     """
-    words = set(_WORD_RE.findall(text.lower()))
+    cleaned = _PLACEHOLDER_RE.sub("", text)
+    words = set(_WORD_RE.findall(cleaned.lower()))
     words -= ALLOWLIST
     return any(word in STOP_WORDS for word in words)

--- a/Tools/test_language_utils.py
+++ b/Tools/test_language_utils.py
@@ -4,3 +4,8 @@ import language_utils
 def test_allowlisted_word_is_ignored(monkeypatch):
     monkeypatch.setattr(language_utils, "STOP_WORDS", {"bloodcraft"})
     assert not language_utils.contains_english("Bloodcraft")
+
+
+def test_tokens_are_ignored(monkeypatch):
+    monkeypatch.setattr(language_utils, "STOP_WORDS", {"token_0"})
+    assert not language_utils.contains_english("Hola [[TOKEN_0]]")


### PR DESCRIPTION
## Summary
- expand English allowlist with common game terms and proper nouns
- skip placeholder tokens before scanning for English stop words
- add regression test so tokenized strings like `Hola [[TOKEN_0]]` are not flagged

## Testing
- `pytest Tools/test_language_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a252fa43ec832d8466a7b7e7de98d7