### PR TITLE
Simplify token handling for Argos translations

### DIFF
--- a/Tools/tests/test_placeholder_roundtrip.py
+++ b/Tools/tests/test_placeholder_roundtrip.py
@@ -6,8 +6,8 @@ def test_round_trip_mixed_placeholders_and_nested_tags():
     safe, tokens = translate_argos.protect_strict(text)
     ids = list(tokens.keys())
     translation = (
-        f"⟦T{ids[1]}⟧⟦T{ids[2]}⟧⟦T{ids[0]}⟧ "
-        f"⟦T{ids[4]}⟧⟦T{ids[3]}⟧⟦T{ids[5]}⟧"
+        f"[[TOKEN_{ids[1]}]][[TOKEN_{ids[2]}]][[TOKEN_{ids[0]}]] "
+        f"[[TOKEN_{ids[4]}]][[TOKEN_{ids[3]}]][[TOKEN_{ids[5]}]]"
     )
     normalized = translate_argos.normalize_tokens(translation)
     reordered, changed = translate_argos.reorder_tokens(normalized, ids)


### PR DESCRIPTION
## Summary
- Replace UUID token markers with sequential `[[TOKEN_n]]` placeholders
- Allow Argos output with reordered or missing tokens by logging warnings instead of failing
- Update token normalization and tests for the new placeholder scheme

## Testing
- `pytest Tools/test_translate_argos_tokens.py Tools/tests/test_placeholder_roundtrip.py Tools/test_translate_argos.py`
- `python Tools/translate_argos.py Resources/Localization/Messages/Spanish_sample.json --to es --run-dir translations/es/sample --log-level INFO --overwrite` *(interrupted after confirming token reorders are logged without aborting)*

------
https://chatgpt.com/codex/tasks/task_e_68a8643431b4832d946019f55bd9a2aa