### PR TITLE
docs: clarify placeholder token rules

### DIFF
--- a/Docs/Localization.md
+++ b/Docs/Localization.md
@@ -172,6 +172,21 @@ python Tools/fix_tokens.py Resources/Localization/Messages/<Language>.json
 
 Run the check-only mode first to fail fast if tokens were altered, then apply the fixes. Perform this validation after every translation pass and before committing changes.
 
+### Placeholder rules
+
+When translating, the `[[TOKEN_n]]` placeholders must follow these rules:
+
+- **Do not translate tokens.** Copy them exactly as they appear in English.
+- **Keep token counts equal to English.** Every `[[TOKEN_n]]` in English must appear in the translation.
+- **Reorder only if grammar demands it.** Change the order only when required for correct grammar.
+
+**Example**
+
+```
+Before: "[[TOKEN_0]] has [[TOKEN_1]] apples"
+After:  "[[TOKEN_0]] tiene [[TOKEN_1]] manzanas"
+```
+
 ### Token warnings
 
 Argos may reorder or drop placeholder tokens during translation. The translation log highlights these issues:

--- a/README.md
+++ b/README.md
@@ -825,6 +825,7 @@ This process applies only to files under `Resources/Localization/Messages`.
    python Tools/fix_tokens.py Resources/Localization/Messages/<Language>.json
    ```
    Running with `--check-only` fails fast if tokens were altered.
+   See the [placeholder rules](Docs/Localization.md#placeholder-rules) for guidance on handling `[[TOKEN_n]]` tokens.
 5. **Verify translations.**
    `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations --show-text --summary-json summary.json`
    This command confirms every hash exists and no English text remains. Use `--summary-json <path>` to write aggregate counts for each language.


### PR DESCRIPTION
## Summary
- Detail rules for preserving `[[TOKEN_n]]` placeholders and add example in Localization guide
- Link README token check section to placeholder rules documentation

## Testing
- `python Tools/fix_tokens.py --check-only Resources/Localization/Messages/*.json` *(fails: 218 token mismatches)*
- `dotnet test Bloodcraft.Tests/Bloodcraft.Tests.csproj` *(fails: missing .NET 6 runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e37a2f8c832d87f2ac3d39a55157