### PR TITLE
Use deterministic sentinels for placeholder tokens

### DIFF
--- a/Tools/test_translate_argos.py
+++ b/Tools/test_translate_argos.py
@@ -1101,7 +1101,7 @@ def test_interpolation_block_translated(tmp_path, monkeypatch):
     translate_argos.main()
 
     assert translator.called
-    assert translator.seen == "before [[TOKEN_0]] after"
+    assert translator.seen == "before ⟦T0⟧ after"
 
     data = json.loads((root / target_rel).read_text())
     assert data["Messages"]["hash"] == "translated {(cond ? \"yes\" : \"no\")} after"
@@ -1161,7 +1161,7 @@ def test_multiple_interpolation_blocks_translated(tmp_path, monkeypatch):
     translate_argos.main()
 
     assert translator.called
-    assert translator.seen == "before [[TOKEN_0]] middle [[TOKEN_1]] after"
+    assert translator.seen == "before ⟦T0⟧ middle ⟦T1⟧ after"
 
     data = json.loads((root / target_rel).read_text())
     assert (
@@ -2060,7 +2060,7 @@ def test_wraps_and_unwraps_placeholders(tmp_path, monkeypatch):
 
     translate_argos.main()
 
-    assert translator.seen and "[[TOKEN_0]]" in translator.seen[0]
+    assert translator.seen and "⟦T0⟧" in translator.seen[0]
     data = json.loads((root / target_rel).read_text())
     assert data["Messages"]["h1"] == "Bonjour {0}"
 

--- a/Tools/tests/test_placeholder_roundtrip.py
+++ b/Tools/tests/test_placeholder_roundtrip.py
@@ -4,7 +4,7 @@ import translate_argos
 def test_round_trip_mixed_placeholders_and_nested_tags():
     text = "[b]<color=red>${var} {0}</color>[/b]"
     safe, tokens = translate_argos.protect_strict(text)
-    translation = "[[TOKEN_1]][[TOKEN_2]][[TOKEN_0]] [[TOKEN_4]][[TOKEN_3]][[TOKEN_5]]"
+    translation = "⟦T1⟧⟦T2⟧⟦T0⟧ ⟦T4⟧⟦T3⟧⟦T5⟧"
     normalized = translate_argos.normalize_tokens(translation)
     reordered, changed = translate_argos.reorder_tokens(normalized, len(tokens))
     assert changed


### PR DESCRIPTION
## Summary
- Map `<...>`, `{...}`, `${...}` and similar placeholders to deterministic `⟦Tn⟧` sentinels
- Normalize and restore sentinel tokens post-translation
- Add regression tests for mixed numbered placeholders and color tags

## Testing
- `pytest`
- `~/.dotnet/dotnet test Bloodcraft.Tests/Bloodcraft.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a7c3323198832dab2cab8848a751da