### PR TITLE
Log run directory and git metadata in translation metrics

### DIFF
--- a/Docs/Localization.md
+++ b/Docs/Localization.md
@@ -283,13 +283,13 @@ is specified (default `translate_metrics.json` under `--root`):
 python Tools/translate_argos.py Resources/Localization/Messages/Turkish.json --to tr --metrics-file translate_metrics.json
 ```
 
-An entry records the run ID, source commit, Argos Translate version, model version, CLI arguments, and summarises successes, timeouts, token reorders and per‑hash token statistics:
+An entry records the run ID, git commit, Argos Translate version, model version, run directory, CLI arguments, and summarises successes, timeouts, token reorders and per‑hash token statistics. If the run terminates early, ``error`` notes the reason:
 
 ```json
 [
   {
     "run_id": "123e4567-e89b-12d3-a456-426614174000",
-    "commit": "abcdef1",
+    "git_commit": "abcdef1",
     "argos_version": "1.8.0",
     "model_version": "1",
     "cli_args": {
@@ -301,6 +301,7 @@ An entry records the run ID, source commit, Argos Translate version, model versi
       "timeout": 60,
       "overwrite": false
     },
+    "run_dir": "TranslationRuns/Turkish/2024-02-20",
     "file": "Resources/Localization/Messages/Turkish.json",
     "timestamp": "2024-02-20T12:00:02Z",
     "processed": 500,

--- a/Tools/analyze_translation_logs.py
+++ b/Tools/analyze_translation_logs.py
@@ -4,8 +4,8 @@
 This script reads ``translate_metrics.json`` and ``skipped.csv`` from the
 repository root and prints counts of failures grouped by category. Paths may be
 overridden via ``--metrics-file`` and ``--skipped-file`` to inspect a specific
-run directory. Metrics entries include metadata such as ``run_id``, ``commit``,
-``model_version``, and ``cli_args`` which are emitted at debug level. The script
+run directory. Metrics entries include metadata such as ``run_id``, ``git_commit``,
+``model_version``, ``run_dir``, and ``cli_args`` which are emitted at debug level. The script
 exits with a non-zero status if any token mismatches or placeholder-only
 failures remain so CI systems can fail fast. Categories include ``english``,
 ``identical``, ``sentinel``, ``token_mismatch``, and ``placeholder``.
@@ -51,13 +51,15 @@ def _summarize_metrics(path: Path) -> Counter:
         return counts
     for entry in entries:
         failures = entry.get("failures", {})
-        if failures:
+        if failures or entry.get("error"):
             logger.debug(
-                "Run %s commit %s model %s args %s had %d failures",
+                "Run %s commit %s model %s dir %s args %s error %s had %d failures",
                 entry.get("run_id"),
-                entry.get("commit"),
+                entry.get("git_commit"),
                 entry.get("model_version", entry.get("argos_version")),
+                entry.get("run_dir"),
                 entry.get("cli_args"),
+                entry.get("error"),
                 len(failures),
             )
         for reason in failures.values():

--- a/Tools/test_translate_argos.py
+++ b/Tools/test_translate_argos.py
@@ -5,6 +5,7 @@ import os
 import subprocess
 import sys
 import tempfile
+from pathlib import Path
 
 import pytest
 
@@ -1260,6 +1261,9 @@ def test_metrics_file_records_failure_reason(tmp_path, monkeypatch):
     data = json.loads(metrics_files[0].read_text())
     entry = data[-1]
     assert "model_version" in entry
+    assert entry["run_id"]
+    assert entry["git_commit"] == "unknown"
+    assert Path(entry["run_dir"]).is_dir()
     assert entry["processed"] == 1
     assert entry["successes"] == 0
     assert entry["timeouts"] == 0


### PR DESCRIPTION
## Summary
- include run directory and git commit in translation metrics and record early exit errors
- surface new fields in translation log analyzer
- document expanded metrics schema and verify new fields in tests

## Testing
- `pytest Tools/test_analyze_translation_logs.py Tools/test_translate_argos.py::test_metrics_file_records_failure_reason Tools/test_translate_argos.py::test_metrics_file_records_timeout Tools/test_translate_argos.py::test_metrics_file_counts_token_reorders`

------
https://chatgpt.com/codex/tasks/task_e_68a66cc80280832d96bc7b524ed8f50b