### PR TITLE
Add Spanish sample translation runner

### DIFF
--- a/Tools/run_spanish_sample.sh
+++ b/Tools/run_spanish_sample.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Verify Argos Spanish model is installed
+if ! argospm list | grep -q 'translate-en_es'; then
+  echo 'Required model translate-en_es not found. Please install before running.' >&2
+  exit 1
+fi
+
+# Prepare timestamped run directory
+timestamp="$(date +%Y%m%d_%H%M%S)"
+run_dir="translations/es/$timestamp"
+mkdir -p "$run_dir"
+
+# Run translation with logs and reports in run directory
+python Tools/translate_argos.py Resources/Localization/Messages/Spanish_sample.json \
+  --to es \
+  --run-dir "$run_dir" \
+  --log-level INFO \
+  --log-file "$run_dir/translate.log" \
+  --report-file "$run_dir/report.csv" \
+  --metrics-file "$run_dir/metrics.json"
+exit_code=$?
+
+echo "run_dir=$run_dir"
+echo "exit_code=$exit_code"
+exit $exit_code


### PR DESCRIPTION
## Summary
- add `run_spanish_sample.sh` to verify Argos Spanish model and run sample translation with timestamped artifacts

## Testing
- `pytest Tools/test_translate_argos.py::test_run_dir_creates_outputs Tools/test_translate_argos.py::test_run_dir_redirects_paths`
- `shellcheck Tools/run_spanish_sample.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a769b5f68c832d930d080de4b446b2