### PR TITLE
Ensure skip report persists after exceptions

### DIFF
--- a/Tools/test_translate_argos_integration.py
+++ b/Tools/test_translate_argos_integration.py
@@ -3,6 +3,7 @@ import json
 import subprocess
 import sys
 
+import pytest
 import translate_argos
 
 
@@ -74,3 +75,65 @@ def test_multibatch_continues_after_line_error(tmp_path, monkeypatch):
     assert data["Messages"]["h4"] == "Line 4_t"
     rows = list(csv.DictReader(report_path.open()))
     assert rows == []
+
+
+def test_report_written_on_exception(tmp_path, monkeypatch):
+    root = tmp_path
+    messages_dir = root / "Resources" / "Localization" / "Messages"
+    messages_dir.mkdir(parents=True)
+    english = {"Messages": {f"h{i}": f"Line {i}" for i in range(2)}}
+    (messages_dir / "English.json").write_text(json.dumps(english))
+
+    target_rel = "Resources/Localization/Messages/Test.json"
+    report_path = root / "skipped.csv"
+
+    class DummyTranslator:
+        def translate(self, text):
+            return text
+
+    class DummyCompleted:
+        def __init__(self, code=0):
+            self.returncode = code
+
+    monkeypatch.setattr(
+        translate_argos.argos_translate,
+        "get_translation_from_codes",
+        lambda src, dst: DummyTranslator(),
+    )
+    monkeypatch.setattr(
+        translate_argos.argos_translate, "load_installed_languages", lambda: None
+    )
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: DummyCompleted())
+
+    original_unprotect = translate_argos.unprotect
+    call_count = {"n": 0}
+
+    def boom_unprotect(text, tokens):
+        call_count["n"] += 1
+        if call_count["n"] == 2:
+            raise SystemExit(1)
+        return original_unprotect(text, tokens)
+
+    monkeypatch.setattr(translate_argos, "unprotect", boom_unprotect)
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "translate_argos.py",
+            target_rel,
+            "--to",
+            "xx",
+            "--root",
+            str(root),
+            "--report-file",
+            str(report_path),
+            "--overwrite",
+        ],
+    )
+
+    with pytest.raises(SystemExit):
+        translate_argos.main()
+
+    rows = list(csv.DictReader(report_path.open()))
+    assert [row["hash"] for row in rows] == ["h0"]


### PR DESCRIPTION
## Summary
- centralize skip-report writing and always flush it in a finally block
- cover exception handling by testing report persistence after mid-run crashes

## Testing
- `pytest Tools/test_translate_argos_integration.py::test_multibatch_continues_after_line_error Tools/test_translate_argos_integration.py::test_report_written_on_exception -q`

------
https://chatgpt.com/codex/tasks/task_e_68a3826c2570832d85929ecd7655d81a