### PR TITLE
fix_tokens: align bracket tags with translator regex

### DIFF
--- a/Tools/fix_tokens.py
+++ b/Tools/fix_tokens.py
@@ -23,7 +23,7 @@ TOKEN_PLACEHOLDER = re.compile(r"\[\[[^\]]+\]\]")
 #   * Bracket tags:         ``[tag]`` or ``[tag=value]``
 #   * Percent sign:         ``%``
 TOKEN_PATTERN = re.compile(
-    r"<[^>]+>|\{[^{}]+\}|\$\{[^{}]+\}|\[(?:/?[a-zA-Z]+(?:=[^\]]*)?)\]|%"
+    r"<[^>]+>|\{[^{}]+\}|\$\{[^{}]+\}|\[(?:/?[a-zA-Z]+(?:=[^\]]+)?)\]|%"
 )
 
 

--- a/Tools/test_fix_tokens.py
+++ b/Tools/test_fix_tokens.py
@@ -144,9 +144,9 @@ def test_exit_on_mismatch(tmp_path, monkeypatch):
     assert metrics["tokens_reordered"] == 0
 
 
-def test_extract_tokens_bracket_and_percent():
-    text = "[b]100%[/b] [color=]"
-    assert fix_tokens.extract_tokens(text) == ["[b]", "%", "[/b]", "[color=]"]
+def test_extract_tokens_bracket_tags_and_percent():
+    text = "[b]100%[/b] [color=red]"
+    assert fix_tokens.extract_tokens(text) == ["[b]", "%", "[/b]", "[color=red]"]
 
 
 def test_replace_placeholders_with_bracket_tags_and_percent():


### PR DESCRIPTION
## Summary
- align fix_tokens bracket-tag pattern with translate_argos
- note bracket tags and percent placeholders in comments
- test extraction and restoration of bracket tags and percent sign

## Testing
- `pytest Tools/test_fix_tokens.py`

------
https://chatgpt.com/codex/tasks/task_e_68aa303d0a44832d8418ba0194600516