### PR TITLE
Record translation run metadata

### DIFF
--- a/Docs/Localization.md
+++ b/Docs/Localization.md
@@ -296,13 +296,17 @@ is specified (default `translate_metrics.json` under `--root`):
 python Tools/translate_argos.py Resources/Localization/Messages/Turkish.json --to tr --metrics-file translate_metrics.json
 ```
 
-An entry records the run ID, git commit, Argos Translate version, model version, run directory, CLI arguments, and summarises successes, timeouts, token reorders and per‑hash token statistics. If the run terminates early, ``error`` notes the reason:
+An entry records the run ID, git commit, Python and Argos Translate versions,
+model version, paths to the log, report and metrics files, run directory, CLI
+arguments, and summarises successes, timeouts, token reorders and per‑hash token
+statistics. If the run terminates early, ``error`` notes the reason:
 
 ```json
 [
   {
     "run_id": "123e4567-e89b-12d3-a456-426614174000",
     "git_commit": "abcdef1",
+    "python_version": "3.11.0",
     "argos_version": "1.8.0",
     "model_version": "1",
     "cli_args": {
@@ -314,6 +318,9 @@ An entry records the run ID, git commit, Argos Translate version, model version,
       "timeout": 60,
       "overwrite": false
     },
+    "log_file": "translations/tr/2024-02-20/translate.log",
+    "report_file": "translations/tr/2024-02-20/skipped.csv",
+    "metrics_file": "translations/tr/2024-02-20/translate_metrics.json",
     "run_dir": "translations/tr/2024-02-20",
     "file": "Resources/Localization/Messages/Turkish.json",
     "timestamp": "2024-02-20T12:00:02Z",

--- a/Tools/analyze_translation_logs.py
+++ b/Tools/analyze_translation_logs.py
@@ -6,11 +6,12 @@ of failures grouped by category. By default the files are looked up under the
 repository root, but ``--run-dir`` can point to a translation run directory.
 Paths may also be overridden individually via ``--metrics-file`` and
 ``--skipped-file``. Metrics entries include metadata such as ``run_id``,
-``git_commit``, ``model_version``, ``run_dir``, and ``cli_args`` which are emitted at
-debug level. The script exits with a non-zero status if any token mismatches or
-placeholder-only
-failures remain so CI systems can fail fast. Categories include ``english``,
-``identical``, ``sentinel``, ``token_mismatch``, and ``placeholder``.
+``git_commit``, ``python_version``, ``argos_version``, ``model_version``, ``run_dir``,
+``log_file``, ``report_file``, ``metrics_file``, and ``cli_args`` which are emitted
+at debug level. The script exits with a non-zero status if any token mismatches
+or placeholder-only failures remain so CI systems can fail fast. Categories
+include ``english``, ``identical``, ``sentinel``, ``token_mismatch``, and
+``placeholder``.
 """
 
 from __future__ import annotations
@@ -55,11 +56,19 @@ def _summarize_metrics(path: Path) -> Counter:
         failures = entry.get("failures", {})
         if failures or entry.get("error"):
             logger.debug(
-                "Run %s commit %s model %s dir %s args %s error %s had %d failures",
+                (
+                    "Run %s commit %s py %s argos %s model %s dir %s log %s "
+                    "report %s metrics %s args %s error %s had %d failures"
+                ),
                 entry.get("run_id"),
                 entry.get("git_commit"),
-                entry.get("model_version", entry.get("argos_version")),
+                entry.get("python_version"),
+                entry.get("argos_version"),
+                entry.get("model_version"),
                 entry.get("run_dir"),
+                entry.get("log_file"),
+                entry.get("report_file"),
+                entry.get("metrics_file"),
                 entry.get("cli_args"),
                 entry.get("error"),
                 len(failures),

--- a/Tools/summarize_token_stats.py
+++ b/Tools/summarize_token_stats.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
-"""Summarize per-hash token mismatches and reorders."""
+"""Summarize per-hash token mismatches and reorders.
+
+The metrics file may include run metadata (e.g., ``run_id``, ``git_commit``,
+``python_version``) and paths to log, report, and metrics files. These fields are
+ignored; only ``file``, ``failures``, and ``hash_stats`` are used."""
 
 from __future__ import annotations
 

--- a/Tools/test_summarize_token_stats.py
+++ b/Tools/test_summarize_token_stats.py
@@ -13,6 +13,12 @@ def test_aggregate():
                 "1": {"original_tokens": 1, "translated_tokens": 0, "reordered": False},
                 "2": {"original_tokens": 1, "translated_tokens": 1, "reordered": True},
             },
+            "run_id": "1",
+            "log_file": "log",
+            "report_file": "report",
+            "metrics_file": "metrics",
+            "python_version": "3",
+            "argos_version": "1",
         },
         {
             "file": "b.json",
@@ -20,6 +26,8 @@ def test_aggregate():
             "hash_stats": {
                 "2": {"original_tokens": 1, "translated_tokens": 1, "reordered": False}
             },
+            "run_id": "2",
+            "python_version": "3",
         },
     ]
     stats = sts._aggregate(entries)

--- a/Tools/test_translate_argos.py
+++ b/Tools/test_translate_argos.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
+import platform
 
 import pytest
 
@@ -1311,6 +1312,11 @@ def test_metrics_file_records_failure_reason(tmp_path, monkeypatch):
     assert "model_version" in entry
     assert entry["run_id"]
     assert entry["git_commit"] == "unknown"
+    assert entry["python_version"] == platform.python_version()
+    assert entry["argos_version"]
+    assert entry["metrics_file"] == str(metrics_files[0])
+    assert Path(entry["log_file"]).is_file()
+    assert Path(entry["report_file"]).is_file()
     assert Path(entry["run_dir"]).is_dir()
     assert entry["cli_args"]["dst"] == "xx"
     assert entry["processed"] == 1
@@ -1376,6 +1382,11 @@ def test_metrics_file_records_timeout(tmp_path, monkeypatch):
 
     data = json.loads(metrics_path.read_text())
     entry = data[-1]
+    assert entry["python_version"] == platform.python_version()
+    assert entry["argos_version"]
+    assert entry["metrics_file"] == str(metrics_path)
+    assert Path(entry["log_file"]).is_file()
+    assert Path(entry["report_file"]).is_file()
     assert entry["processed"] == 1
     assert entry["successes"] == 0
     assert entry["timeouts"] == 1

--- a/Tools/translate_argos.py
+++ b/Tools/translate_argos.py
@@ -19,6 +19,7 @@ import time
 import logging
 import uuid
 import importlib.metadata
+import platform
 from collections import Counter
 from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeout
 from typing import List
@@ -379,7 +380,11 @@ def _append_metrics_entry(args, **extra) -> dict:
         os.makedirs(metrics_dir, exist_ok=True)
     entry = {
         "run_id": args.run_id,
+        "log_file": args.log_file,
+        "report_file": args.report_file,
+        "metrics_file": args.metrics_file,
         "git_commit": args.git_commit,
+        "python_version": args.python_version,
         "argos_version": args.argos_version,
         "model_version": args.model_version,
         "cli_args": args.cli_args,
@@ -1112,6 +1117,7 @@ def main():
         args.argos_version = importlib.metadata.version("argostranslate")
     except Exception:
         args.argos_version = "unknown"
+    args.python_version = platform.python_version()
     try:
         from argostranslate import package as argos_package
 


### PR DESCRIPTION
## Summary
- Track run ID, Python version, git commit, Argos version, and log/report/metrics paths in translation metrics
- Recognize new metadata fields in analysis utilities and ignore them in token statistics
- Document translation run metadata fields in the localization guide

## Testing
- `pytest Tools/test_translate_argos.py::test_metrics_file_records_failure_reason Tools/test_translate_argos.py::test_metrics_file_records_timeout Tools/test_summarize_token_stats.py Tools/test_analyze_translation_logs.py Tools/test_localization_pipeline_metrics.py`

------
https://chatgpt.com/codex/tasks/task_e_68a77bd87254832d89dea041155fa8a7