### PR TITLE
ci: enforce token reorder check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Check tokens and translations
         run: |
           set -e
-          python Tools/fix_tokens.py --check-only Resources/Localization/Messages/*.json
+          python Tools/fix_tokens.py --check-only --reorder Resources/Localization/Messages/*.json
           dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations
 
       - name: Validate translation run


### PR DESCRIPTION
## Summary
- ensure fix_tokens checks for token reorder during build

## Testing
- `python Tools/fix_tokens.py --check-only --reorder Resources/Localization/Messages/*.json`
- `pytest Tools/test_fix_tokens.py`
- `dotnet test Bloodcraft.Tests` *(fails: You must install or update .NET to run this application, missing Microsoft.NETCore.App 6.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f99c3050832d82315cc6a92b8ddb