### PR TITLE
Archive translation logs with commit tag

### DIFF
--- a/Docs/Localization.md
+++ b/Docs/Localization.md
@@ -244,9 +244,10 @@ and `skipped.csv` in the repository root):
 python Tools/localization_pipeline.py --debug --metrics-file metrics.json --skipped-file skipped.csv
 ```
 
-Add `--archive-logs` to preserve per-language `translate_<Language>.log`
-and `skipped_<Language>.csv` files under `TranslationLogs/<timestamp>`
-for later investigation.
+Pass `--archive-logs` to archive each run directory under
+`TranslationLogs/<commit>/<timestamp>` for later investigation. Commit these
+directories to the repository so post-mortem reviews can trace issues back to
+the exact code version.
 
 This writes `localization_metrics.json` (or the path provided via
 `--metrics-file`). Each step records start/end timestamps and per-language

--- a/Tools/archive_translation_logs.py
+++ b/Tools/archive_translation_logs.py
@@ -1,43 +1,65 @@
 #!/usr/bin/env python3
-"""Archive translation log files with timestamped directories.
+"""Archive translation log directories for later inspection.
 
-This script moves translation artifacts matching ``translate_*.log`` and
-``skipped_*.csv`` into a directory named ``TranslationLogs/<timestamp>``
-relative to the repository root. For each archived file an accompanying
-``.info`` file is written containing the timestamp of the run, providing a
-clear indicator of when the log was generated.
+Moves a translation run directory into ``TranslationLogs/<commit>/<timestamp>``
+relative to the repository root. The git commit hash is included so log sets
+can be traced back to the code that produced them.
 """
 
 from __future__ import annotations
 
+import argparse
 import datetime as _dt
 import shutil
+import subprocess
 from pathlib import Path
 
 
-def archive_logs() -> Path:
-    """Move translation logs into a timestamped directory.
+def archive_logs(run_dir: str | Path) -> Path:
+    """Move ``run_dir`` into a commit-scoped archive directory.
 
-    Returns the directory containing the archived logs. If no logs are
-    present the directory is still created so callers can attach additional
-    artifacts if desired.
+    Parameters
+    ----------
+    run_dir:
+        Directory containing translation artifacts such as ``translate.log``
+        and ``skipped.csv``.
+
+    Returns
+    -------
+    Path
+        Destination directory under ``TranslationLogs/<commit>/<timestamp>``.
     """
 
     root = Path(__file__).resolve().parent.parent
-    timestamp = _dt.datetime.now().strftime("%Y%m%d-%H%M%S")
-    destination = root / "TranslationLogs" / timestamp
-    destination.mkdir(parents=True, exist_ok=True)
+    run_path = Path(run_dir)
+    timestamp = run_path.name or _dt.datetime.now().strftime("%Y%m%d-%H%M%S")
+    try:
+        commit = (
+            subprocess.check_output(
+                ["git", "rev-parse", "--short", "HEAD"], cwd=root
+            )
+            .decode()
+            .strip()
+        )
+    except Exception:
+        commit = "unknown"
 
-    for pattern in ("translate_*.log", "skipped_*.csv"):
-        for source in root.glob(pattern):
-            target = destination / source.name
-            shutil.move(str(source), target)
-            info = destination / f"{source.name}.info"
-            info.write_text(f"Archived: {timestamp}\n")
+    destination = root / "TranslationLogs" / commit / timestamp
+    destination.parent.mkdir(parents=True, exist_ok=True)
+
+    if run_path.exists():
+        shutil.move(str(run_path), destination)
+    else:
+        destination.mkdir(parents=True, exist_ok=True)
+
+    info = destination / "archive.info"
+    info.write_text(f"Archived: {timestamp}\nCommit: {commit}\n")
 
     return destination
 
 
 if __name__ == "__main__":
-    archive_logs()
+    parser = argparse.ArgumentParser(description="Archive translation logs")
+    parser.add_argument("run_dir", help="Translation run directory")
+    archive_logs(parser.parse_args().run_dir)
 


### PR DESCRIPTION
## Summary
- archive translation run directories under `TranslationLogs/<commit>/<timestamp>`
- ensure localization pipeline archives each run's logs after completion
- document committing archived logs for post-mortem analysis

## Testing
- `pytest`
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a688fb8eb4832db9c4f5a2bb73e62d