### PR TITLE
feat: centralise translation run outputs

### DIFF
--- a/Docs/Localization.md
+++ b/Docs/Localization.md
@@ -50,9 +50,11 @@ Argos models are stored under `Resources/Localization/Models/<LANG>` as split ar
 
    Omitting `--overwrite` translates only missing entries and keeps existing
    translations intact. Use `--overwrite` sparingly, as it retranslates every
-   line and can reprocess thousands of entries unnecessarily. Outputs are saved
-   under `translations/<iso-code>/<timestamp>/` by default; override with
-   `--run-dir` if a custom location is desired.
+  line and can reprocess thousands of entries unnecessarily. Outputs are saved
+  under `translations/<iso-code>/<timestamp>/` by default; override with
+  `--run-dir` if a custom location is desired. The translator writes
+  `translate.log`, `skipped.csv`, and `translate_metrics.json` to this run
+  directory.
 
    To refresh specific messages without touching the rest, pass one or more
    `--hash <hash>` options to translate only those hashes.

--- a/Tools/translate_argos.py
+++ b/Tools/translate_argos.py
@@ -1042,7 +1042,8 @@ def main():
     root = os.path.abspath(args.root)
 
     timestamp = time.strftime("%Y%m%d-%H%M%S")
-    if args.run_dir:
+    provided_run_dir = bool(args.run_dir)
+    if provided_run_dir:
         run_dir = (
             args.run_dir
             if os.path.isabs(args.run_dir)
@@ -1053,35 +1054,17 @@ def main():
     os.makedirs(run_dir, exist_ok=True)
     args.run_dir = run_dir
 
-    if args.log_file:
-        log_path = (
-            args.log_file
-            if os.path.isabs(args.log_file)
-            else os.path.join(run_dir, args.log_file)
-        )
-    else:
-        log_path = os.path.join(run_dir, "translate.log")
-    args.log_file = log_path
+    def resolve_path(path: str | None, default_name: str) -> str:
+        if provided_run_dir:
+            name = os.path.basename(path) if path else default_name
+            return os.path.join(run_dir, name)
+        if path:
+            return path if os.path.isabs(path) else os.path.join(root, path)
+        return os.path.join(run_dir, default_name)
 
-    if args.report_file:
-        report_path = (
-            args.report_file
-            if os.path.isabs(args.report_file)
-            else os.path.join(run_dir, args.report_file)
-        )
-    else:
-        report_path = os.path.join(run_dir, "skipped.csv")
-    args.report_file = report_path
-
-    if args.metrics_file:
-        metrics_path = (
-            args.metrics_file
-            if os.path.isabs(args.metrics_file)
-            else os.path.join(run_dir, args.metrics_file)
-        )
-    else:
-        metrics_path = os.path.join(run_dir, "translate_metrics.json")
-    args.metrics_file = metrics_path
+    args.log_file = resolve_path(args.log_file, "translate.log")
+    args.report_file = resolve_path(args.report_file, "skipped.csv")
+    args.metrics_file = resolve_path(args.metrics_file, "translate_metrics.json")
 
     args.run_id = str(uuid.uuid4())
     try:


### PR DESCRIPTION
## Summary
- allow `translate_argos.py` to gather logs, skipped report, and metrics under a run directory
- document run directory convention for translation outputs
- cover run-directory behaviour in tests

## Testing
- `pytest Tools/test_translate_argos.py::test_run_dir_creates_outputs -q`
- `pytest Tools/test_translate_argos.py::test_run_dir_redirects_paths -q`
- `pytest Tools -q`
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a63b2cdb48832db291b85d237aca22