### PR TITLE
Add skip report analysis tool

### DIFF
--- a/Docs/Localization.md
+++ b/Docs/Localization.md
@@ -88,12 +88,20 @@ Argos models are stored under `Resources/Localization/Models/<LANG>` as split ar
    translated manually. Re-run the translator until the file is empty.
    Summarise each run and fail fast on unresolved issues:
 
-    ```bash
-    python Tools/validate_translation_run.py --run-dir translations/<iso-code>/<timestamp>
-    ```
+   ```bash
+   python Tools/validate_translation_run.py --run-dir translations/<iso-code>/<timestamp>
+   ```
 
-    The script reports how many entries were translated or skipped and
-    exits non-zero when any `token_mismatch` or `sentinel` problems remain.
+   The script reports how many entries were translated or skipped and
+   exits non-zero when any `token_mismatch` or `sentinel` problems remain.
+
+   To review skip categories at a glance, run:
+
+   ```bash
+   python Tools/analyze_skip_report.py translations/<iso-code>/<timestamp>/skipped.csv
+   ```
+
+   This prints the number of rows per category so manual fixes can be prioritised.
 
 ### Sample translation dataset
 

--- a/Makefile
+++ b/Makefile
@@ -5,4 +5,5 @@
 sample-translate:
 > python Tools/translate_argos.py Resources/Localization/Messages/Spanish_sample.json --to es --run-dir translations/sample_es --overwrite
 > python Tools/validate_translation_run.py --run-dir translations/sample_es
+> python Tools/analyze_skip_report.py translations/sample_es/skipped.csv
 

--- a/README.md
+++ b/README.md
@@ -814,6 +814,11 @@ This process applies only to files under `Resources/Localization/Messages`.
    Reassemble the split Argos model and install it before running the translator (see [Docs/Localization.md](Docs/Localization.md#automated-translation-for-messages) or [model directories](#model-directories)).
    `python Tools/translate_argos.py Resources/Localization/Messages/<Language>.json --to <iso-code> --batch-size 100 --max-retries 3 --log-level INFO --overwrite`
    Outputs are saved under `translations/<iso-code>/<timestamp>/` (override with `--run-dir`). Verify the model is installed: `argos-translate --from en --to tr - < /dev/null` (replace `tr` with the target code). Any hashes listed in `skipped.csv` within the run directory must be manually translated and the script re-run to confirm they are handled.
+   Summarise skip categories to prioritise fixes:
+
+   ```bash
+   python Tools/analyze_skip_report.py translations/<iso-code>/<timestamp>/skipped.csv
+   ```
 4. **Check and fix tokens.**
    ```bash
    python Tools/fix_tokens.py --check-only Resources/Localization/Messages/<Language>.json

--- a/Tools/analyze_skip_report.py
+++ b/Tools/analyze_skip_report.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Summarize skipped translation categories."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+from collections import Counter
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def summarize_report(path: Path) -> Counter[str]:
+    """Return counts grouped by `category` from `path`."""
+    counts: Counter[str] = Counter()
+    with path.open(encoding="utf-8") as fp:
+        reader = csv.DictReader(fp)
+        for row in reader:
+            cat = (row.get("category") or "unknown").strip() or "unknown"
+            counts[cat] += 1
+    return counts
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description="Group skipped rows by category and print counts",
+    )
+    ap.add_argument("report", type=Path, help="Path to skipped.csv report")
+    args = ap.parse_args()
+
+    report_path = args.report
+    if not report_path.is_absolute():
+        report_path = ROOT / report_path
+
+    try:
+        counts = summarize_report(report_path)
+    except FileNotFoundError:
+        print(f"Report not found: {report_path}", file=sys.stderr)
+        sys.exit(1)
+
+    for category, count in sorted(counts.items()):
+        print(f"{category}: {count}")
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/Tools/localization_pipeline.py
+++ b/Tools/localization_pipeline.py
@@ -224,6 +224,17 @@ def main() -> None:
                     for row in reader:
                         writer.writerow(row)
 
+        logger.info("Analyzing skipped translations")
+        run(
+            [
+                sys.executable,
+                "Tools/analyze_skip_report.py",
+                str(combined_report.relative_to(ROOT)),
+            ],
+            check=False,
+            logger=logger,
+        )
+
         logger.info("Fixing tokens")
         metrics["steps"]["token_fix"] = {"start": timestamp(), "totals": {
             "tokens_restored": 0,

--- a/Tools/test_analyze_skip_report.py
+++ b/Tools/test_analyze_skip_report.py
@@ -1,0 +1,32 @@
+import csv
+from collections import Counter
+import sys
+from pathlib import Path
+
+import analyze_skip_report as asr
+import pytest
+
+
+def test_summarize_report(tmp_path):
+    path = tmp_path / "skipped.csv"
+    with path.open("w", newline="", encoding="utf-8") as fp:
+        writer = csv.DictWriter(fp, fieldnames=["hash", "english", "reason", "category"])
+        writer.writeheader()
+        writer.writerow({"hash": "1", "english": "a", "reason": "r", "category": "identical"})
+        writer.writerow({"hash": "2", "english": "a", "reason": "r", "category": "identical"})
+        writer.writerow({"hash": "3", "english": "a", "reason": "r", "category": "token_mismatch"})
+        writer.writerow({"hash": "4", "english": "a", "reason": "r", "category": ""})
+    counts = asr.summarize_report(path)
+    assert counts == Counter({"identical": 2, "token_mismatch": 1, "unknown": 1})
+
+
+def test_main_cli(tmp_path, monkeypatch, capsys):
+    report = tmp_path / "skipped.csv"
+    report.write_text("hash,english,reason,category\n1,a,r,identical\n", encoding="utf-8")
+    monkeypatch.setattr(sys, "argv", ["analyze_skip_report.py", str(report)])
+    with pytest.raises(SystemExit) as exc:
+        asr.main()
+    assert exc.value.code == 0
+    captured = capsys.readouterr().out.strip().splitlines()
+    assert captured == ["identical: 1"]
+

--- a/Tools/translate_argos.py
+++ b/Tools/translate_argos.py
@@ -6,6 +6,8 @@ Use ``--hash`` to restrict translation to specific hashes for targeted updates.
 
 After each run, summarise results and fail fast on remaining issues with
 ``python Tools/validate_translation_run.py --run-dir <directory>``.
+Review skip categories with
+``python Tools/analyze_skip_report.py <directory>/skipped.csv``.
 """
 
 import argparse


### PR DESCRIPTION
## Summary
- add analyze_skip_report utility to count skipped translation categories
- document and invoke skip analysis after translation runs
- test the new skip report analyzer

## Testing
- `pytest`
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7d760c2e8832da9f55010e9a1d59b