### PR TITLE
Preserve custom tokens in Argos translation tools

### DIFF
--- a/Tools/test_fix_tokens.py
+++ b/Tools/test_fix_tokens.py
@@ -61,6 +61,14 @@ def test_replace_placeholders_token_only_line():
     assert replaced and not mismatch
 
 
+def test_replace_placeholders_with_various_tokens():
+    tokens = ["{0}", "${var}", "[[TOKEN_0]]", "{(a (b))}"]
+    value = "".join(f"[[TOKEN_{i}]]" for i in range(len(tokens)))
+    new_value, replaced, mismatch = fix_tokens.replace_placeholders(value, tokens)
+    assert new_value == "".join(tokens)
+    assert replaced and not mismatch
+
+
 def test_exit_on_mismatch(tmp_path, monkeypatch):
     root = tmp_path
     messages_dir = root / "Resources" / "Localization" / "Messages"


### PR DESCRIPTION
## Summary
- enhance token detection to include `${var}`, numeric placeholders, existing `[[TOKEN_n]]` markers, and nested `{( … )}` blocks
- add round-trip and reordering tests for these tokens
- add regression test ensuring translation runs without token mismatch warnings

## Testing
- `pytest Tools/test_translate_argos.py Tools/test_fix_tokens.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a39982605c832d8bbb67cbe46e1fcf