### PR TITLE
Add fix-tokens Makefile target and document usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
 .RECIPEPREFIX := >
 
-.PHONY: sample-translate
+.PHONY: sample-translate fix-tokens
 
 sample-translate:
 > python Tools/translate_argos.py Resources/Localization/Messages/Spanish_sample.json --to es --run-dir translations/sample_es --overwrite
 > python Tools/validate_translation_run.py --run-dir translations/sample_es
 > python Tools/analyze_skip_report.py translations/sample_es/skipped.csv
+
+fix-tokens:
+> python Tools/fix_tokens.py --reorder Resources/Localization/Messages/*.json
 

--- a/README.md
+++ b/README.md
@@ -825,6 +825,7 @@ This process applies only to files under `Resources/Localization/Messages`.
    python Tools/fix_tokens.py Resources/Localization/Messages/<Language>.json
    ```
    Running with `--check-only` fails fast if tokens were altered.
+   After manually editing any `Resources/Localization/Messages/*.json` file, run `make fix-tokens` to reorder placeholder tokens across all languages.
    See the [placeholder rules](Docs/Localization.md#placeholder-rules) for guidance on handling `[[TOKEN_n]]` tokens.
 5. **Verify translations.**
    `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations --show-text --summary-json summary.json`


### PR DESCRIPTION
## Summary
- add `fix-tokens` Makefile target to reorder tokens in all localization files
- mention running `make fix-tokens` after manual localization edits in README

## Testing
- `python Tools/fix_tokens.py --check-only Resources/Localization/Messages/*.json`
- `make fix-tokens`
- `~/.dotnet/dotnet test Bloodcraft.Tests/Bloodcraft.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a905a9c590832dbe79bd09202c58de