### PR TITLE
feat: centralize translation run outputs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,9 +46,9 @@ Current PRDs and task lists are stored in `.project-management/current-prd/`, wh
 2. **Propagate new hashes.** Copy the refreshed `English.json` entries into each `Resources/Localization/Messages/<Language>.json` while preserving numeric hashes.
    Use `--overwrite` when translating after propagating hashes so English text is replaced by its translation.
 3. **Translate missing entries.**
-   `python Tools/translate_argos.py Resources/Localization/Messages/<Language>.json --to <iso-code> --batch-size 100 --max-retries 3 --log-level INFO --log-file translate.log --report-file skipped.csv --overwrite`
-   Verify the Argos model is installed before running translations: `argos-translate --from en --to tr - < /dev/null` (substitute the target code for `tr`).
-   `--log-level`, `--log-file`, and `--report-file` help pinpoint skipped or untranslated strings. Any hashes listed in `skipped.csv` must be manually translated and the script re‑run to confirm they are handled.
+   `python Tools/translate_argos.py Resources/Localization/Messages/<Language>.json --to <iso-code> --batch-size 100 --max-retries 3 --log-level INFO --overwrite`
+   Outputs are written to `translations/<iso-code>/<timestamp>/` (override with `--run-dir`). Verify the Argos model is installed before running translations: `argos-translate --from en --to tr - < /dev/null` (substitute the target code for `tr`).
+   `--log-level` helps pinpoint skipped or untranslated strings. Any hashes listed in `skipped.csv` within the run directory must be manually translated and the script re‑run to confirm they are handled.
 4. **Fix tokens after manual translation.**
    `python Tools/fix_tokens.py Resources/Localization/Messages/Turkish.json`
    Run with `--check-only` (`python Tools/fix_tokens.py --check-only`) to fail fast if tokens were altered. After fixing tokens, re‑run the translator to ensure no hashes remain in `skipped.csv`.

--- a/Docs/Localization.md
+++ b/Docs/Localization.md
@@ -45,25 +45,28 @@ Argos models are stored under `Resources/Localization/Models/<LANG>` as split ar
 2. **Run the translator**
 
    ```bash
-   python Tools/translate_argos.py Resources/Localization/Messages/<Language>.json --to <iso-code> --batch-size 100 --max-retries 3 --log-level INFO --log-file translate.log --report-file skipped.csv --overwrite
+   python Tools/translate_argos.py Resources/Localization/Messages/<Language>.json --to <iso-code> --batch-size 100 --max-retries 3 --log-level INFO --overwrite
    ```
 
    Omitting `--overwrite` translates only missing entries and keeps existing
    translations intact. Use `--overwrite` sparingly, as it retranslates every
-   line and can reprocess thousands of entries unnecessarily.
+   line and can reprocess thousands of entries unnecessarily. Outputs are saved
+   under `translations/<iso-code>/<timestamp>/` by default; override with
+   `--run-dir` if a custom location is desired.
 
    To refresh specific messages without touching the rest, pass one or more
    `--hash <hash>` options to translate only those hashes.
 
 3. **Handle skipped rows**
 
-   Any hashes listed in `skipped.csv` must be translated manually. Re-run the translator until the file is empty.
+   Any hashes listed in `skipped.csv` within the run directory must be
+   translated manually. Re-run the translator until the file is empty.
 
    To extract hashes that were skipped due to token mismatches, scan the
    translation log:
 
    ```bash
-   python Tools/collect_skipped_hashes.py --log-file translate.log --csv mismatches.csv
+   python Tools/collect_skipped_hashes.py --log-file translations/<iso-code>/<timestamp>/translate.log --csv mismatches.csv
    ```
 
    Omit `--csv` to print the unique hashes to stdout.

--- a/README.md
+++ b/README.md
@@ -811,8 +811,8 @@ This process applies only to files under `Resources/Localization/Messages`.
 2. **Propagate new hashes.** Copy the refreshed `English.json` entries into each `Resources/Localization/Messages/<Language>.json` while keeping numeric hashes intact.
    Use `--overwrite` when translating after propagating hashes so English text is replaced by its translation.
 3. **Translate missing entries.**
-   `python Tools/translate_argos.py Resources/Localization/Messages/<Language>.json --to <iso-code> --batch-size 100 --max-retries 3 --verbose --log-file translate.log --report-file skipped.csv --overwrite`
-   Verify the Argos model is installed before running translations: `argos-translate --from en --to tr - < /dev/null` (replace `tr` with the target code). Reassemble models from the module zip parts at the start of each session. Any hashes listed in `skipped.csv` must be manually translated and the script re-run to confirm they are handled.
+   `python Tools/translate_argos.py Resources/Localization/Messages/<Language>.json --to <iso-code> --batch-size 100 --max-retries 3 --log-level INFO --overwrite`
+   Outputs are saved under `translations/<iso-code>/<timestamp>/` (override with `--run-dir`). Verify the Argos model is installed before running translations: `argos-translate --from en --to tr - < /dev/null` (replace `tr` with the target code). Any hashes listed in `skipped.csv` within the run directory must be manually translated and the script re-run to confirm they are handled.
 4. **Check and fix tokens.**
    ```bash
    python Tools/fix_tokens.py --check-only Resources/Localization/Messages/<Language>.json
@@ -866,7 +866,7 @@ Rebuild and install models at the start of every session; they are not persisted
 | EN_ZH | Simplified Chinese (`zh`) |
 | EN_ZT | Traditional Chinese — non‑ISO `zt` |
 
-`Tools/translate_argos.py` uses the `argostranslate` Python API and protects `<...>` tags and `{...}` variables by replacing them with `[[TOKEN_n]]`. Tokens must be preserved, but they may be reordered when grammar requires; the script logs a warning if their order changes. Lines made entirely of tokens receive a `TRANSLATE` suffix so Argos does not skip them. Set `--log-level INFO` to display each entry as it is processed or `DEBUG` for more detail. Use `--log-file` to keep a record, and `--report-file skipped.csv` (or `.json`) to capture skipped hashes with reasons and the original English text for manual follow-up. `translate_argos.py` accepts `--batch-size`, `--max-retries`, and `--timeout` options. Re-run it on a clean copy of `Spanish.json` to restart translations from scratch. `Tools/translate.py` remains for backward compatibility but prints a deprecation warning.
+`Tools/translate_argos.py` uses the `argostranslate` Python API and protects `<...>` tags and `{...}` variables by replacing them with `[[TOKEN_n]]`. Tokens must be preserved, but they may be reordered when grammar requires; the script logs a warning if their order changes. Lines made entirely of tokens receive a `TRANSLATE` suffix so Argos does not skip them. Set `--log-level INFO` to display each entry as it is processed or `DEBUG` for more detail. Translation logs (`translate.log`), skip reports (`skipped.csv`), and metrics (`translate_metrics.json`) are written to the run directory (`translations/<lang>/<timestamp>` by default). `translate_argos.py` accepts `--batch-size`, `--max-retries`, `--timeout`, and `--run-dir` options. Re-run it on a clean copy of `Spanish.json` to restart translations from scratch. `Tools/translate.py` remains for backward compatibility but prints a deprecation warning.
 
 Run `Tools/fix_tokens.py` after translating to restore `<...>` tags and `{...}` placeholders if any `[[TOKEN_n]]` markers remain. Use `--check-only` to report discrepancies without modifying files.
 

--- a/Tools/analyze_translation_logs.py
+++ b/Tools/analyze_translation_logs.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Summarize translation log failures.
 
-This script reads ``translate_metrics.json`` and ``skipped.csv`` from the
-repository root and prints counts of failures grouped by category. It exits
+This script reads ``translate_metrics.json`` files under ``translations`` and
+``skipped.csv`` from the repository root and prints counts of failures grouped by category. It exits
 with a non-zero status if any token mismatches or placeholder-only failures
 remain so CI systems can fail fast. Categories include ``english``,
 ``identical``, ``sentinel``, ``token_mismatch``, and ``placeholder``.
@@ -19,7 +19,6 @@ from collections import Counter
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
-METRICS_PATH = ROOT / "translate_metrics.json"
 SKIPPED_PATH = ROOT / "skipped.csv"
 logger = logging.getLogger(__name__)
 
@@ -82,7 +81,9 @@ def main() -> None:
         stream=sys.stdout,
     )
 
-    metric_counts = _summarize_metrics(METRICS_PATH)
+    metric_counts: Counter[str] = Counter()
+    for path in (ROOT / "translations").glob("*/*/translate_metrics.json"):
+        metric_counts.update(_summarize_metrics(path))
     skipped_counts = _summarize_skipped(SKIPPED_PATH)
 
     if metric_counts:

--- a/Tools/collect_skipped_hashes.py
+++ b/Tools/collect_skipped_hashes.py
@@ -41,8 +41,12 @@ def main() -> None:
     parser.add_argument(
         "--log-file",
         type=Path,
-        default=ROOT / "translate.log",
         help="Path to translate.log",
+    )
+    parser.add_argument(
+        "--run-dir",
+        type=Path,
+        help="Directory containing translate.log (defaults to current run dir)",
     )
     parser.add_argument(
         "--csv",
@@ -50,6 +54,11 @@ def main() -> None:
         help="Optional CSV output file; hashes are printed to stdout when omitted",
     )
     args = parser.parse_args()
+
+    if not args.log_file:
+        if not args.run_dir:
+            parser.error("--log-file or --run-dir is required")
+        args.log_file = args.run_dir / "translate.log"
 
     hashes = parse_hashes(args.log_file)
     if args.csv:

--- a/Tools/localization_pipeline.py
+++ b/Tools/localization_pipeline.py
@@ -143,8 +143,7 @@ def main() -> None:
             continue
         lang_metrics["skipped"] = False
         t_start = timestamp()
-        log_name = f"translate_{name}.log"
-        report_name = f"skipped_{name}.csv"
+        run_dir = ROOT / "translations" / code / datetime.now().strftime("%Y%m%d-%H%M%S")
         result = run(
             [
                 sys.executable,
@@ -152,29 +151,28 @@ def main() -> None:
                 str(path.relative_to(ROOT)),
                 "--to",
                 code,
+                "--run-dir",
+                str(run_dir),
                 "--batch-size",
                 "100",
                 "--max-retries",
                 "3",
                 "--log-level",
                 "INFO",
-                "--log-file",
-                log_name,
-                "--report-file",
-                report_name,
                 "--overwrite",
             ],
             check=False,
             logger=logger,
         )
-        report_paths.append(ROOT / report_name)
+        report = run_dir / "skipped.csv"
+        report_paths.append(report)
         t_end = timestamp()
         lang_metrics["translation"] = {
             "start": t_start,
             "end": t_end,
             "returncode": result.returncode,
         }
-        report = ROOT / report_name
+        report = run_dir / "skipped.csv"
         skipped_counts: Dict[str, int] = {}
         if report.is_file():
             with report.open("r", encoding="utf-8") as fp:


### PR DESCRIPTION
## Summary
- add `--run-dir` option to translate_argos and write logs, reports, and metrics in that directory by default
- update localization pipeline and analysis scripts for new directory structure
- refresh docs and tests for translation run folders

## Testing
- `dotnet test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5ef9bd5b8832daa3c083603b032c1