### PR TITLE
Add translation run validator and document usage

### DIFF
--- a/Tools/translate_argos.py
+++ b/Tools/translate_argos.py
@@ -3,6 +3,9 @@
 
 Lines exceeding the timeout are skipped and listed in the report.
 Use ``--hash`` to restrict translation to specific hashes for targeted updates.
+
+After each run, summarise results and fail fast on remaining issues with
+``python Tools/validate_translation_run.py --run-dir <directory>``.
 """
 
 import argparse

--- a/Tools/validate_translation_run.py
+++ b/Tools/validate_translation_run.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 """Validate a translation run directory.
 
-Counts `TRANSLATED`/`SKIPPED` entries in `translate.log` and
-summarises categories from `skipped.csv`. The script is used by the
-`Spanish_sample.json` dataset via ``make sample-translate`` to verify
-that translation tooling handles placeholders and color tags. Exits
-with a non-zero status if any `token_mismatch` or `sentinel` issues
-remain so CI can fail fast.
+Counts ``TRANSLATED``/``SKIPPED`` entries in ``translate.log`` and
+groups skip reasons from that log alongside categories from
+``skipped.csv``. Exits with a non-zero status when any
+``token_mismatch`` or ``sentinel`` issues remain so CI can fail fast.
+
+The script is used by the ``Spanish_sample.json`` dataset via
+``make sample-translate`` to verify that translation tooling handles
+placeholders and colour tags.
 """
 
 from __future__ import annotations
@@ -21,27 +23,28 @@ from pathlib import Path
 LOG_RE = re.compile(r": (TRANSLATED|SKIPPED)(?: \(([^)]+)\))?")
 
 def summarize_log(path: Path) -> tuple[int, int, Counter[str]]:
-    """Return translated/skipped counts and issue categories from `path`."""
+    """Return counts for translations and skip reasons from ``path``."""
+
     translated = skipped = 0
-    issues: Counter[str] = Counter()
+    reasons: Counter[str] = Counter()
+
     try:
         with path.open(encoding="utf-8") as fp:
             for line in fp:
                 m = LOG_RE.search(line)
                 if not m:
                     continue
-                status, reason = m.group(1), (m.group(2) or "").lower()
+                status, reason = m.group(1), (m.group(2) or "")
                 if status == "TRANSLATED":
                     translated += 1
                 else:
                     skipped += 1
-                    if "token mismatch" in reason:
-                        issues["token_mismatch"] += 1
-                    if "sentinel" in reason:
-                        issues["sentinel"] += 1
+                    cleaned = reason.strip().lower().replace(" ", "_")
+                    if cleaned:
+                        reasons[cleaned] += 1
     except FileNotFoundError:
         pass
-    return translated, skipped, issues
+    return translated, skipped, reasons
 
 def summarize_skipped(path: Path) -> Counter[str]:
     """Return category counts from `path` if it exists."""
@@ -66,20 +69,23 @@ def main() -> None:
     args = ap.parse_args()
 
     run_dir = Path(args.run_dir)
-    translated, skipped, log_issues = summarize_log(run_dir / "translate.log")
+    translated, skipped, log_reasons = summarize_log(run_dir / "translate.log")
     skip_counts = summarize_skipped(run_dir / "skipped.csv")
 
     print(f"Log results: {translated} TRANSLATED, {skipped} SKIPPED")
+    if log_reasons:
+        print("Skip reasons:")
+        for reason, count in sorted(log_reasons.items()):
+            print(f"  {reason}: {count}")
     if skip_counts:
         print("Skip report:")
         for category, count in sorted(skip_counts.items()):
             print(f"  {category}: {count}")
 
-    exit_code = 0
-    if log_issues.get("token_mismatch") or log_issues.get("sentinel"):
-        exit_code = 1
-    if skip_counts.get("token_mismatch") or skip_counts.get("sentinel"):
-        exit_code = 1
+    def has_mismatch(counter: Counter[str]) -> bool:
+        return any("token_mismatch" in k or "sentinel" in k for k in counter)
+
+    exit_code = 1 if has_mismatch(log_reasons) or has_mismatch(skip_counts) else 0
 
     sys.exit(exit_code)
 


### PR DESCRIPTION
## Summary
- add script to summarise translation run results and exit on token mismatches
- mention validator script in Argos translation tool

## Testing
- `pytest Tools/test_validate_translation_run.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a74f513880832dbd55c4581c36a12c