### PR TITLE
Refactor token placeholder mapping in Argos translator

### DIFF
--- a/Tools/test_translate_argos.py
+++ b/Tools/test_translate_argos.py
@@ -695,6 +695,24 @@ def test_round_trip_with_reordered_tokens():
     assert restored.replace(" ", "") == text.replace(" ", "")
 
 
+@pytest.mark.parametrize(
+    "text",
+    [
+        "<tag>",
+        "{0}",
+        "${value}",
+        "[[TOKEN_0]]",
+        "mix <b>{0}${val}[[TOKEN_0]]",
+    ],
+)
+def test_tokens_round_trip_without_mismatch(text):
+    safe, tokens = translate_argos.protect_strict(text)
+    normalized = translate_argos.normalize_tokens(safe)
+    reordered, _ = translate_argos.reorder_tokens(normalized, len(tokens))
+    restored = translate_argos.unprotect(reordered, tokens)
+    assert restored == text
+
+
 def test_interpolation_block_translated(tmp_path, monkeypatch):
     root = tmp_path
     messages_dir = root / "Resources" / "Localization" / "Messages"


### PR DESCRIPTION
## Summary
- Replace token patterns with durable `⟦Tn⟧` placeholders before translation and restore deterministically afterwards
- Normalize placeholder formats and support recovery of original `<...>`, `{...}`, `${...}` and `[[TOKEN_n]]` tokens
- Add regression tests ensuring tokenized strings round-trip without mismatches

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4b046fcc4832da3b9e36dfbcf073c