### PR TITLE
feat: improve report logging

### DIFF
--- a/Tools/test_translate_argos.py
+++ b/Tools/test_translate_argos.py
@@ -1659,10 +1659,12 @@ def test_write_report_logs_counts_and_success(tmp_path, caplog):
     out_rows = list(csv.DictReader(path.open()))
     assert len(out_rows) == 2
     assert (
-        f"Report rows before deduplication: {len(rows)}, after: {len(out_rows)}"
+        f"Received {len(rows)} rows; deduplicated to {len(out_rows)} rows"
         in caplog.text
     )
-    assert f"Wrote report to {path}" in caplog.text
+    assert (
+        f"Successfully wrote {len(out_rows)} rows to {path}" in caplog.text
+    )
 
 
 def test_write_report_warns_on_failure(tmp_path, monkeypatch, caplog):

--- a/Tools/translate_argos.py
+++ b/Tools/translate_argos.py
@@ -346,9 +346,7 @@ def _write_report(path: str, rows: list[dict[str, str]], *, max_retries: int = 3
                 deduped[key] = row
         rows = list(deduped.values())
     after_count = len(rows)
-    logger.info(
-        "Report rows before deduplication: %d, after: %d", before_count, after_count
-    )
+    logger.info("Received %d rows; deduplicated to %d rows", before_count, after_count)
 
     ext = os.path.splitext(path)[1].lower()
     for attempt in range(1, max_retries + 1):
@@ -364,7 +362,7 @@ def _write_report(path: str, rows: list[dict[str, str]], *, max_retries: int = 3
                     writer.writerows(rows)
                 else:
                     raise RuntimeError("Report file must end with .json or .csv")
-            logger.info("Wrote report to %s", path)
+            logger.info("Successfully wrote %d rows to %s", after_count, path)
             break
         except Exception as exc:
             logger.warning(


### PR DESCRIPTION
## Summary
- log deduped and written row counts in `_write_report`
- warn on write retries and report successes via info logs
- adjust tests for new logging messages

## Testing
- `pytest Tools/test_translate_argos.py::test_write_report_deduplicates_rows Tools/test_translate_argos.py::test_write_report_logs_counts_and_success Tools/test_translate_argos.py::test_write_report_warns_on_failure -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6497854e4832dab34d9df17aeca6c