### PR TITLE
Log translation run configuration

### DIFF
--- a/Tools/translate_argos.py
+++ b/Tools/translate_argos.py
@@ -13,7 +13,6 @@ import re
 import subprocess
 import sys
 import time
-import traceback
 import logging
 import uuid
 import importlib.metadata
@@ -1133,6 +1132,16 @@ def main():
 
     if getattr(args, "verbose", False):
         logger.info("--verbose is deprecated; use --log-level INFO")
+
+    summary = {
+        "input_file": args.target_file,
+        "target_language": args.dst,
+        "batch_size": args.batch_size,
+        "max_retries": args.max_retries,
+        "timeout": args.timeout,
+        "run_dir": args.run_dir,
+    }
+    logger.info("Run configuration: %s", summary)
 
     if args.report_file:
         try:


### PR DESCRIPTION
## Summary
- log key translation parameters after argument parsing for visibility in console and log file
- remove unused traceback import

## Testing
- `ruff check Tools/translate_argos.py`
- `pytest Tools/test_translate_argos.py Tools/test_translate_argos_tokens.py Tools/test_translate_argos_integration.py Tools/test_validate_translation_run.py`


------
https://chatgpt.com/codex/tasks/task_e_68a64525c590832d9ee2647dfe3e905b