### PR TITLE
Refine translation skip categorization

### DIFF
--- a/Tools/analyze_translation_logs.py
+++ b/Tools/analyze_translation_logs.py
@@ -4,7 +4,8 @@
 This script reads ``translate_metrics.json`` and ``skipped.csv`` from the
 repository root and prints counts of failures grouped by category. It exits
 with a non-zero status if any token mismatches or placeholder-only failures
-remain so CI systems can fail fast.
+remain so CI systems can fail fast. Categories include ``english``,
+``identical``, ``sentinel``, ``token_mismatch``, and ``placeholder``.
 """
 
 from __future__ import annotations
@@ -19,6 +20,23 @@ ROOT = Path(__file__).resolve().parent.parent
 METRICS_PATH = ROOT / "translate_metrics.json"
 SKIPPED_PATH = ROOT / "skipped.csv"
 
+
+def _categorize(reason: str | None) -> str:
+    if not reason:
+        return "unknown"
+    r = reason.lower()
+    if "token mismatch" in r:
+        return "token_mismatch"
+    if "sentinel" in r:
+        return "sentinel"
+    if "identical" in r:
+        return "identical"
+    if "placeholder" in r or "tokens only" in r or "token only" in r:
+        return "placeholder"
+    if "untranslated" in r or "english" in r:
+        return "english"
+    return r
+
 def _summarize_metrics(path: Path) -> Counter:
     counts: Counter[str] = Counter()
     try:
@@ -29,10 +47,7 @@ def _summarize_metrics(path: Path) -> Counter:
         return counts
     for entry in entries:
         for reason in entry.get("failures", {}).values():
-            if "token mismatch" in reason:
-                counts["token_mismatch"] += 1
-            else:
-                counts[reason] += 1
+            counts[_categorize(reason)] += 1
     return counts
 
 def _summarize_skipped(path: Path) -> Counter:
@@ -41,7 +56,10 @@ def _summarize_skipped(path: Path) -> Counter:
         with path.open(encoding="utf-8") as fp:
             reader = csv.DictReader(fp)
             for row in reader:
-                counts[row.get("category") or "unknown"] += 1
+                cat = row.get("category") or "unknown"
+                if cat == "untranslated":
+                    cat = "english"
+                counts[cat] += 1
     except FileNotFoundError:
         return counts
     return counts
@@ -60,7 +78,7 @@ def main() -> None:
             print(f"  {category}: {count}")
 
     exit_code = 0
-    if metric_counts.get("token_mismatch"):
+    if metric_counts.get("token_mismatch") or skipped_counts.get("token_mismatch"):
         exit_code = 1
     if skipped_counts.get("placeholder"):
         exit_code = 1

--- a/Tools/test_analyze_translation_logs.py
+++ b/Tools/test_analyze_translation_logs.py
@@ -1,0 +1,34 @@
+import csv
+from collections import Counter
+
+import analyze_translation_logs as atl
+
+
+def test_categorize():
+    assert atl._categorize("missing sentinel") == "sentinel"
+    assert atl._categorize("identical to source") == "identical"
+    assert atl._categorize("contains English") == "english"
+    assert atl._categorize("token mismatch (missing [1])") == "token_mismatch"
+    assert atl._categorize("placeholders only") == "placeholder"
+
+
+def test_summarize_skipped(tmp_path):
+    path = tmp_path / "skipped.csv"
+    with path.open("w", newline="", encoding="utf-8") as fp:
+        writer = csv.DictWriter(fp, fieldnames=["hash", "english", "reason", "category"])
+        writer.writeheader()
+        writer.writerow({"hash": "1", "english": "a", "reason": "r", "category": "identical"})
+        writer.writerow({"hash": "2", "english": "a", "reason": "r", "category": "sentinel"})
+        writer.writerow({"hash": "3", "english": "a", "reason": "r", "category": "placeholder"})
+        writer.writerow({"hash": "4", "english": "a", "reason": "r", "category": "untranslated"})
+        writer.writerow({"hash": "5", "english": "a", "reason": "r", "category": "token_mismatch"})
+    counts = atl._summarize_skipped(path)
+    assert counts == Counter(
+        {
+            "identical": 1,
+            "sentinel": 1,
+            "placeholder": 1,
+            "english": 1,
+            "token_mismatch": 1,
+        }
+    )

--- a/Tools/test_translate_argos.py
+++ b/Tools/test_translate_argos.py
@@ -332,6 +332,57 @@ def test_placeholder_only_report(tmp_path, monkeypatch):
     assert data["Messages"]["hash"] == "Hello {0}"
 
 
+def test_token_mismatch_report(tmp_path, monkeypatch):
+    root = tmp_path
+    messages_dir = root / "Resources" / "Localization" / "Messages"
+    messages_dir.mkdir(parents=True)
+    (messages_dir / "English.json").write_text(
+        json.dumps({"Messages": {"hash": "Hello {0} {1}"}})
+    )
+
+    target_rel = "Resources/Localization/Messages/Test.json"
+    report_path = root / "skipped.csv"
+
+    class DummyTranslator:
+        def translate(self, text):
+            return "Bonjour [[TOKEN_0]]"  # missing token 1
+
+    class DummyCompleted:
+        def __init__(self, code=0):
+            self.returncode = code
+
+    monkeypatch.setattr(
+        translate_argos.argos_translate,
+        "get_translation_from_codes",
+        lambda src, dst: DummyTranslator(),
+    )
+    monkeypatch.setattr(
+        translate_argos.argos_translate, "load_installed_languages", lambda: None
+    )
+    monkeypatch.setattr(translate_argos, "contains_english", lambda s: False)
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: DummyCompleted())
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "translate_argos.py",
+            target_rel,
+            "--to",
+            "xx",
+            "--root",
+            str(root),
+            "--report-file",
+            str(report_path),
+            "--overwrite",
+        ],
+    )
+
+    translate_argos.main()
+    rows = list(csv.DictReader(report_path.open()))
+    assert rows[0]["category"] == "token_mismatch"
+    assert "token mismatch" in rows[0]["reason"]
+
+
 def test_contains_english_report(tmp_path, monkeypatch):
     root = tmp_path
     messages_dir = root / "Resources" / "Localization" / "Messages"
@@ -379,7 +430,7 @@ def test_contains_english_report(tmp_path, monkeypatch):
 
     translate_argos.main()
     rows = list(csv.DictReader(report_path.open()))
-    assert rows[0]["category"] == "untranslated"
+    assert rows[0]["category"] == "english"
     assert "English" in rows[0]["reason"]
 
 

--- a/Tools/translate_argos.py
+++ b/Tools/translate_argos.py
@@ -356,10 +356,12 @@ def _run_translation(args, root: str) -> None:
             return "sentinel"
         if "identical" in r:
             return "identical"
-        if "untranslated" in r or "english" in r:
-            return "untranslated"
+        if "token mismatch" in r:
+            return "token_mismatch"
         if "placeholder" in r or "tokens only" in r or "token only" in r:
             return "placeholder"
+        if "untranslated" in r or "english" in r:
+            return "english"
         return "other"
 
     def log_entry(


### PR DESCRIPTION
## Summary
- expand Argos translator skip categorization with english, sentinel, token mismatch, and placeholder labels
- teach log analysis to map new categories and fail fast on token mismatches or placeholder-only rows
- cover every skip category with unit tests, including token mismatch scenarios

## Testing
- `pytest Tools/test_translate_argos.py::test_fallback_to_english_and_reports Tools/test_translate_argos.py::test_sentinel_missing_report Tools/test_translate_argos.py::test_placeholder_only_report Tools/test_translate_argos.py::test_token_mismatch_report Tools/test_translate_argos.py::test_contains_english_report Tools/test_analyze_translation_logs.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a399916b08832d9d10b3694ebc5fca