### PR TITLE
Handle bracket placeholders and percent symbols

### DIFF
--- a/Bloodcraft.Tests/LocalizationHelpersTests.cs
+++ b/Bloodcraft.Tests/LocalizationHelpersTests.cs
@@ -8,6 +8,9 @@ public class LocalizationHelpersTests
     [InlineData("Hello <b>world</b> {player}")]
     [InlineData("<color=red>${blood}</color> {another}")]
     [InlineData("Just plain text")]
+    [InlineData("Look [here] for loot")]
+    [InlineData("Progress is 50% complete")]
+    [InlineData("<i>[target]</i> gains {amount}% ${bonus}")]
     public void ProtectUnprotect_ReturnsOriginal(string input)
     {
         Dictionary<string, string> map = new();

--- a/Utilities/LocalizationHelpers.cs
+++ b/Utilities/LocalizationHelpers.cs
@@ -8,6 +8,10 @@ namespace Bloodcraft.Utilities;
 /// </summary>
 internal static class LocalizationHelpers
 {
+    static readonly Regex BracketPlaceholder = new(
+        @"\[.*?\]",
+        RegexOptions.Compiled);
+
     static readonly Regex RichTextTag = new(
         @"</?\w+[^>]*>",
         RegexOptions.Compiled);
@@ -20,6 +24,10 @@ internal static class LocalizationHelpers
         @"\$\{[^}]+\}",
         RegexOptions.Compiled);
 
+    static readonly Regex PercentSymbol = new(
+        @"%",
+        RegexOptions.Compiled);
+
     /// <summary>
     /// Replaces tags and placeholders with indexed markers so translation services do not alter them.
     /// </summary>
@@ -28,7 +36,7 @@ internal static class LocalizationHelpers
         List<string> tokens = [];
         string result = message;
 
-        foreach (Regex regex in new[] { RichTextTag, Placeholder, CsInterp })
+        foreach (Regex regex in new[] { BracketPlaceholder, RichTextTag, Placeholder, CsInterp, PercentSymbol })
         {
             result = regex.Replace(result, m =>
             {


### PR DESCRIPTION
## Summary
- include regex for bracket placeholders and bare percent symbols in localization protection
- cover new placeholder types in tokenization tests

## Testing
- `dotnet test Bloodcraft.Tests/Bloodcraft.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68ab3ae04380832dbda991190b7e5064