### PR TITLE
feat: log translation run metadata

### DIFF
--- a/Docs/Localization.md
+++ b/Docs/Localization.md
@@ -283,7 +283,7 @@ is specified (default `translate_metrics.json` under `--root`):
 python Tools/translate_argos.py Resources/Localization/Messages/Turkish.json --to tr --metrics-file translate_metrics.json
 ```
 
-An entry records the run ID, source commit, Argos Translate version, model version, and summarises successes, timeouts, token reorders and per‑hash token statistics:
+An entry records the run ID, source commit, Argos Translate version, model version, CLI arguments, and summarises successes, timeouts, token reorders and per‑hash token statistics:
 
 ```json
 [
@@ -292,6 +292,15 @@ An entry records the run ID, source commit, Argos Translate version, model versi
     "commit": "abcdef1",
     "argos_version": "1.8.0",
     "model_version": "1",
+    "cli_args": {
+      "target_file": "Resources/Localization/Messages/Turkish.json",
+      "src": "en",
+      "dst": "tr",
+      "batch_size": 100,
+      "max_retries": 3,
+      "timeout": 60,
+      "overwrite": false
+    },
     "file": "Resources/Localization/Messages/Turkish.json",
     "timestamp": "2024-02-20T12:00:02Z",
     "processed": 500,

--- a/Tools/analyze_translation_logs.py
+++ b/Tools/analyze_translation_logs.py
@@ -4,7 +4,7 @@
 This script reads ``translate_metrics.json`` files under ``translations`` and
 ``skipped.csv`` from the repository root and prints counts of failures grouped
 by category. Metrics entries now include additional metadata such as
-``run_id``, ``commit``, and ``model_version`` which are emitted at debug level.
+``run_id``, ``commit``, ``model_version``, and ``cli_args`` which are emitted at debug level.
 The script exits with a non-zero status if any token mismatches or
 placeholder-only failures remain so CI systems can fail fast. Categories
 include ``english``, ``identical``, ``sentinel``, ``token_mismatch``, and
@@ -54,10 +54,11 @@ def _summarize_metrics(path: Path) -> Counter:
         failures = entry.get("failures", {})
         if failures:
             logger.debug(
-                "Run %s commit %s model %s had %d failures",
+                "Run %s commit %s model %s args %s had %d failures",
                 entry.get("run_id"),
                 entry.get("commit"),
                 entry.get("model_version", entry.get("argos_version")),
+                entry.get("cli_args"),
                 len(failures),
             )
         for reason in failures.values():


### PR DESCRIPTION
## Summary
- record run metadata including cli arguments, git commit, and Argos model version during translation runs
- surface run metadata in translation log analysis and docs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a64167c6e4832db73c97993464e121