### PR TITLE
feat: add run directory support for translations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ Current PRDs and task lists are stored in `.project-management/current-prd/`, wh
    Use `--overwrite` when translating after propagating hashes so English text is replaced by its translation.
 3. **Translate missing entries.**
    `python Tools/translate_argos.py Resources/Localization/Messages/<Language>.json --to <iso-code> --batch-size 100 --max-retries 3 --log-level INFO --overwrite`
-   Outputs are written to `TranslationRuns/<iso-code>/<timestamp>/` (override with `--run-dir`). Verify the Argos model is installed before running translations: `argos-translate --from en --to tr - < /dev/null` (substitute the target code for `tr`).
+   Outputs are written to `translations/<iso-code>/<timestamp>/` (override with `--run-dir`). Verify the Argos model is installed before running translations: `argos-translate --from en --to tr - < /dev/null` (substitute the target code for `tr`).
    `--log-level` helps pinpoint skipped or untranslated strings. Any hashes listed in `skipped.csv` within the run directory must be manually translated and the script re‑run to confirm they are handled.
 4. **Fix tokens after manual translation.**
    `python Tools/fix_tokens.py Resources/Localization/Messages/Turkish.json`

--- a/Docs/Localization.md
+++ b/Docs/Localization.md
@@ -51,7 +51,7 @@ Argos models are stored under `Resources/Localization/Models/<LANG>` as split ar
    Omitting `--overwrite` translates only missing entries and keeps existing
    translations intact. Use `--overwrite` sparingly, as it retranslates every
   line and can reprocess thousands of entries unnecessarily. Outputs are saved
-  under `TranslationRuns/<iso-code>/<timestamp>/` by default; override with
+  under `translations/<iso-code>/<timestamp>/` by default; override with
   `--run-dir` if a custom location is desired. The translator writes
   `translate.log`, `skipped.csv`, and `translate_metrics.json` to this run
   directory.
@@ -66,7 +66,7 @@ Argos models are stored under `Resources/Localization/Models/<LANG>` as split ar
    Summarise each run and fail fast on unresolved issues:
 
     ```bash
-    python Tools/validate_translation_run.py --run-dir TranslationRuns/<iso-code>/<timestamp>
+    python Tools/validate_translation_run.py --run-dir translations/<iso-code>/<timestamp>
     ```
 
     The script reports how many entries were translated or skipped and
@@ -88,7 +88,7 @@ make sample-translate
    translation log:
 
    ```bash
-   python Tools/collect_skipped_hashes.py --log-file TranslationRuns/<iso-code>/<timestamp>/translate.log --csv mismatches.csv
+   python Tools/collect_skipped_hashes.py --run-dir translations/<iso-code>/<timestamp> --csv mismatches.csv
    ```
 
    Omit `--csv` to print the unique hashes to stdout.
@@ -302,7 +302,7 @@ An entry records the run ID, git commit, Argos Translate version, model version,
       "timeout": 60,
       "overwrite": false
     },
-    "run_dir": "TranslationRuns/Turkish/2024-02-20",
+    "run_dir": "translations/tr/2024-02-20",
     "file": "Resources/Localization/Messages/Turkish.json",
     "timestamp": "2024-02-20T12:00:02Z",
     "processed": 500,
@@ -353,7 +353,7 @@ By default, the script reads `translate_metrics.json` and `skipped.csv` from
 the repository root. Override these paths to analyse a specific run directory:
 
 ```bash
-python Tools/analyze_translation_logs.py --metrics-file TranslationRuns/French/2025-05-16/translate_metrics.json --skipped-file TranslationRuns/French/2025-05-16/skipped.csv
+python Tools/analyze_translation_logs.py --run-dir translations/fr/2025-05-16
 ```
 
 The script lists token mismatches or placeholder-only entries and exits
@@ -363,7 +363,7 @@ For a focused view of hashes with mismatched or reordered tokens recorded in
 `translate_metrics.json`, run:
 
 ```bash
-python Tools/summarize_token_stats.py --top 20
+python Tools/summarize_token_stats.py --run-dir translations/fr/2025-05-16 --top 20
 ```
 
 This prints a table of problematic hashes; add `--csv output.csv` to write the

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,6 @@
 .PHONY: sample-translate
 
 sample-translate:
-> python Tools/translate_argos.py Resources/Localization/Messages/Spanish_sample.json --to es --run-dir TranslationRuns/sample_es --overwrite
-> python Tools/validate_translation_run.py --run-dir TranslationRuns/sample_es
+> python Tools/translate_argos.py Resources/Localization/Messages/Spanish_sample.json --to es --run-dir translations/sample_es --overwrite
+> python Tools/validate_translation_run.py --run-dir translations/sample_es
 

--- a/README.md
+++ b/README.md
@@ -812,7 +812,7 @@ This process applies only to files under `Resources/Localization/Messages`.
    Use `--overwrite` when translating after propagating hashes so English text is replaced by its translation.
 3. **Translate missing entries.**
    `python Tools/translate_argos.py Resources/Localization/Messages/<Language>.json --to <iso-code> --batch-size 100 --max-retries 3 --log-level INFO --overwrite`
-   Outputs are saved under `TranslationRuns/<iso-code>/<timestamp>/` (override with `--run-dir`). Verify the Argos model is installed before running translations: `argos-translate --from en --to tr - < /dev/null` (replace `tr` with the target code). Any hashes listed in `skipped.csv` within the run directory must be manually translated and the script re-run to confirm they are handled.
+   Outputs are saved under `translations/<iso-code>/<timestamp>/` (override with `--run-dir`). Verify the Argos model is installed before running translations: `argos-translate --from en --to tr - < /dev/null` (replace `tr` with the target code). Any hashes listed in `skipped.csv` within the run directory must be manually translated and the script re-run to confirm they are handled.
 4. **Check and fix tokens.**
    ```bash
    python Tools/fix_tokens.py --check-only Resources/Localization/Messages/<Language>.json
@@ -866,7 +866,7 @@ Rebuild and install models at the start of every session; they are not persisted
 | EN_ZH | Simplified Chinese (`zh`) |
 | EN_ZT | Traditional Chinese — non‑ISO `zt` |
 
-`Tools/translate_argos.py` uses the `argostranslate` Python API and protects `<...>` tags and `{...}` variables by replacing them with `[[TOKEN_n]]`. Tokens must be preserved, but they may be reordered when grammar requires; the script logs a warning if their order changes. Lines made entirely of tokens receive a `TRANSLATE` suffix so Argos does not skip them. Set `--log-level INFO` to display each entry as it is processed or `DEBUG` for more detail. Translation logs (`translate.log`), skip reports (`skipped.csv`), and metrics (`translate_metrics.json`) are written to the run directory (`TranslationRuns/<lang>/<timestamp>` by default). `translate_argos.py` accepts `--batch-size`, `--max-retries`, `--timeout`, and `--run-dir` options. Re-run it on a clean copy of `Spanish.json` to restart translations from scratch. `Tools/translate.py` remains for backward compatibility but prints a deprecation warning.
+`Tools/translate_argos.py` uses the `argostranslate` Python API and protects `<...>` tags and `{...}` variables by replacing them with `[[TOKEN_n]]`. Tokens must be preserved, but they may be reordered when grammar requires; the script logs a warning if their order changes. Lines made entirely of tokens receive a `TRANSLATE` suffix so Argos does not skip them. Set `--log-level INFO` to display each entry as it is processed or `DEBUG` for more detail. Translation logs (`translate.log`), skip reports (`skipped.csv`), and metrics (`translate_metrics.json`) are written to the run directory (`translations/<lang>/<timestamp>` by default). `translate_argos.py` accepts `--batch-size`, `--max-retries`, `--timeout`, and `--run-dir` options. Re-run it on a clean copy of `Spanish.json` to restart translations from scratch. `Tools/translate.py` remains for backward compatibility but prints a deprecation warning.
 
 Run `Tools/fix_tokens.py` after translating to restore `<...>` tags and `{...}` placeholders if any `[[TOKEN_n]]` markers remain. Use `--check-only` to report discrepancies without modifying files.
 

--- a/Tools/summarize_token_stats.py
+++ b/Tools/summarize_token_stats.py
@@ -73,10 +73,14 @@ def _write_csv(rows: List[Tuple[str, int, int, str]], path: Path) -> None:
 def main() -> None:
     ap = argparse.ArgumentParser(description="Summarize token stats from translate_metrics.json")
     ap.add_argument(
+        "--run-dir",
+        type=Path,
+        help="Translation run directory containing translate_metrics.json",
+    )
+    ap.add_argument(
         "--metrics-file",
         type=Path,
-        default=ROOT / "translate_metrics.json",
-        help="Path to translate_metrics.json",
+        help="Path to translate_metrics.json (overrides --run-dir)",
     )
     ap.add_argument(
         "--csv",
@@ -91,7 +95,12 @@ def main() -> None:
     )
     args = ap.parse_args()
 
-    entries = _load_metrics(args.metrics_file)
+    metrics_path = args.metrics_file
+    if args.run_dir and metrics_path is None:
+        metrics_path = args.run_dir / "translate_metrics.json"
+    if metrics_path is None:
+        metrics_path = ROOT / "translate_metrics.json"
+    entries = _load_metrics(metrics_path)
     stats = _aggregate(entries)
     rows = _sort_rows(stats)
     if args.top and args.top > 0:

--- a/Tools/test_analyze_translation_logs.py
+++ b/Tools/test_analyze_translation_logs.py
@@ -60,3 +60,20 @@ def test_cli_overrides_paths(tmp_path, monkeypatch):
     with pytest.raises(SystemExit) as exc:
         atl.main()
     assert exc.value.code == 0
+
+
+def test_run_dir_argument(tmp_path, monkeypatch):
+    metrics = tmp_path / "translate_metrics.json"
+    metrics.write_text(json.dumps([{"failures": {}}]))
+    skipped = tmp_path / "skipped.csv"
+    with skipped.open("w", newline="", encoding="utf-8") as fp:
+        writer = csv.DictWriter(fp, fieldnames=["hash", "english", "reason", "category"])
+        writer.writeheader()
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["analyze_translation_logs.py", "--run-dir", str(tmp_path)],
+    )
+    with pytest.raises(SystemExit) as exc:
+        atl.main()
+    assert exc.value.code == 0

--- a/Tools/test_summarize_token_stats.py
+++ b/Tools/test_summarize_token_stats.py
@@ -1,3 +1,6 @@
+import json
+import sys
+
 import summarize_token_stats as sts
 
 
@@ -24,3 +27,28 @@ def test_aggregate():
         "1": {"mismatches": 1, "reorders": 0, "file": "a.json"},
         "2": {"mismatches": 0, "reorders": 1, "file": "a.json"},
     }
+
+
+def test_run_dir_cli(tmp_path, monkeypatch, capsys):
+    metrics = tmp_path / "translate_metrics.json"
+    metrics.write_text(
+        json.dumps([
+            {
+                "file": "a.json",
+                "failures": {"1": "token mismatch"},
+                "hash_stats": {
+                    "1": {
+                        "original_tokens": 1,
+                        "translated_tokens": 0,
+                        "reordered": False,
+                    }
+                },
+            }
+        ])
+    )
+    monkeypatch.setattr(
+        sys, "argv", ["summarize_token_stats.py", "--run-dir", str(tmp_path)]
+    )
+    sts.main()
+    out = capsys.readouterr().out
+    assert "hash" in out

--- a/Tools/test_translate_argos.py
+++ b/Tools/test_translate_argos.py
@@ -1256,7 +1256,7 @@ def test_metrics_file_records_failure_reason(tmp_path, monkeypatch):
 
     translate_argos.main()
 
-    metrics_files = list((root / "TranslationRuns" / "xx").glob("*/translate_metrics.json"))
+    metrics_files = list((root / "translations" / "xx").glob("*/translate_metrics.json"))
     assert len(metrics_files) == 1
     data = json.loads(metrics_files[0].read_text())
     entry = data[-1]
@@ -1264,6 +1264,7 @@ def test_metrics_file_records_failure_reason(tmp_path, monkeypatch):
     assert entry["run_id"]
     assert entry["git_commit"] == "unknown"
     assert Path(entry["run_dir"]).is_dir()
+    assert entry["cli_args"]["dst"] == "xx"
     assert entry["processed"] == 1
     assert entry["successes"] == 0
     assert entry["timeouts"] == 0

--- a/Tools/translate_argos.py
+++ b/Tools/translate_argos.py
@@ -997,7 +997,7 @@ def main():
         "--run-dir",
         help=(
             "Directory to store logs, reports, and metrics. "
-            "Defaults to TranslationRuns/<lang>/<timestamp>/ under --root"
+            "Defaults to translations/<lang>/<timestamp>/ under --root"
         ),
     )
     ap.add_argument("--batch-size", type=int, default=100, help="Number of lines to translate per request")
@@ -1039,20 +1039,23 @@ def main():
     )
     ap.add_argument(
         "--log-file",
-        help="Write log output to this file; missing directories are created",
+        help=(
+            "Write log output to this file (default: translate.log in run directory); "
+            "missing directories are created"
+        ),
     )
     ap.add_argument(
         "--report-file",
         help=(
-            "Write skipped hashes and reasons to this JSON or CSV file; "
-            "missing directories are created"
+            "Write skipped hashes and reasons to this JSON or CSV file "
+            "(default: skipped.csv in run directory); missing directories are created"
         ),
     )
     ap.add_argument(
         "--metrics-file",
         help=(
-            "Append translation metrics to this JSON file; "
-            "defaults to translate_metrics.json under --root"
+            "Append translation metrics to this JSON file "
+            "(default: translate_metrics.json in run directory)"
         ),
     )
     args = ap.parse_args()
@@ -1068,7 +1071,7 @@ def main():
             else os.path.join(root, args.run_dir)
         )
     else:
-        run_dir = os.path.join(root, "TranslationRuns", args.dst, timestamp)
+        run_dir = os.path.join(root, "translations", args.dst, timestamp)
     os.makedirs(run_dir, exist_ok=True)
     args.run_dir = run_dir
 


### PR DESCRIPTION
## Summary
- default translation runs to `translations/<lang>/<timestamp>`
- enrich translation metrics and support run-dir in analysis helpers
- document new run directory conventions

## Testing
- `pytest Tools -q`

------
https://chatgpt.com/codex/tasks/task_e_68a73fd98a98832db46e487ea611527a