### PR TITLE
Use info level for translation progress

### DIFF
--- a/Tools/translate_argos.py
+++ b/Tools/translate_argos.py
@@ -338,7 +338,7 @@ def _write_report(path: str, rows: list[dict[str, str]], *, max_retries: int = 3
                     writer.writerows(rows)
                 else:
                     raise RuntimeError("Report file must end with .json or .csv")
-            logger.warning(f"Wrote skip report to {path}")
+            logger.info(f"Wrote skip report to {path}")
             break
         except Exception:
             if attempt == max_retries:
@@ -366,7 +366,7 @@ def _run_translation(args, root: str) -> None:
         logger.error(msg)
         raise SystemExit(msg)
 
-    logger.warning(
+    logger.info(
         "NOTE TO TRANSLATORS: **DO NOT** alter anything inside [[TOKEN_n]], <...> tags, or {...} variables."
     )
     english_path = os.path.join(
@@ -389,7 +389,7 @@ def _run_translation(args, root: str) -> None:
         to_translate = [(k, v) for k, v in english.items() if k not in messages]
 
     if not to_translate:
-        logger.warning("No messages need translation.")
+        logger.info("No messages need translation.")
         return
 
     safe_lines: List[str] = []
@@ -829,7 +829,7 @@ def _run_translation(args, root: str) -> None:
         summary_msg = (
             f"Processed {num_batches} batches in {total_elapsed:.2f} seconds"
         )
-        logger.warning(summary_msg)
+        logger.info(summary_msg)
         category_counts = Counter(entry["category"] for entry in report.values())
         if category_counts:
             breakdown_msg = "Report breakdown: " + ", ".join(
@@ -837,7 +837,7 @@ def _run_translation(args, root: str) -> None:
             )
         else:
             breakdown_msg = "Report breakdown: none"
-        logger.warning(breakdown_msg)
+        logger.info(breakdown_msg)
 
         successes = processed_lines - len(failures)
 
@@ -858,7 +858,7 @@ def _run_translation(args, root: str) -> None:
         if result.returncode != 0:
             raise SystemExit(result.returncode)
 
-        logger.warning(f"Wrote translations to {target_path}")
+        logger.info(f"Wrote translations to {target_path}")
 
         metrics_dir = os.path.dirname(args.metrics_file)
         if metrics_dir:
@@ -883,7 +883,7 @@ def _run_translation(args, root: str) -> None:
             f"Summary: {successes}/{processed_lines} translated, {timeouts_count} timeouts, "
             f"{token_reorders} token reorders. Metrics written to {args.metrics_file}"
         )
-        logger.warning(summary_line)
+        logger.info(summary_line)
     finally:
         exc_type = sys.exc_info()[0]
         if args.report_file:
@@ -1022,7 +1022,7 @@ def main():
             if not hashes or set(hashes) == prev_hashes:
                 break
             prev_hashes = set(hashes)
-            logger.warning(
+            logger.info(
                 f"Retrying {len(hashes)} hash(es) from {args.report_file}"
             )
             args.hashes = hashes


### PR DESCRIPTION
## Summary
- log normal translation progress as info instead of warnings
- keep warnings for recoverable translation issues

## Testing
- `pytest -q`
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4fcaa8a58832d9f63a6503fc8dbce