### PR TITLE
Add token stats summarizer script

### DIFF
--- a/Docs/Localization.md
+++ b/Docs/Localization.md
@@ -340,6 +340,16 @@ The script reads `translate_metrics.json` along with any `skipped_*.csv`
 reports and lists token mismatches or placeholder-only entries. It exits
 non-zero when problems remain so CI and contributors can investigate.
 
+For a focused view of hashes with mismatched or reordered tokens recorded in
+`translate_metrics.json`, run:
+
+```bash
+python Tools/summarize_token_stats.py --top 20
+```
+
+This prints a table of problematic hashes; add `--csv output.csv` to write the
+results to disk.
+
 ## Troubleshooting & Notes
 
 - **Argos model installation**: Some environments lack the `install` subcommand. Combine split archives and install using the Python API each session:

--- a/Tools/summarize_token_stats.py
+++ b/Tools/summarize_token_stats.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Summarize per-hash token mismatches and reorders."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load_metrics(path: Path) -> List[dict]:
+    try:
+        with path.open(encoding="utf-8") as fp:
+            return json.load(fp)
+    except FileNotFoundError:
+        return []
+    except json.JSONDecodeError:
+        return []
+
+
+def _aggregate(entries: List[dict]) -> Dict[str, Dict[str, int | str]]:
+    stats: Dict[str, Dict[str, int | str]] = {}
+    for entry in entries:
+        file = entry.get("file", "")
+        failures = entry.get("failures", {})
+        for hash_id, info in entry.get("hash_stats", {}).items():
+            mismatch = info.get("original_tokens") != info.get("translated_tokens")
+            if hash_id in failures:
+                mismatch = True
+            reordered = bool(info.get("reordered"))
+            if mismatch or reordered:
+                record = stats.setdefault(hash_id, {"mismatches": 0, "reorders": 0, "file": file})
+                if mismatch:
+                    record["mismatches"] += 1
+                if reordered:
+                    record["reorders"] += 1
+                record["file"] = file
+    return stats
+
+
+def _sort_rows(stats: Dict[str, Dict[str, int | str]]) -> List[Tuple[str, int, int, str]]:
+    rows = [
+        (hash_id, data["mismatches"], data["reorders"], str(data.get("file", "")))
+        for hash_id, data in stats.items()
+    ]
+    rows.sort(key=lambda r: (r[1] + r[2], r[0]), reverse=True)
+    return rows
+
+
+def _print_table(rows: List[Tuple[str, int, int, str]]) -> None:
+    if not rows:
+        return
+    header = ("hash", "mismatches", "reorders", "file")
+    widths = [max(len(str(x)) for x in col) for col in zip(*(rows + [header]))]
+    fmt = "{:<%d} {:>%d} {:>%d} {:<%d}" % tuple(widths)
+    print(fmt.format(*header))
+    for row in rows:
+        print(fmt.format(*row))
+
+
+def _write_csv(rows: List[Tuple[str, int, int, str]], path: Path) -> None:
+    with path.open("w", newline="", encoding="utf-8") as fp:
+        writer = csv.writer(fp)
+        writer.writerow(["hash", "mismatches", "reorders", "file"])
+        for row in rows:
+            writer.writerow(row)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Summarize token stats from translate_metrics.json")
+    ap.add_argument(
+        "--metrics-file",
+        type=Path,
+        default=ROOT / "translate_metrics.json",
+        help="Path to translate_metrics.json",
+    )
+    ap.add_argument(
+        "--csv",
+        type=Path,
+        help="Optional CSV output file",
+    )
+    ap.add_argument(
+        "--top",
+        type=int,
+        default=0,
+        help="Limit results to top N hashes",
+    )
+    args = ap.parse_args()
+
+    entries = _load_metrics(args.metrics_file)
+    stats = _aggregate(entries)
+    rows = _sort_rows(stats)
+    if args.top and args.top > 0:
+        rows = rows[: args.top]
+
+    if args.csv:
+        _write_csv(rows, args.csv)
+    _print_table(rows)
+
+
+if __name__ == "__main__":
+    main()

--- a/Tools/test_summarize_token_stats.py
+++ b/Tools/test_summarize_token_stats.py
@@ -1,0 +1,26 @@
+import summarize_token_stats as sts
+
+
+def test_aggregate():
+    entries = [
+        {
+            "file": "a.json",
+            "failures": {"1": "token mismatch"},
+            "hash_stats": {
+                "1": {"original_tokens": 1, "translated_tokens": 0, "reordered": False},
+                "2": {"original_tokens": 1, "translated_tokens": 1, "reordered": True},
+            },
+        },
+        {
+            "file": "b.json",
+            "failures": {},
+            "hash_stats": {
+                "2": {"original_tokens": 1, "translated_tokens": 1, "reordered": False}
+            },
+        },
+    ]
+    stats = sts._aggregate(entries)
+    assert stats == {
+        "1": {"mismatches": 1, "reorders": 0, "file": "a.json"},
+        "2": {"mismatches": 0, "reorders": 1, "file": "a.json"},
+    }


### PR DESCRIPTION
## Summary
- add summarize_token_stats.py to list hashes with token mismatches or reorders
- document token statistics diagnostics in localization guide
- test token stats aggregation

## Testing
- `python -m pytest Tools/test_summarize_token_stats.py`
- `python -m pytest`
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-6.0` *(fails: Package 'dotnet-sdk-6.0' has no installation candidate)*

------
https://chatgpt.com/codex/tasks/task_e_68a62f0b4874832d9d36265bf4ac7ecf