### PR TITLE
Log translation summaries as info

### DIFF
--- a/Tools/translate_argos.py
+++ b/Tools/translate_argos.py
@@ -1134,7 +1134,7 @@ def main():
         logger.addHandler(file_handler)
 
     if getattr(args, "verbose", False):
-        logger.warning("--verbose is deprecated; use --log-level INFO")
+        logger.info("--verbose is deprecated; use --log-level INFO")
 
     if args.report_file:
         try:


### PR DESCRIPTION
## Summary
- Log deprecated `--verbose` flag usage at INFO level
- Test that batch summary and success logs use INFO instead of WARNING

## Testing
- `pytest Tools/test_translate_argos.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a62bde2880832d9be967a44c6cd8ed