### PR TITLE
Gracefully handle missing Argos model

### DIFF
--- a/Tools/test_translate_argos.py
+++ b/Tools/test_translate_argos.py
@@ -248,6 +248,9 @@ def test_exit_when_translation_engine_missing(tmp_path, monkeypatch, caplog):
     msg = "No Argos translation model for en->xx"
     assert msg in str(exc.value)
     assert msg in caplog.text
+    install_hint = "argospm install translate-en_xx"
+    assert install_hint in str(exc.value)
+    assert install_hint in caplog.text
 
 
 def test_exit_when_translation_engine_attribute_error(tmp_path, monkeypatch, caplog):
@@ -297,6 +300,42 @@ def test_exit_when_translation_engine_attribute_error(tmp_path, monkeypatch, cap
     msg = "No Argos translation model for en->xx"
     assert msg in str(exc.value)
     assert msg in caplog.text
+    install_hint = "argospm install translate-en_xx"
+    assert install_hint in str(exc.value)
+    assert install_hint in caplog.text
+
+
+def test_missing_model_logs_install_hint(tmp_path, monkeypatch, caplog):
+    root = tmp_path
+    target_rel = "Resources/Localization/Messages/Spanish.json"
+
+    monkeypatch.setattr(
+        translate_argos.argos_translate,
+        "get_translation_from_codes",
+        lambda src, dst: None,
+    )
+    monkeypatch.setattr(
+        translate_argos.argos_translate, "load_installed_languages", lambda: None
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "translate_argos.py",
+            target_rel,
+            "--to",
+            "es",
+            "--root",
+            str(root),
+        ],
+    )
+
+    with caplog.at_level("ERROR"):
+        with pytest.raises(SystemExit) as exc:
+            translate_argos.main()
+    hint = "argospm install translate-en_es"
+    assert hint in str(exc.value)
+    assert hint in caplog.text
 
 
 def test_translates_only_specified_hashes(tmp_path, monkeypatch):

--- a/Tools/translate_argos.py
+++ b/Tools/translate_argos.py
@@ -432,10 +432,10 @@ def _run_translation(args, root: str) -> None:
             raise SystemExit(f"Failed to initialize Argos translation engine: {e}")
 
     if translator is None:
+        package = f"translate-{args.src}_{args.dst}"
         msg = (
             f"No Argos translation model for {args.src}->{args.dst}. "
-            "Assemble the model from module zip parts and install it for this session, "
-            "or run `.codex/install.sh`."
+            f"Install it with `argospm install {package}`."
         )
         logger.error(msg)
         raise SystemExit(msg)


### PR DESCRIPTION
## Summary
- Exit early with a clear logger error when no Argos translation model is installed, advising `argospm install translate-<src>_<dst>`
- Cover missing-model scenario with tests that assert the new install hint

## Testing
- `pytest Tools/test_translate_argos.py::test_exit_when_translation_engine_missing Tools/test_translate_argos.py::test_exit_when_translation_engine_attribute_error Tools/test_translate_argos.py::test_missing_model_logs_install_hint -q`


------
https://chatgpt.com/codex/tasks/task_e_68a743d3fd08832db2b9cdc3a58c4840