### PR TITLE
refactor: modularize core initialization

### DIFF
--- a/Core.cs
+++ b/Core.cs
@@ -91,17 +91,24 @@ internal static class Core
         // string hexString = SecretManager.GetNewSharedKey();
         // NEW_SHARED_KEY = [..Enumerable.Range(0, hexString.Length / 2).Select(i => Convert.ToByte(hexString.Substring(i * 2, 2), 16))];
 
+        InitializeServices();
+        RegisterEventHandlers();
+        ConfigureSystems();
+
+        _initialized = true;
+        DebugLoggerPatch._initialized = true;
+    }
+
+    static void InitializeServices()
+    {
         if (!ComponentRegistry._initialized) ComponentRegistry.Initialize();
-        
+
         _ = new PlayerService();
         _ = new LocalizationService();
 
         if (ConfigService.Eclipse) _ = new EclipseService();
-
         if (ConfigService.ExtraRecipes) Recipes.ModifyRecipes();
-
         if (ConfigService.StarterKit) Configuration.GetStarterKitItems();
-
         if (ConfigService.PrestigeSystem) Buffs.GetPrestigeBuffs();
 
         if (ConfigService.ClassSystem)
@@ -111,26 +118,41 @@ internal static class Core
             Classes.GetAbilityJewels();
         }
 
-        if (ConfigService.LevelingSystem) DeathEventListenerSystemPatch.OnDeathEventHandler += LevelingSystem.OnUpdate;
-
-        if (ConfigService.ExpertiseSystem) DeathEventListenerSystemPatch.OnDeathEventHandler += WeaponSystem.OnUpdate;
-
         if (ConfigService.QuestSystem)
         {
             _ = new QuestService();
-            DeathEventListenerSystemPatch.OnDeathEventHandler += QuestSystem.OnUpdate;
         }
 
         if (ConfigService.FamiliarSystem)
         {
             Configuration.GetExcludedFamiliars();
-            if (!ConfigService.LevelingSystem) DeathEventListenerSystemPatch.OnDeathEventHandler += FamiliarLevelingSystem.OnUpdate;
-            DeathEventListenerSystemPatch.OnDeathEventHandler += FamiliarUnlockSystem.OnUpdate;
-
             _ = new BattleService();
             _ = new FamiliarService();
         }
+    }
 
+    static void RegisterEventHandlers()
+    {
+        if (ConfigService.LevelingSystem)
+            DeathEventListenerSystemPatch.OnDeathEventHandler += LevelingSystem.OnUpdate;
+
+        if (ConfigService.ExpertiseSystem)
+            DeathEventListenerSystemPatch.OnDeathEventHandler += WeaponSystem.OnUpdate;
+
+        if (ConfigService.QuestSystem)
+            DeathEventListenerSystemPatch.OnDeathEventHandler += QuestSystem.OnUpdate;
+
+        if (ConfigService.FamiliarSystem)
+        {
+            if (!ConfigService.LevelingSystem)
+                DeathEventListenerSystemPatch.OnDeathEventHandler += FamiliarLevelingSystem.OnUpdate;
+
+            DeathEventListenerSystemPatch.OnDeathEventHandler += FamiliarUnlockSystem.OnUpdate;
+        }
+    }
+
+    static void ConfigureSystems()
+    {
         if (ConfigService.ProfessionSystem)
         {
             // Misc.GetStatModPrefabs(); // modifier stuff, although... fusion forge, hm
@@ -154,9 +176,6 @@ internal static class Core
         {
             ResetShardBearers();
         }
-
-        _initialized = true;
-        DebugLoggerPatch._initialized = true;
     }
     static World GetServerWorld()
     {


### PR DESCRIPTION
## Summary
- split `Core.Initialize` into helpers for services, event handlers, and system configuration
- orchestrate new helpers from `Initialize`

## Testing
- `dotnet test` *(fails: A compatible .NET SDK was not found: 8.0.413)*

------
https://chatgpt.com/codex/tasks/task_e_68addde155e8832d8919344e12b5af61