### PR TITLE
Handle bracket tags and percent tokens in fix_tokens

### DIFF
--- a/Tools/fix_tokens.py
+++ b/Tools/fix_tokens.py
@@ -16,11 +16,14 @@ from translate_argos import normalize_tokens
 logger = logging.getLogger(__name__)
 
 TOKEN_PLACEHOLDER = re.compile(r"\[\[[^\]]+\]\]")
-# Match HTML tags, .NET style numeric or named tokens (e.g. {PlayerName}) and
-# ${var} style variables. Named tokens may optionally include a format segment
-# such as {Value:0.00}.
+# Match standard placeholder patterns:
+#   * XML-like tags:        ``<tag>``
+#   * Format items:         ``{0}`` or ``{PlayerName}``
+#   * String interpolation: ``${var}``
+#   * Bracket tags:         ``[tag]`` or ``[tag=value]``
+#   * Percent sign:         ``%``
 TOKEN_PATTERN = re.compile(
-    r"<[^>]+>|\{[A-Za-z0-9_.-]+(?:[:][^{}]+)?\}|\$\{[A-Za-z0-9_.-]+\}"
+    r"<[^>]+>|\{[^{}]+\}|\$\{[^{}]+\}|\[(?:/?[a-zA-Z]+(?:=[^\]]*)?)\]|%"
 )
 
 

--- a/Tools/test_fix_tokens.py
+++ b/Tools/test_fix_tokens.py
@@ -130,3 +130,16 @@ def test_exit_on_mismatch(tmp_path, monkeypatch):
     assert metrics["token_mismatches"] == 1
     assert metrics["tokens_restored"] == 0
     assert metrics["tokens_reordered"] == 0
+
+
+def test_extract_tokens_bracket_and_percent():
+    text = "[b]100%[/b] [color=]"
+    assert fix_tokens.extract_tokens(text) == ["[b]", "%", "[/b]", "[color=]"]
+
+
+def test_replace_placeholders_with_bracket_tags_and_percent():
+    tokens = ["[b]", "%", "[/b]"]
+    value = "[[TOKEN_0]]100[[TOKEN_1]][[TOKEN_2]]"
+    new_value, replaced, mismatch = fix_tokens.replace_placeholders(value, tokens)
+    assert new_value == "[b]100%[/b]"
+    assert replaced and not mismatch


### PR DESCRIPTION
## Summary
- expand `fix_tokens.py` placeholder pattern to handle bracket tags and `%`
- add unit tests for bracket-tag and percent token extraction and restoration

## Testing
- `pytest Tools/test_fix_tokens.py`


------
https://chatgpt.com/codex/tasks/task_e_68a9edca15a0832d9d19a1adcb828119