### PR TITLE
Handle sentinel token normalization

### DIFF
--- a/Tools/test_translate_argos_tokens.py
+++ b/Tools/test_translate_argos_tokens.py
@@ -77,3 +77,11 @@ def test_token_only_line_uses_sentinel(tmp_path, monkeypatch):
     assert translator.last.endswith(" " + translate_argos.TOKEN_SENTINEL)
     data = json.loads(target_path.read_text())
     assert data["Messages"]["hash"] == "<b>{0}</b>"
+
+
+def test_sentinel_round_trip():
+    tokens = ["<b>", "{0}", "</b>"]
+    result = "[[TOKEN_0]][[TOKEN_1]][[TOKEN_2]] [[ TOKEN_SENTINEL ]]"
+    normalized = translate_argos.normalize_tokens(result)
+    restored = translate_argos.unprotect(normalized, tokens)
+    assert restored == "<b>{0}</b>"


### PR DESCRIPTION
## Summary
- handle `[[TOKEN_SENTINEL]]` variations during token normalization
- strip leftover sentinel markers when unprotecting tokens
- cover sentinel token round-trip with regression test

## Testing
- `pytest Tools/test_translate_argos_tokens.py -q`
- `pytest Tools/test_translate_argos.py -q`
- `dotnet test` *(fail: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5db1f848c832dbe0c2da4051a7a8d