### PR TITLE
Add token handling tests for translate_argos and run in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,13 @@ jobs:
         
       - name: Restore dependencies
         run: dotnet restore
-        
+
+      - name: Run Python tests
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest argostranslate
+          pytest Tools
+
       - name: Discover .csproj
         id: discover_csproj
         run: |

--- a/Tools/test_translate_argos_tokens.py
+++ b/Tools/test_translate_argos_tokens.py
@@ -1,0 +1,79 @@
+import json
+import subprocess
+import sys
+
+import pytest
+
+import translate_argos
+
+
+def test_protect_unprotect_simple_tokens():
+    text = "Attack {0}!"
+    safe, tokens = translate_argos.protect_strict(text)
+    assert tokens == ["{0}"]
+    assert "⟦T0⟧" in safe
+    assert translate_argos.unprotect(safe, tokens) == text
+
+
+def test_protect_unprotect_nested_color_and_placeholder():
+    text = "<color=red>{0}</color>"
+    safe, tokens = translate_argos.protect_strict(text)
+    assert tokens == ["<color=red>", "{0}", "</color>"]
+    assert translate_argos.unprotect(safe, tokens) == text
+
+
+def test_token_only_line_uses_sentinel(tmp_path, monkeypatch):
+    root = tmp_path
+    messages_dir = root / "Resources" / "Localization" / "Messages"
+    messages_dir.mkdir(parents=True)
+    english = {"Messages": {"hash": "<b>{0}</b>"}}
+    (messages_dir / "English.json").write_text(json.dumps(english))
+
+    target_rel = "Resources/Localization/Messages/Test.json"
+    target_path = root / target_rel
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    target_path.write_text(json.dumps({"Messages": {"hash": ""}}))
+
+    class EchoTranslator:
+        def __init__(self):
+            self.last = ""
+
+        def translate(self, text: str) -> str:
+            self.last = text
+            return text
+
+    class DummyCompleted:
+        def __init__(self, code=0):
+            self.returncode = code
+
+    translator = EchoTranslator()
+
+    monkeypatch.setattr(
+        translate_argos.argos_translate,
+        "get_translation_from_codes",
+        lambda src, dst: translator,
+    )
+    monkeypatch.setattr(
+        translate_argos.argos_translate, "load_installed_languages", lambda: None
+    )
+    monkeypatch.setattr(translate_argos, "contains_english", lambda s: False)
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: DummyCompleted())
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "translate_argos.py",
+            target_rel,
+            "--to",
+            "xx",
+            "--root",
+            str(root),
+            "--overwrite",
+        ],
+    )
+
+    translate_argos.main()
+
+    assert translator.last.endswith(" " + translate_argos.TOKEN_SENTINEL)
+    data = json.loads(target_path.read_text())
+    assert data["Messages"]["hash"] == "<b>{0}</b>"


### PR DESCRIPTION
## Summary
- add unit tests for translate_argos token handling
- cover nested <color> + {0} placeholders and sentinel-only lines
- run Python tests during CI build

## Testing
- `pytest Tools/test_translate_argos_tokens.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4c7c57e84832d81f39b5e01113b7c