### PR TITLE
Use deterministic token sentinels for Argos translation

### DIFF
--- a/Tools/test_token_roundtrip.py
+++ b/Tools/test_token_roundtrip.py
@@ -1,0 +1,19 @@
+import pytest
+
+import translate_argos
+
+
+def test_mixed_placeholders_nested_tags_round_trip():
+    text = "[b]<color=red>{0}% [link]{1}[/link]</color>[/b]"
+    safe, tokens = translate_argos.protect_strict(text)
+    normalized = translate_argos.normalize_tokens(safe)
+    reordered, changed = translate_argos.reorder_tokens(normalized, len(tokens))
+    assert not changed
+    restored = translate_argos.unprotect(reordered, tokens)
+    assert restored == text
+
+
+def test_unprotect_mismatch_raises():
+    tokens = ["%"]
+    with pytest.raises(ValueError):
+        translate_argos.unprotect("[[TOKEN_0]] [[TOKEN_1]]", tokens)

--- a/Tools/test_translate_argos.py
+++ b/Tools/test_translate_argos.py
@@ -603,7 +603,7 @@ def test_strict_retry_succeeds(tmp_path, monkeypatch):
             self.calls += 1
             if self.calls == 1:
                 return "[[TOKEN_1]]Bonjour"
-            return "⟦T0⟧Bonjour⟦T1⟧"
+            return "[[TOKEN_0]]Bonjour[[TOKEN_1]]"
 
     class DummyCompleted:
         def __init__(self, code=0):
@@ -733,7 +733,7 @@ def test_protect_round_trip_with_placeholders():
 def test_round_trip_with_reordered_tokens():
     text = "{0} ${var} [[TOKEN_0]] {(x (y))}"
     _, tokens = translate_argos.protect_strict(text)
-    swapped = "⟦T2⟧ ⟦T0⟧ ⟦T1⟧ ⟦T3⟧"
+    swapped = "[[TOKEN_2]] [[TOKEN_0]] [[TOKEN_1]] [[TOKEN_3]]"
     normalized = translate_argos.normalize_tokens(swapped)
     reordered, changed = translate_argos.reorder_tokens(normalized, len(tokens))
     assert changed
@@ -813,7 +813,7 @@ def test_interpolation_block_translated(tmp_path, monkeypatch):
     translate_argos.main()
 
     assert translator.called
-    assert translator.seen == "before ⟦T0⟧ after"
+    assert translator.seen == "before [[TOKEN_0]] after"
 
     data = json.loads((root / target_rel).read_text())
     assert data["Messages"]["hash"] == "translated {(cond ? \"yes\" : \"no\")} after"
@@ -873,7 +873,7 @@ def test_multiple_interpolation_blocks_translated(tmp_path, monkeypatch):
     translate_argos.main()
 
     assert translator.called
-    assert translator.seen == "before ⟦T0⟧ middle ⟦T1⟧ after"
+    assert translator.seen == "before [[TOKEN_0]] middle [[TOKEN_1]] after"
 
     data = json.loads((root / target_rel).read_text())
     assert (
@@ -949,10 +949,10 @@ def test_roundtrip_with_reordered_tokens(tmp_path, monkeypatch):
     class ReversingTranslator:
         def translate(self, text):
             import re
-            tokens = re.findall(r"⟦T\d+⟧", text)
+            tokens = re.findall(r"\[\[TOKEN_\d+\]\]", text)
             tokens.reverse()
             it = iter(tokens)
-            return re.sub(r"⟦T\d+⟧", lambda _m: next(it), text)
+            return re.sub(r"\[\[TOKEN_\d+\]\]", lambda _m: next(it), text)
 
     class DummyCompleted:
         def __init__(self, code=0):
@@ -1661,6 +1661,6 @@ def test_wraps_and_unwraps_placeholders(tmp_path, monkeypatch):
 
     translate_argos.main()
 
-    assert translator.seen and "⟦T0⟧" in translator.seen[0]
+    assert translator.seen and "[[TOKEN_0]]" in translator.seen[0]
     data = json.loads((root / target_rel).read_text())
     assert data["Messages"]["h1"] == "Bonjour {0}"

--- a/Tools/test_translate_argos_tokens.py
+++ b/Tools/test_translate_argos_tokens.py
@@ -11,7 +11,7 @@ def test_protect_unprotect_simple_tokens():
     text = "Attack {0}!"
     safe, tokens = translate_argos.protect_strict(text)
     assert tokens == ["{0}"]
-    assert "⟦T0⟧" in safe
+    assert "[[TOKEN_0]]" in safe
     assert translate_argos.unprotect(safe, tokens) == text
 
 

--- a/Tools/translate_argos.py
+++ b/Tools/translate_argos.py
@@ -40,8 +40,9 @@ class FatalTranslationError(Exception):
 #   * Bracket tags:         ``[tag]`` or ``[tag=value]``
 #   * Existing tokens:      ``[[TOKEN_n]]``
 #   * Strict markers:       ``⟦Tn⟧``
+#   * Percent sign:         ``%``
 TOKEN_PATTERN = re.compile(
-    r"<[^>]+>|\{[^{}]+\}|\$\{[^{}]+\}|\[(?:/?[a-zA-Z]+(?:=[^\]]+)?)\]|\[\[TOKEN_\d+\]\]|⟦T\d+⟧"
+    r"<[^>]+>|\{[^{}]+\}|\$\{[^{}]+\}|\[(?:/?[a-zA-Z]+(?:=[^\]]+)?)\]|\[\[TOKEN_\d+\]\]|⟦T\d+⟧|%"
 )
 TOKEN_RE = re.compile(r'\[\[TOKEN_(\d+)\]\]')
 STRICT_TOKEN_RE = re.compile(r'⟦T(\d+)⟧')
@@ -68,7 +69,7 @@ def unwrap_placeholders(text: str) -> str:
 
 
 def protect_strict(text: str) -> tuple[str, List[str]]:
-    """Replace tokens with durable ``⟦Tn⟧`` placeholders."""
+    """Replace tokens with deterministic ``[[TOKEN_n]]`` sentinels."""
 
     text = text.replace("\\u003C", "<").replace("\\u003E", ">")
     tokens: List[str] = []
@@ -99,14 +100,14 @@ def protect_strict(text: str) -> tuple[str, List[str]]:
                 if depth == 0 and j < len(text) and text[j] == "}":
                     block = text[start : j + 1]
                     tokens.append(block)
-                    result.append(f"⟦T{len(tokens)-1}⟧")
+                    result.append(f"[[TOKEN_{len(tokens)-1}]]")
                     i = j + 1
                     continue
 
         m = TOKEN_PATTERN.match(text, i)
         if m:
             tokens.append(m.group(0))
-            result.append(f"⟦T{len(tokens)-1}⟧")
+            result.append(f"[[TOKEN_{len(tokens)-1}]]")
             i = m.end()
             continue
 
@@ -117,17 +118,24 @@ def protect_strict(text: str) -> tuple[str, List[str]]:
 
 
 def unprotect(text: str, tokens: List[str]) -> str:
-    """Restore original tokens from placeholder markers."""
+    """Restore original tokens from ``[[TOKEN_n]]`` markers.
 
-    pattern = re.compile(r"⟦T(\d+)⟧|\[\[TOKEN_(\d+)\]\]")
+    Validates that the placeholders appear in the expected order and count
+    before performing the substitution.
+    """
+
+    found = TOKEN_RE.findall(text)
+    expected = [str(i) for i in range(len(tokens))]
+    if found != expected:
+        raise ValueError(
+            f"Token sequence mismatch: expected {expected}, got {found}"
+        )
 
     def repl(m: re.Match) -> str:
-        idx = m.group(1) or m.group(2)
-        assert idx is not None
-        num = int(idx)
-        return tokens[num] if 0 <= num < len(tokens) else m.group(0)
+        idx = int(m.group(1))
+        return tokens[idx] if 0 <= idx < len(tokens) else m.group(0)
 
-    return pattern.sub(repl, text)
+    return TOKEN_RE.sub(repl, text)
 
 
 def normalize_tokens(text: str) -> str:
@@ -413,7 +421,7 @@ def _run_translation(args, root: str) -> None:
 
     for key, text in to_translate:
         safe, tokens = protect_strict(text)
-        token_only = STRICT_TOKEN_RE.sub("", safe).strip() == ""
+        token_only = TOKEN_RE.sub("", safe).strip() == ""
         if token_only:
             safe += f" {TOKEN_SENTINEL}"
         safe_lines.append(safe)
@@ -753,7 +761,7 @@ def _run_translation(args, root: str) -> None:
         def strict_retry(key: str) -> tuple[bool, str, int, bool, str | None]:
             nonlocal token_reorders
             safe, tokens = protect_strict(english[key])
-            token_only = STRICT_TOKEN_RE.sub("", safe).strip() == ""
+            token_only = TOKEN_RE.sub("", safe).strip() == ""
             if token_only:
                 safe += f" {TOKEN_SENTINEL}"
             try:


### PR DESCRIPTION
## Summary
- replace placeholders with deterministic `[[TOKEN_n]]` sentinels before Argos translation
- validate and restore tokens after translation
- cover complex placeholder round-trips with new unit tests

## Testing
- `pytest Tools/test_translate_argos_tokens.py Tools/test_token_roundtrip.py Tools/test_translate_argos.py`
- `dotnet test Bloodcraft.Tests/Bloodcraft.Tests.csproj` *(fails: .NET 6 runtime missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a5db0ff404832db9fb31190d405181