### PR TITLE
Handle named hashes in skipped log parsing

### DIFF
--- a/Tools/collect_skipped_hashes.py
+++ b/Tools/collect_skipped_hashes.py
@@ -11,7 +11,7 @@ from typing import Iterable, Set
 
 ROOT = Path(__file__).resolve().parent.parent
 
-PATTERN = re.compile(r"^(\d+): SKIPPED \(token mismatch")
+PATTERN = re.compile(r"^([^:]+): SKIPPED \(token mismatch")
 
 
 def parse_hashes(path: Path) -> Set[str]:
@@ -22,7 +22,10 @@ def parse_hashes(path: Path) -> Set[str]:
         for line in fp:
             match = PATTERN.search(line)
             if match:
-                hashes.add(match.group(1))
+                hash_id = match.group(1).strip()
+                if hash_id.isdigit():
+                    hash_id = str(int(hash_id))
+                hashes.add(hash_id)
     return hashes
 
 

--- a/Tools/test_collect_skipped_hashes.py
+++ b/Tools/test_collect_skipped_hashes.py
@@ -1,0 +1,13 @@
+import collect_skipped_hashes as csh
+
+
+def test_parse_hashes_with_named_and_numeric(tmp_path):
+    log = tmp_path / "translate.log"
+    log.write_text(
+        "00123: SKIPPED (token mismatch)\n"
+        "welcome: SKIPPED (token mismatch)\n"
+        "other: TRANSLATED\n",
+        encoding="utf-8",
+    )
+    hashes = csh.parse_hashes(log)
+    assert hashes == {"123", "welcome"}


### PR DESCRIPTION
## Summary
- allow collect_skipped_hashes to capture named keys
- normalize parsed IDs to remove whitespace and leading zeros
- test parsing of mixed numeric and named hashes

## Testing
- `pytest Tools/test_collect_skipped_hashes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a61b8ea500832d89d6ee780e2b80cb