### PR TITLE
Flush translation skip report after each batch

### DIFF
--- a/Tools/translate_argos.py
+++ b/Tools/translate_argos.py
@@ -641,6 +641,11 @@ def _run_translation(args, root: str) -> None:
                 f"Batch {batch_idx + 1}/{num_batches} end @ {batch_end - start:.2f}s "
                 f"({batch_end - batch_start:.2f}s)"
             )
+            if args.report_file:
+                try:
+                    _write_report(args.report_file, list(report.values()))
+                except Exception as e:
+                    logger.warning(f"Failed to flush skip report: {e}")
 
         def strict_retry(key: str) -> tuple[bool, str, int, bool, str | None]:
             nonlocal token_reorders


### PR DESCRIPTION
## Summary
- Flush skip-report data to disk after each translation batch and tolerate write errors
- Test that early process termination retains skipped entries

## Testing
- `pytest Bloodcraft/Tools/test_translate_argos_integration.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a39995d768832db3a73480cc01c1c9