### PR TITLE
feat: hint at rebuilding Argos models

### DIFF
--- a/Tools/test_translate_argos.py
+++ b/Tools/test_translate_argos.py
@@ -251,6 +251,9 @@ def test_exit_when_translation_engine_missing(tmp_path, monkeypatch, caplog):
     install_hint = "argospm install translate-en_xx"
     assert install_hint in str(exc.value)
     assert install_hint in caplog.text
+    rebuild_hint = "cd Resources/Localization/Models/xx"
+    assert rebuild_hint in str(exc.value)
+    assert rebuild_hint in caplog.text
 
 
 def test_exit_when_translation_engine_attribute_error(tmp_path, monkeypatch, caplog):
@@ -303,6 +306,9 @@ def test_exit_when_translation_engine_attribute_error(tmp_path, monkeypatch, cap
     install_hint = "argospm install translate-en_xx"
     assert install_hint in str(exc.value)
     assert install_hint in caplog.text
+    rebuild_hint = "cd Resources/Localization/Models/xx"
+    assert rebuild_hint in str(exc.value)
+    assert rebuild_hint in caplog.text
 
 
 def test_missing_model_logs_install_hint(tmp_path, monkeypatch, caplog):
@@ -336,6 +342,9 @@ def test_missing_model_logs_install_hint(tmp_path, monkeypatch, caplog):
     hint = "argospm install translate-en_es"
     assert hint in str(exc.value)
     assert hint in caplog.text
+    rebuild_hint = "cd Resources/Localization/Models/es"
+    assert rebuild_hint in str(exc.value)
+    assert rebuild_hint in caplog.text
 
 
 def test_translates_only_specified_hashes(tmp_path, monkeypatch):

--- a/Tools/translate_argos.py
+++ b/Tools/translate_argos.py
@@ -438,7 +438,13 @@ def _run_translation(args, root: str) -> None:
         package = f"translate-{args.src}_{args.dst}"
         msg = (
             f"No Argos translation model for {args.src}->{args.dst}. "
-            f"Install it with `argospm install {package}`."
+            f"Install it with `argospm install {package}`. If split segments are\n"
+            f"present, rebuild and install from `Resources/Localization/Models/{args.dst}`:\n"
+            f"cd Resources/Localization/Models/{args.dst}\n"
+            "cat translate-*.z[0-9][0-9] translate-*.zip > model.zip\n"
+            "unzip -o model.zip\n"
+            "unzip -p translate-*.argosmodel */metadata.json | jq '.from_code, .to_code'\n"
+            "argos-translate install translate-*.argosmodel"
         )
         logger.error(msg)
         raise SystemExit(msg)


### PR DESCRIPTION
## Summary
- log a full rebuild/install snippet when no Argos model is found
- verify tests expect the new rebuild hint

## Testing
- `.venv/bin/pytest Tools/test_translate_argos.py::test_exit_when_translation_engine_missing Tools/test_translate_argos.py::test_exit_when_translation_engine_attribute_error Tools/test_translate_argos.py::test_missing_model_logs_install_hint -q`


------
https://chatgpt.com/codex/tasks/task_e_68a75501fae0832d970514517e3e3e4a