### PR TITLE
feat: add translation run validator

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,6 +89,9 @@ jobs:
           python Tools/fix_tokens.py --check-only Resources/Localization/Messages/*.json
           dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations
 
+      - name: Validate translation run
+        run: python Tools/validate_translation_run.py --run-dir .
+
       - name: GH Release
         uses: softprops/action-gh-release@v1
         if: github.event_name == 'workflow_dispatch'

--- a/Docs/Localization.md
+++ b/Docs/Localization.md
@@ -61,6 +61,15 @@ Argos models are stored under `Resources/Localization/Models/<LANG>` as split ar
 
    Any hashes listed in `skipped.csv` within the run directory must be
    translated manually. Re-run the translator until the file is empty.
+   Summarise each run and fail fast on unresolved issues:
+
+   ```bash
+   python Tools/validate_translation_run.py --run-dir translations/<iso-code>/<timestamp>
+   ```
+
+   The script reports how many entries were translated or skipped and
+   exits non-zero when any `token_mismatch` or `sentinel` problems remain.
+
 
    To extract hashes that were skipped due to token mismatches, scan the
    translation log:

--- a/Tools/test_validate_translation_run.py
+++ b/Tools/test_validate_translation_run.py
@@ -1,0 +1,50 @@
+import csv
+import subprocess
+import csv
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().with_name("validate_translation_run.py")
+
+
+def _write_csv(path: Path, rows: list[dict[str, str]]) -> None:
+    with path.open("w", newline="", encoding="utf-8") as fp:
+        writer = csv.DictWriter(fp, fieldnames=["hash", "english", "reason", "category"])
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def test_exit_code_on_issues(tmp_path: Path) -> None:
+    run_dir = tmp_path
+    (run_dir / "translate.log").write_text(
+        "hash1: TRANSLATED\n" "hash2: SKIPPED (token mismatch)\n", encoding="utf-8"
+    )
+    _write_csv(
+        run_dir / "skipped.csv",
+        [{"hash": "h2", "english": "e", "reason": "r", "category": "token_mismatch"}],
+    )
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--run-dir", str(run_dir)],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 1
+    assert "Log results: 1 TRANSLATED, 1 SKIPPED" in proc.stdout
+    assert "token_mismatch: 1" in proc.stdout
+
+
+def test_success_without_issues(tmp_path: Path) -> None:
+    run_dir = tmp_path
+    (run_dir / "translate.log").write_text(
+        "hash1: TRANSLATED\n", encoding="utf-8"
+    )
+    _write_csv(run_dir / "skipped.csv", [])
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--run-dir", str(run_dir)],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0
+    assert "Log results: 1 TRANSLATED, 0 SKIPPED" in proc.stdout

--- a/Tools/validate_translation_run.py
+++ b/Tools/validate_translation_run.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Validate a translation run directory.
+
+Counts `TRANSLATED`/`SKIPPED` entries in `translate.log` and
+summarises categories from `skipped.csv`. Exits with a non-zero status
+if any `token_mismatch` or `sentinel` issues remain so CI can fail
+fast.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+LOG_RE = re.compile(r": (TRANSLATED|SKIPPED)(?: \(([^)]+)\))?")
+
+def summarize_log(path: Path) -> tuple[int, int, Counter[str]]:
+    """Return translated/skipped counts and issue categories from `path`."""
+    translated = skipped = 0
+    issues: Counter[str] = Counter()
+    try:
+        with path.open(encoding="utf-8") as fp:
+            for line in fp:
+                m = LOG_RE.search(line)
+                if not m:
+                    continue
+                status, reason = m.group(1), (m.group(2) or "").lower()
+                if status == "TRANSLATED":
+                    translated += 1
+                else:
+                    skipped += 1
+                    if "token mismatch" in reason:
+                        issues["token_mismatch"] += 1
+                    if "sentinel" in reason:
+                        issues["sentinel"] += 1
+    except FileNotFoundError:
+        pass
+    return translated, skipped, issues
+
+def summarize_skipped(path: Path) -> Counter[str]:
+    """Return category counts from `path` if it exists."""
+    counts: Counter[str] = Counter()
+    try:
+        with path.open(encoding="utf-8") as fp:
+            reader = csv.DictReader(fp)
+            for row in reader:
+                cat = (row.get("category") or "unknown").strip() or "unknown"
+                counts[cat] += 1
+    except FileNotFoundError:
+        pass
+    return counts
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Validate translation run output")
+    ap.add_argument(
+        "--run-dir",
+        required=True,
+        help="Directory containing translate.log and skipped.csv",
+    )
+    args = ap.parse_args()
+
+    run_dir = Path(args.run_dir)
+    translated, skipped, log_issues = summarize_log(run_dir / "translate.log")
+    skip_counts = summarize_skipped(run_dir / "skipped.csv")
+
+    print(f"Log results: {translated} TRANSLATED, {skipped} SKIPPED")
+    if skip_counts:
+        print("Skip report:")
+        for category, count in sorted(skip_counts.items()):
+            print(f"  {category}: {count}")
+
+    exit_code = 0
+    if log_issues.get("token_mismatch") or log_issues.get("sentinel"):
+        exit_code = 1
+    if skip_counts.get("token_mismatch") or skip_counts.get("sentinel"):
+        exit_code = 1
+
+    sys.exit(exit_code)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add validate_translation_run.py to summarize translation logs and skip reports
- check translation runs in localization pipeline and CI workflow
- document and test translation run validation helper

## Testing
- `pytest Tools`
- `python Tools/validate_translation_run.py --run-dir .`


------
https://chatgpt.com/codex/tasks/task_e_68a5fc18e2d4832dbda8c47c022728ed