### PR TITLE
chore: translate sample Spanish messages

### DIFF
--- a/Resources/Localization/Messages/Spanish.json
+++ b/Resources/Localization/Messages/Spanish.json
@@ -1,7 +1,7 @@
 {
   "Messages": {
-    "welcome": "Welcome to Bloodcraft",
-    "binding-failed": "Binding failed...",
+    "welcome": "Bienvenido a Bloodcraft",
+    "binding-failed": "La unión falló...",
     "profession-improved": "{0} improved to [<color=white>{1}</color>]",
     "profession-proficiency-gain": "+<color=yellow>{0}</color> <color=#FFC0CB>proficiency</color> in {1} (<color=white>{2}%</color>)",
     "profession-bonus-received": "<color=green>{0}</color>x<color=white>{1}</color> received from {2}",


### PR DESCRIPTION
## Summary
- translate sample welcome and binding failure messages to Spanish

## Testing
- `python Tools/fix_tokens.py --check-only Resources/Localization/Messages/Spanish.json` *(fails: token count mismatch in unrelated entries)*
- `python Tools/translate_argos.py Resources/Localization/Messages/Spanish.json --to es --hash welcome --hash binding-failed --report-file skipped_Spanish_sample.csv --overwrite --batch-size 100 --max-retries 3 --log-level INFO --log-file translate.log --root sample`


------
https://chatgpt.com/codex/tasks/task_e_68a5db192e44832da14d7f64f9f49d40