### PR TITLE
Ensure deterministic token round-trips

### DIFF
--- a/Tools/tests/test_placeholder_roundtrip.py
+++ b/Tools/tests/test_placeholder_roundtrip.py
@@ -1,0 +1,12 @@
+import translate_argos
+
+
+def test_round_trip_mixed_placeholders_and_nested_tags():
+    text = "[b]<color=red>${var} {0}</color>[/b]"
+    safe, tokens = translate_argos.protect_strict(text)
+    translation = "[[TOKEN_1]][[TOKEN_2]][[TOKEN_0]] [[TOKEN_4]][[TOKEN_3]][[TOKEN_5]]"
+    normalized = translate_argos.normalize_tokens(translation)
+    reordered, changed = translate_argos.reorder_tokens(normalized, len(tokens))
+    assert changed
+    restored = translate_argos.unprotect(reordered, tokens)
+    assert restored == text

--- a/Tools/translate_argos.py
+++ b/Tools/translate_argos.py
@@ -120,22 +120,13 @@ def protect_strict(text: str) -> tuple[str, List[str]]:
 
 
 def unprotect(text: str, tokens: List[str]) -> str:
-    """Restore original tokens from ``[[TOKEN_n]]`` markers.
-
-    Validates that the placeholders appear in the expected order and count
-    before performing the substitution.
-    """
-
-    found = TOKEN_RE.findall(text)
-    expected = [str(i) for i in range(len(tokens))]
-    if found != expected:
-        raise ValueError(
-            f"Token sequence mismatch: expected {expected}, got {found}"
-        )
+    """Restore original tokens from ``[[TOKEN_n]]`` markers."""
 
     def repl(m: re.Match) -> str:
         idx = int(m.group(1))
-        return tokens[idx] if 0 <= idx < len(tokens) else m.group(0)
+        if idx >= len(tokens):
+            raise ValueError(f"Unknown token index: {idx}")
+        return tokens[idx]
 
     return TOKEN_RE.sub(repl, text)
 


### PR DESCRIPTION
## Summary
- Replace and restore placeholder tokens without enforcing order
- Add regression test for mixed placeholders and nested tags

## Testing
- `PYTHONPATH=Tools pytest Tools/tests Tools/test_token_roundtrip.py Tools/test_translate_argos_tokens.py Tools/test_translate_argos.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a731ec8274832da81f78543d7edc6c