### PR TITLE
test: cover lenient token mismatches

### DIFF
--- a/Tools/test_fix_tokens.py
+++ b/Tools/test_fix_tokens.py
@@ -250,6 +250,9 @@ def test_fix_tokens_after_lenient_translation(tmp_path, monkeypatch, caplog, tra
         translate_argos.main()
 
     assert warning in caplog.text
+    intermediate = json.loads(target_path.read_text())
+    assert "{0}" in intermediate["Messages"]["hash"]
+    assert "{1}" in intermediate["Messages"]["hash"]
 
     monkeypatch.setattr(sys, "argv", ["fix_tokens.py", "--root", str(root), target_rel])
     fix_tokens.main()


### PR DESCRIPTION
## Summary
- expand translation token tests for missing, extra, and reordered placeholders under lenient mode
- verify fix_tokens handles lenient mismatches and preserves placeholders

## Testing
- `pytest Tools/test_translate_argos_tokens.py Tools/test_fix_tokens.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa49f66444832dbf22bdadba4af8a1