### PR TITLE
Add skipped translation review script and docs

### DIFF
--- a/Docs/Localization.md
+++ b/Docs/Localization.md
@@ -78,7 +78,22 @@ Only the JSON files in `Resources/Localization/Messages` contain user-facing mes
 
    ### Placeholder-only results
 
-   Sometimes the translator may output only `[[TOKEN_n]]` placeholders without any surrounding text. These messages are left in their original English form and appear in `skipped.csv` with the `placeholder` category so they can be reviewed manually.
+    Sometimes the translator may output only `[[TOKEN_n]]` placeholders without any surrounding text. These messages are left in their original English form and appear in `skipped.csv` with the `placeholder` category so they can be reviewed manually.
+
+    ### Manual review script
+
+    Use `Tools/review_skipped.py skipped_Spanish.csv` to list each skipped hash with its current Spanish text. Replace the English strings in `Resources/Localization/Messages/Spanish.json` with manual translations, then run:
+
+    ```bash
+    python Tools/fix_tokens.py Resources/Localization/Messages/Spanish.json
+    python Tools/translate_argos.py Resources/Localization/Messages/Spanish.json --to es --overwrite
+    ```
+
+    Re-run the translator until `skipped_Spanish.csv` is empty and verify the catalog:
+
+    ```bash
+    dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations
+    ```
 
 4. **Fix tokens**
 

--- a/Tools/review_skipped.py
+++ b/Tools/review_skipped.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Display skipped translation entries for manual review."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+def load_messages(path: Path) -> dict:
+    with path.open(encoding="utf-8") as fp:
+        data = json.load(fp)
+    return data.get("Messages", {})
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description="List skipped hashes and current translations to aid manual fixes",
+    )
+    ap.add_argument(
+        "csv",
+        type=Path,
+        help="Path to skipped_<Language>.csv",
+    )
+    ap.add_argument(
+        "--language-file",
+        type=Path,
+        default=ROOT / "Resources/Localization/Messages/Spanish.json",
+        help="JSON file containing translations; defaults to Spanish",
+    )
+    args = ap.parse_args()
+
+    messages = load_messages(args.language_file)
+
+    with args.csv.open(encoding="utf-8") as fp:
+        reader = csv.DictReader(fp)
+        for row in reader:
+            hash_id = row.get("hash", "")
+            english = row.get("english", "")
+            current = messages.get(hash_id, "")
+            print(f"{hash_id}\n  English : {english}\n  Current : {current}\n")
+
+    print(
+        "Edit the language file to supply manual Spanish strings, then run:\n"
+        f"python Tools/fix_tokens.py {args.language_file}\n"
+        f"python Tools/translate_argos.py {args.language_file} --to es --overwrite\n"
+        "After translations are updated, verify with:\n"
+        "dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations",
+    )
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `review_skipped.py` to list skipped translation hashes with current Spanish strings
- document manual review workflow for `skipped_*.csv` and final verification

## Testing
- `pytest`
- `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c7c0038c832dbfa96f6e586817e2