### PR TITLE
Archive Brazilian translation run

### DIFF
--- a/translations/pb/20250823-030044/metrics.json
+++ b/translations/pb/20250823-030044/metrics.json
@@ -1,0 +1,48 @@
+[
+  {
+    "run_id": "652c934c-79f4-40cf-a158-8f8e2e4fbcf5",
+    "log_file": "/workspace/Bloodcraft/translations/pb/20250823-030044/translate.log",
+    "report_file": "/workspace/Bloodcraft/translations/pb/20250823-030044/skipped.csv",
+    "metrics_file": "/workspace/Bloodcraft/translations/pb/20250823-030044/metrics.json",
+    "git_commit": "ed48c19",
+    "python_version": "3.11.12",
+    "argos_version": "1.9.6",
+    "model_version": "unknown",
+    "cli_args": {
+      "target_file": "Resources/Localization/Messages/Brazilian.json",
+      "src": "en",
+      "dst": "pb",
+      "root": "/workspace/Bloodcraft",
+      "run_dir": "/workspace/Bloodcraft/translations/pb/20250823-030044",
+      "batch_size": 100,
+      "max_retries": 3,
+      "timeout": 60,
+      "overwrite": false,
+      "hashes": [
+        "3439613370"
+      ],
+      "log_level": "INFO",
+      "verbose": false,
+      "log_file": "/workspace/Bloodcraft/translations/pb/20250823-030044/translate.log",
+      "report_file": "/workspace/Bloodcraft/translations/pb/20250823-030044/skipped.csv",
+      "metrics_file": "/workspace/Bloodcraft/translations/pb/20250823-030044/metrics.json",
+      "dry_run": false,
+      "run_index_file": "/workspace/Bloodcraft/translations/run_index.json"
+    },
+    "run_dir": "/workspace/Bloodcraft/translations/pb/20250823-030044",
+    "file": "Resources/Localization/Messages/Brazilian.json",
+    "timestamp": "2025-08-23T03:00:52Z",
+    "processed": 1,
+    "successes": 1,
+    "timeouts": 0,
+    "token_reorders": 0,
+    "failures": {},
+    "hash_stats": {
+      "3439613370": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      }
+    }
+  }
+]

--- a/translations/pb/20250823-030044/skipped.csv
+++ b/translations/pb/20250823-030044/skipped.csv
@@ -1,0 +1,1 @@
+hash,english,reason,category

--- a/translations/pb/20250823-030044/translate.log
+++ b/translations/pb/20250823-030044/translate.log
@@ -1,0 +1,14 @@
+2025-08-23 03:00:47,275 INFO target_file=Resources/Localization/Messages/Brazilian.json src=en dst=pb batch_size=100 timeout=60 max_retries=3 run_dir=/workspace/Bloodcraft/translations/pb/20250823-030044 git_commit=ed48c19 model_version=unknown
+2025-08-23 03:00:47,276 INFO NOTE TO TRANSLATORS: **DO NOT** alter anything inside [[TOKEN_n]], <...> tags, or {...} variables.
+2025-08-23 03:00:47,277 INFO Batch 1/1 start @ 0.00s
+2025-08-23 03:00:48,915 INFO 3439613370: TRANSLATED
+  Original: Welcome to Bloodcraft
+  Result: Bem-vindo ao Bloodcraft.
+2025-08-23 03:00:48,915 INFO Batch 1/1 end @ 1.64s (1.64s)
+2025-08-23 03:00:48,915 INFO Processed 1 batches in 1.64 seconds
+2025-08-23 03:00:48,915 INFO Report breakdown: none
+2025-08-23 03:00:52,040 INFO Wrote translations to /workspace/Bloodcraft/Resources/Localization/Messages/Brazilian.json
+2025-08-23 03:00:52,041 INFO Summary: 1/1 translated, 0 timeouts, 0 token reorders. Metrics written to /workspace/Bloodcraft/translations/pb/20250823-030044/metrics.json
+2025-08-23 03:00:52,041 INFO Received 0 rows; deduplicated to 0 rows
+2025-08-23 03:00:52,042 INFO Wrote skip report to /workspace/Bloodcraft/translations/pb/20250823-030044/skipped.csv with 0 row(s)
+2025-08-23 03:00:52,042 INFO Totals: processed=1 translated=1 skipped=0

--- a/translations/run_index.json
+++ b/translations/run_index.json
@@ -28,5 +28,15 @@
     "report_file": "/workspace/Bloodcraft/translations/es/20250822-181053/skipped.csv",
     "metrics_file": "/workspace/Bloodcraft/translations/es/20250822-181053/metrics.json",
     "success_rate": 0
+  },
+  {
+    "run_id": "652c934c-79f4-40cf-a158-8f8e2e4fbcf5",
+    "timestamp": "2025-08-23T03:00:52Z",
+    "language": "pb",
+    "run_dir": "/workspace/Bloodcraft/translations/pb/20250823-030044",
+    "log_file": "/workspace/Bloodcraft/translations/pb/20250823-030044/translate.log",
+    "report_file": "/workspace/Bloodcraft/translations/pb/20250823-030044/skipped.csv",
+    "metrics_file": "/workspace/Bloodcraft/translations/pb/20250823-030044/metrics.json",
+    "success_rate": 1.0
   }
 ]


### PR DESCRIPTION
## Summary
- Run Argos translator for Brazilian Portuguese and store logs, metrics, and skip report under `translations/pb/20250823-030044`.
- Append the run details to `translations/run_index.json` for traceability.

## Testing
- `argos-translate --from en --to pb - < /dev/null`
- `python Tools/translate_argos.py Resources/Localization/Messages/Brazilian.json --to pb --hash 3439613370 --log-level INFO --run-dir translations/pb/20250823-030044`
- `python Tools/validate_translation_run.py --run-dir translations/pb/20250823-030044`


------
https://chatgpt.com/codex/tasks/task_e_68a92dd25908832dadb654ccb1a8a80c