### PR TITLE
Refactor Buff Spawn Server into handler architecture

### DIFF
--- a/Patches/BuffSpawnServerPatches.cs
+++ b/Patches/BuffSpawnServerPatches.cs
@@ -1,15 +1,13 @@
-﻿using Bloodcraft.Interfaces;
+using System;
+using Bloodcraft.Patches.BuffSpawnServerPatches;
 using Bloodcraft.Resources;
 using Bloodcraft.Services;
-using Bloodcraft.Systems.Professions;
 using Bloodcraft.Utilities;
 using HarmonyLib;
 using ProjectM;
 using ProjectM.Network;
-using ProjectM.Scripting;
 using Stunlock.Core;
 using Unity.Entities;
-using static Bloodcraft.Utilities.Misc.PlayerBools;
 
 namespace Bloodcraft.Patches;
 
@@ -27,38 +25,11 @@ internal static class BuffSystemSpawnPatches
     static readonly bool _eliteShardBearers = ConfigService.EliteShardBearers;
     static readonly bool _legacies = ConfigService.LegacySystem;
     static readonly bool _expertise = ConfigService.ExpertiseSystem;
-    static readonly bool _exoForm = ConfigService.ExoPrestiging;
     static readonly bool _trueImmortal = ConfigService.TrueImmortal;
-    static readonly bool _classes = ConfigService.ClassSystem;
     static readonly bool _familiars = ConfigService.FamiliarSystem;
     static readonly bool _familiarPvP = ConfigService.FamiliarPvP;
     static readonly bool _potionStacking = ConfigService.PotionStacking;
     static readonly bool _professions = ConfigService.ProfessionSystem;
-
-    const float FAMILIAR_TRAVEL_DURATION = 7.5f;
-    const float MINION_LIFETIME = 30f;
-    const int MAX_PROFESSION_LEVEL = ProfessionSystem.MAX_PROFESSION_LEVEL;
-
-    static readonly PrefabGUID _fallenAngel = PrefabGUIDs.CHAR_Paladin_FallenAngel;
-    static readonly PrefabGUID _solarus = PrefabGUIDs.CHAR_ChurchOfLight_Paladin_VBlood;
-
-    static readonly PrefabGUID _holyBubbleBuff = Buffs.HolyBubbleBuff;
-    static readonly PrefabGUID _gateBossFeedCompleteBuff = Buffs.GateBossFeedCompleteBuff;
-    static readonly PrefabGUID _holyBeamPowerBuff = Buffs.HolyBeamPowerBuff;
-    static readonly PrefabGUID _pvpProtectedBuff = Buffs.PvPProtectedBuff;
-    static readonly PrefabGUID _pveCombatBuff = Buffs.PvECombatBuff;
-    static readonly PrefabGUID _pvpCombatBuff = Buffs.PvPCombatBuff;
-    static readonly PrefabGUID _phasingBuff = Buffs.PhasingBuff;
-    static readonly PrefabGUID _witchPigTransformationBuff = Buffs.WitchPigTransformationBuff;
-    static readonly PrefabGUID _wranglerPotionBuff = Buffs.WranglerPotionBuff;
-    static readonly PrefabGUID _highlordGroundSwordBossBuff = Buffs.HighlordGroundSwordBossBuff;
-    static readonly PrefabGUID _bloodCurseBuff = Buffs.DraculaBloodCurseBuff;
-    static readonly PrefabGUID _inkCrawlerDeathBuff = Buffs.InkCrawlerDeathBuff;
-    static readonly PrefabGUID _targetSwallowedBuff = Buffs.TargetSwallowedBuff;
-    static readonly PrefabGUID _combatStanceBuff = Buffs.CombatStanceBuff;
-    static readonly PrefabGUID _evolvedVampireBuff = Buffs.EvolvedVampireBuff;
-    static readonly PrefabGUID _draculaReturnHideBuff = Buffs.DraculaReturnHideBuff;
-    static readonly PrefabGUID _batLandingTravel = new(-371745443);
 
     static readonly EntityQuery _query = QueryService.BuffSpawnServerQuery;
 
@@ -77,657 +48,52 @@ internal static class BuffSystemSpawnPatches
 
         try
         {
-            for (int i = 0; i < entities.Length; i++)
+            for (int i = 0; i < entities.Length; ++i)
             {
                 Entity buffEntity = entities[i];
                 Entity buffTarget = buffs[i].Target;
                 PrefabGUID buffPrefabGuid = prefabGuids[i];
 
-                string prefabName = buffPrefabGuid.GetPrefabName();
+                if (!buffTarget.Exists())
+                    continue;
 
-                // if (!prefabName.Contains("AntennaBuff")) Core.Log.LogWarning($"[BuffSystem_Spawn_Server] - {buffTarget.GetPrefabGuid().GetPrefabName()} | {prefabName}");
-
-                if (!buffTarget.Exists()) continue;
-                
                 bool isPlayerTarget = playerCharacterLookup.HasComponent(buffTarget);
                 ulong steamId = isPlayerTarget ? buffTarget.GetSteamId() : 0;
+                string prefabName = buffPrefabGuid.GetPrefabName();
 
-                int buffType = GetBuffType(buffPrefabGuid.GuidHash, prefabName);
-
-                switch (buffType)
+                var ctx = new BuffSpawnContext
                 {
-                    case 1 when _eliteShardBearers && buffTarget.GetPrefabGuid().Equals(_solarus): // Elite Solarus Final Phase
-                        if (!buffTarget.Has<BlockFeedBuff>() && !buffTarget.HasBuff(_holyBeamPowerBuff))
-                        {
-                            if (buffTarget.TryApplyAndGetBuff(_holyBeamPowerBuff, out buffEntity))
-                            {
-                                if (buffEntity.Has<LifeTime>())
-                                {
-                                    buffEntity.With((ref LifeTime lifeTime) =>
-                                    {
-                                        lifeTime.Duration = 0f;
-                                        lifeTime.EndAction = LifeTimeEndAction.None;
-                                    });
-                                }
-                            }
-                        }
-                        break;
-                    case 2 when _trueImmortal && isPlayerTarget: // ExoForm Immortal Handling
-                        if (buffEntity.Has<SpellTarget>())
-                        {
-                            Entity spellTarget = buffEntity.GetSpellTarget();
+                    BuffEntity = buffEntity,
+                    Target = buffTarget,
+                    PrefabGuid = buffPrefabGuid,
+                    PrefabName = prefabName,
+                    IsPlayer = isPlayerTarget,
+                    SteamId = steamId,
+                    GameMode = _gameMode,
+                    EliteShardBearers = _eliteShardBearers,
+                    Legacies = _legacies,
+                    Expertise = _expertise,
+                    TrueImmortal = _trueImmortal,
+                    Familiars = _familiars,
+                    FamiliarPvP = _familiarPvP,
+                    PotionStacking = _potionStacking,
+                    Professions = _professions,
+                    BlockFeedLookup = blockFeedBuffLookup
+                };
 
-                            if (!spellTarget.IsVBloodOrGateBoss())
-                            {
-                                Shapeshifts.TrueImmortal(buffEntity, buffTarget);
-                            }
-                        }
-                        break;
-                    case 3 when isPlayerTarget: // Familiar and player has PvE Combat Buff
-                        Entity familiar = Entity.Null;
-                        if (buffTarget.HasBuff(_evolvedVampireBuff)) buffEntity.Remove<SetOwnerRotateTowardsMouse>();
-                        if (_familiars && steamId.HasActiveFamiliar())
-                        {
-                            familiar = Familiars.GetActiveFamiliar(buffTarget);
-                            // Core.Log.LogWarning($"[BuffSystem_Spawn_Server] SyncingAggro - {familiar.Exists()}");
-                            Familiars.HandleFamiliarEnteringCombat(buffTarget, familiar);
-                            Familiars.SyncAggro(buffTarget, familiar);
-                        }
-                        break;
-                    case 4 when _familiars && isPlayerTarget: // Familiars and player has PvP Combat Buff
-                        if (steamId.HasActiveFamiliar())
-                        {
-                            familiar = Familiars.GetActiveFamiliar(buffTarget);
-
-                            if (!_familiarPvP)
-                            {
-                                User combatUser = buffTarget.GetUser();
-                                Familiars.DismissFamiliar(buffTarget, familiar, combatUser, steamId);
-                            }
-                            else
-                            {
-                                Familiars.HandleFamiliarEnteringCombat(buffTarget, familiar);
-                            }
-                        }
-                        break;
-                    case 5 when _familiars && isPlayerTarget: // Vampiric curse (BloodyPoint)
-                        if (!buffEntity.Has<GameplayEventListeners>())
-                        {
-                            familiar = Familiars.GetActiveFamiliar(buffTarget);
-                            if (familiar.Exists())
-                            {
-                                if (familiar.TryApplyAndGetBuffWithOwner(buffTarget, _targetSwallowedBuff, out buffEntity))
-                                {
-                                    if (buffEntity.Has<LifeTime>())
-                                    {
-                                        buffEntity.With((ref LifeTime lifeTime) => lifeTime.Duration = FAMILIAR_TRAVEL_DURATION);
-                                    }
-                                }
-                            }
-                        }
-                        break;
-                    case 7 when _familiars && buffTarget.IsVBloodOrGateBoss(): // Witch pig transformation buff
-                        buffEntity.Destroy();
-                        break;
-                    case 8 when isPlayerTarget:
-                        if (_familiars && steamId.HasDismissedFamiliar() && Familiars.AutoCallMap.TryRemove(buffTarget, out familiar))
-                        {
-                            Familiars.CallFamiliar(buffTarget, familiar, buffTarget.GetUser(), steamId);
-                        }
-                        if (_legacies || _expertise)
-                        {
-                            Buffs.RefreshStats(buffTarget);
-                        }
-                        break;
-                    case 9 when _familiars:
-                        if (buffTarget.TryGetFollowedPlayer(out Entity playerCharacter))
-                        {
-                            familiar = Familiars.GetActiveFamiliar(playerCharacter);
-
-                            if (familiar.Exists() && familiar.TryGetBuff(_highlordGroundSwordBossBuff, out buffEntity))
-                            {
-                                buffEntity.AddWith((ref AmplifyBuff amplifyBuff) =>
-                                {
-                                    amplifyBuff.AmplifyModifier = -0.75f;
-                                });
-                                
-                                buffEntity.AddWith((ref LifeTime lifeTime) =>
-                                {
-                                    lifeTime.Duration = MINION_LIFETIME;
-                                    lifeTime.EndAction = LifeTimeEndAction.Destroy;
-                                });
-                            }
-                        }
-                        break;
-                    case 10 when _familiars:
-                        if (buffTarget.TryGetFollowedPlayer(out playerCharacter))
-                        {
-                            if (buffEntity.Has<LifeTime>())
-                            {
-                                buffEntity.With((ref LifeTime lifeTime) =>
-                                {
-                                    lifeTime.Duration = 30f;
-                                    lifeTime.EndAction = LifeTimeEndAction.Destroy;
-                                });
-                            }
-                        }
-                        break;
-                    case 11:
-                        if (isPlayerTarget)
-                        {
-                            if (_potionStacking && !prefabName.Contains("holyresistance", StringComparison.OrdinalIgnoreCase))
-                            {
-                                if (buffEntity.Has<RemoveBuffOnGameplayEvent>()) buffEntity.Remove<RemoveBuffOnGameplayEvent>();
-                                if (buffEntity.Has<RemoveBuffOnGameplayEventEntry>()) buffEntity.Remove<RemoveBuffOnGameplayEventEntry>();
-                            }
-
-                            if (_professions)
-                            {
-                                IProfession handler = ProfessionFactory.GetProfession(buffPrefabGuid);
-
-                                int level = handler.GetProfessionData(steamId).Key;
-                                float bonus = 1 + level / (float)MAX_PROFESSION_LEVEL;
-
-                                if (buffEntity.Has<LifeTime>())
-                                {
-                                    LifeTime lifeTime = buffEntity.Read<LifeTime>();
-                                    if (lifeTime.Duration != -1) lifeTime.Duration *= bonus;
-                                    buffEntity.Write(lifeTime);
-                                }
-
-                                if (!prefabName.Contains("holyresistance", StringComparison.OrdinalIgnoreCase) && buffEntity.TryGetBuffer<ModifyUnitStatBuff_DOTS>(out var statBuffer) && !statBuffer.IsEmpty)
-                                {
-                                    for (int j = 0; j < statBuffer.Length; j++)
-                                    {
-                                        ModifyUnitStatBuff_DOTS statBuff = statBuffer[j];
-                                        statBuff.Value *= 1 + level / (float)MAX_PROFESSION_LEVEL;
-
-                                        statBuffer[j] = statBuff;
-                                    }
-                                }
-
-                                if (buffEntity.Has<HealOnGameplayEvent>() && buffEntity.TryGetBuffer<CreateGameplayEventsOnTick>(out var tickBuffer) && !tickBuffer.IsEmpty)
-                                {
-                                    CreateGameplayEventsOnTick eventsOnTick = tickBuffer[0];
-                                    eventsOnTick.MaxTicks = (int)(eventsOnTick.MaxTicks * bonus);
-
-                                    tickBuffer[0] = eventsOnTick;
-                                }
-                            }
-
-                            if (_familiars && !buffPrefabGuid.Equals(_wranglerPotionBuff))
-                            {
-                                familiar = Familiars.GetActiveFamiliar(buffTarget);
-
-                                if (familiar.Exists())
-                                {
-                                    if (buffEntity.Has<HealOnGameplayEvent>() && familiar.IsDisabled())
-                                    {
-                                        continue;
-                                    }
-                                    else
-                                    {
-                                        familiar.TryApplyBuff(buffPrefabGuid);
-                                    }
-                                }
-                            }
-                        }
-                        else if (buffTarget.TryGetFollowedPlayer(out playerCharacter))
-                        {
-                            if (_potionStacking && !prefabName.Contains("holyresistance", StringComparison.OrdinalIgnoreCase))
-                            {
-                                if (buffEntity.Has<RemoveBuffOnGameplayEvent>()) buffEntity.Remove<RemoveBuffOnGameplayEvent>();
-                                if (buffEntity.Has<RemoveBuffOnGameplayEventEntry>()) buffEntity.Remove<RemoveBuffOnGameplayEventEntry>();
-                            }
-
-                            if (_familiars && !buffPrefabGuid.Equals(_wranglerPotionBuff))
-                            {
-                                familiar = Familiars.GetActiveFamiliar(playerCharacter);
-
-                                if (familiar.Exists())
-                                {
-                                    if (buffEntity.Has<HealOnGameplayEvent>() && familiar.IsDisabled())
-                                    {
-                                        continue;
-                                    }
-                                    else
-                                    {
-                                        familiar.TryApplyBuff(buffPrefabGuid);
-                                    }
-                                }
-                            }
-                        }
-                        break;
-                    case 12 when _familiars:
-                        if (buffTarget.TryGetFollowedPlayer(out playerCharacter) && !GetPlayerBool(playerCharacter.GetSteamId(), VBLOOD_EMOTES_KEY))
-                        {
-                            buffEntity.Destroy();
-                        }
-                        break;
-                    case 13 when _familiars && isPlayerTarget:
-                        familiar = Familiars.GetActiveFamiliar(buffTarget);
-                        if (familiar.Exists())
-                        {
-                            familiar.TryApplyBuff(buffPrefabGuid);
-                        }
-                        break;
-                    case 14:
-                        if (isPlayerTarget)
-                        {
-                            if (buffTarget.HasBuff(_evolvedVampireBuff)) buffEntity.Remove<SetOwnerRotateTowardsMouse>();
-                            else if (_familiars && steamId.HasActiveFamiliar())
-                            {
-                                familiar = Familiars.GetActiveFamiliar(buffTarget);
-                                // Core.Log.LogWarning($"[BuffSystem_Spawn_Server] SyncingAggro - {familiar.Exists()}");
-                                Familiars.SyncAggro(buffTarget, familiar);
-                            }
-                        }
-                        /*
-                        else if (blockFeedBuffLookup.HasComponent(buffTarget))
-                        {
-
-                        }
-                        */
-                        break;
-                    case 15 when _familiars:
-                        if (buffTarget.IsFollowingPlayer())
-                        {
-                            buffEntity.Destroy();
-                        }
-                        break;
-                    case 16 when _familiars && isPlayerTarget:
-                        User batUser = buffTarget.GetUser();
-                        if (Familiars.AutoCallMap.TryRemove(buffTarget, out familiar) && familiar.Exists())
-                        {
-                            Familiars.CallFamiliar(buffTarget, familiar, batUser, steamId);
-                        }
-                        break;
-                    default:
-                        if (isPlayerTarget && !buffTarget.IsDueling())
-                        {
-                            Entity owner = buffEntity.GetOwner();
-                            bool isPlayerOwner = owner.IsPlayer();
-
-                            if (_gameMode.Equals(GameModeType.PvE))
-                            {
-                                if (isPlayerOwner && !owner.Equals(buffTarget))
-                                {
-                                    PreventDebuff(buffEntity);
-                                }
-                                else if (_familiars)
-                                {
-                                    if (owner.IsFollowingPlayer())
-                                    {
-                                        PreventDebuff(buffEntity);
-                                    }
-                                    else if (owner.GetOwner().IsFollowingPlayer())
-                                    {
-                                        PreventDebuff(buffEntity);
-                                    }
-                                }
-                            }
-                            else if (_gameMode.Equals(GameModeType.PvP) && buffTarget.HasBuff(_pvpProtectedBuff))
-                            {
-                                if (isPlayerOwner && !owner.Equals(buffTarget))
-                                {
-                                    PreventDebuff(buffEntity);
-                                }
-                                else if (_familiars)
-                                {
-                                    if (owner.IsFollowingPlayer())
-                                    {
-                                        PreventDebuff(buffEntity);
-                                    }
-                                    else if (owner.GetOwner().IsFollowingPlayer())
-                                    {
-                                        PreventDebuff(buffEntity);
-                                    }
-                                }
-                            }
-                        }
-
+                foreach (IBuffSpawnHandler handler in BuffSpawnHandlerRegistry.Handlers)
+                {
+                    if (handler.CanHandle(ctx))
+                    {
+                        handler.Handle(ctx);
                         break;
                     }
+                }
             }
         }
         catch (Exception e)
         {
             Core.Log.LogWarning($"[BuffSystem_Spawn_Server] - Exception: {e}");
-        }
-    }
-    static int GetBuffType(int prefabGuid, string prefabName = "")
-    {
-        string lowerName = prefabName.ToLower();
-
-        if (lowerName.Contains("consumable") || lowerName.Contains("elixir"))
-            return 11;
-        else if (lowerName.Contains("emote_onaggro"))
-            return 12;
-        else if (lowerName.Contains("userelic"))
-            return 13;
-        else
-        {
-            // technically more performant but this is even less readable than the if else if chain x_x and hard to keep up with changes to hashes if needed
-            return prefabGuid switch
-            {
-                358972271 => 1,  // Elite Solarus Final Phase
-                -354622715 => 2,  // TrueImmortal
-                581443919 => 3,  // PvE Combat
-                697095869 => 4,  // Familiar PvP
-                -89195359 => 5,  // Vampiric curse
-                1356064917 => 7,  // Witch pig transformation
-                -79611032 => 8,  // Phasing
-                -6635580 => 9,  // Familiar highlord sword
-                -1584595113 => 10, // Familiar castleman holy buff
-                -952067173 => 3, // Combat stance
-                404387047 => 15, // Dracula return hide
-                -371745443 => 16, // bat landing
-                _ => 0
-            };
-        }
-    }
-    static void PreventDebuff(Entity buffEntity)
-    {
-        if (buffEntity.TryGetComponent(out Buff buff) && buff.BuffEffectType.Equals(BuffEffectType.Debuff))
-        {
-            buffEntity.Destroy();
-        }
-    }
-    static readonly Dictionary<PrefabGUID, Action<BuffSpawnContext>> _buffSpawnActions = new()
-    {
-        { _gateBossFeedCompleteBuff,   HandleEliteSolarusFinalPhase },   // case 1
-        { _bloodCurseBuff,             HandleTrueImmortal         },     // case 2
-        { _pveCombatBuff,              HandlePveCombatBuff        },     // case 3
-        { _pvpCombatBuff,              HandlePvpCombatBuff        },     // case 4
-        { _combatStanceBuff,           HandleCombatStanceBuff     },     // case 14 (re‑used logic)
-        { _witchPigTransformationBuff, HandleWitchPigTransformation},    // case 7
-        { _phasingBuff,                HandlePhasingBuff          },     // case 8 (also 14 part‑A)
-        { _highlordGroundSwordBossBuff,HandleHighlordSwordBuff    },     // case 9
-        { _inkCrawlerDeathBuff,        HandleInkCrawlerDeathBuff  },     // case 10
-        { _draculaReturnHideBuff,      HandleDraculaReturnHide    }      // case 15
-    };
-    readonly struct BuffSpawnContext
-    {
-        public Entity BuffEntity { get; init; }
-        public Entity BuffTarget { get; init; }
-        public bool TargetIsPlayer { get; init; }
-        public ulong SteamId { get; init; }
-        public ComponentLookup<PlayerCharacter> PlayerLookup { get; init; }
-        public ComponentLookup<BlockFeedBuff> BlockFeedLookup { get; init; }
-    }
-    static void HandleConsumable(Entity buffEntity, Entity target, PrefabGUID buffGuid, string prefabName, bool targetIsPlayer, ulong steamId)
-    {
-        if (targetIsPlayer)
-        {
-            ApplyConsumableToPlayer(buffEntity, target, buffGuid, prefabName, steamId);
-        }
-        else if (target.TryGetFollowedPlayer(out Entity playerChar))
-        {
-            ApplyConsumableToFollower(buffEntity, playerChar, prefabName);
-        }
-    }
-    static void HandleAggroEmote(Entity buffEntity, Entity target)
-    {
-        if (_familiars && target.TryGetFollowedPlayer(out Entity player) && !GetPlayerBool(player.GetSteamId(), VBLOOD_EMOTES_KEY))
-        {
-            buffEntity.Destroy();
-        }
-    }
-    static void HandleUseRelic(Entity buffEntity, Entity target, bool targetIsPlayer)
-    {
-        if (_familiars && targetIsPlayer)
-        {
-            Entity familiar = Familiars.GetActiveFamiliar(target);
-
-            if (familiar.Exists())
-            {
-                familiar.TryApplyBuff(buffEntity.GetPrefabGuid());
-            }
-        }
-    }
-    static void HandleEliteSolarusFinalPhase(BuffSpawnContext buff)
-    {
-        if (!_eliteShardBearers) return;
-        else if (!buff.BuffTarget.GetPrefabGuid().Equals(_solarus)) return;
-
-        if (!buff.BuffTarget.HasBuff(_holyBeamPowerBuff) && !buff.BlockFeedLookup.HasComponent(buff.BuffTarget))
-        {
-            if (buff.BuffTarget.TryApplyAndGetBuff(_holyBeamPowerBuff, out Entity buffEntity))
-            {
-                buffEntity.HasWith((ref LifeTime lifeTime) =>
-                {
-                    lifeTime.Duration = 0f;
-                    lifeTime.EndAction = LifeTimeEndAction.None;
-                });
-            }
-        }
-    }
-    static void HandleTrueImmortal(BuffSpawnContext buff)
-    {
-        if (!_trueImmortal || !buff.TargetIsPlayer) return;
-
-        Entity spellTarget = buff.BuffEntity.GetSpellTarget();
-
-        if (!spellTarget.IsVBloodOrGateBoss())
-        {
-            Shapeshifts.TrueImmortal(buff.BuffEntity, buff.BuffTarget);
-        }
-    }
-    static void HandlePveCombatBuff(BuffSpawnContext buff)
-    {
-        // original case 3
-        if (!buff.TargetIsPlayer) return;
-
-        Entity familiar;
-        if (buff.BuffTarget.HasBuff(_evolvedVampireBuff))
-        {
-            buff.BuffEntity.Remove<SetOwnerRotateTowardsMouse>();
-        }
-
-        if (_familiars && buff.SteamId.HasActiveFamiliar())
-        {
-            familiar = Familiars.GetActiveFamiliar(buff.BuffTarget);
-            Familiars.HandleFamiliarEnteringCombat(buff.BuffTarget, familiar);
-            Familiars.SyncAggro(buff.BuffTarget, familiar);
-        }
-    }
-    static void HandlePvpCombatBuff(BuffSpawnContext buff)
-    {
-        // original case 4 – familiar dismissal in PvP
-        if (!_familiars || !buff.TargetIsPlayer) return;
-
-        Entity familiar;
-        if (buff.SteamId.HasActiveFamiliar())
-        {
-            familiar = Familiars.GetActiveFamiliar(buff.BuffTarget);
-
-            if (!_familiarPvP)
-            {
-                User user = buff.BuffTarget.GetUser();
-                Familiars.DismissFamiliar(buff.BuffTarget, familiar, user, buff.SteamId);
-            }
-            else
-            {
-                Familiars.HandleFamiliarEnteringCombat(buff.BuffTarget, familiar);
-            }
-        }
-    }
-    static void HandleWitchPigTransformation(BuffSpawnContext buff)
-    {
-        if (_familiars && buff.BuffTarget.IsVBloodOrGateBoss())
-        {
-            buff.BuffEntity.Destroy();
-        }
-    }
-    static void HandlePhasingBuff(BuffSpawnContext buff)
-    {
-        if (!buff.TargetIsPlayer) return;
-
-        if (_familiars && buff.SteamId.HasDismissedFamiliar() && Familiars.AutoCallMap.TryRemove(buff.BuffTarget, out Entity familiar))
-        {
-            Familiars.CallFamiliar(buff.BuffTarget, familiar, buff.BuffTarget.GetUser(), buff.SteamId);
-        }
-
-        if (_legacies || _expertise)
-        {
-            Buffs.RefreshStats(buff.BuffTarget);
-        }
-    }
-    static void HandleCombatStanceBuff(BuffSpawnContext buff)
-    {
-        if (!buff.TargetIsPlayer) return;
-
-        Entity familiar;
-        if (buff.BuffTarget.HasBuff(_evolvedVampireBuff))
-        {
-            buff.BuffEntity.Remove<SetOwnerRotateTowardsMouse>();
-        }
-        else if (_familiars && buff.SteamId.HasActiveFamiliar())
-        {
-            familiar = Familiars.GetActiveFamiliar(buff.BuffTarget);
-            Familiars.SyncAggro(buff.BuffTarget, familiar);
-        }
-    }
-    static void HandleHighlordSwordBuff(BuffSpawnContext buff)
-    {
-        if (!_familiars) return;
-
-        if (buff.BuffTarget.TryGetFollowedPlayer(out Entity playerChar))
-        {
-            Entity familiar = Familiars.GetActiveFamiliar(playerChar);
-            if (familiar.Exists() && familiar.TryGetBuff(_highlordGroundSwordBossBuff, out Entity buffEntity))
-            {
-                buffEntity.AddWith((ref AmplifyBuff amplify) => amplify.AmplifyModifier = -0.75f);
-                buffEntity.AddWith((ref LifeTime lifeTime) =>
-                {
-                    lifeTime.Duration = MINION_LIFETIME;
-                    lifeTime.EndAction = LifeTimeEndAction.Destroy;
-                });
-            }
-        }
-    }
-    static void HandleInkCrawlerDeathBuff(BuffSpawnContext buff)
-    {
-        if (!_familiars) return;
-
-        if (buff.BuffTarget.TryGetFollowedPlayer(out Entity playerChar))
-        {
-            buff.BuffEntity.With((ref LifeTime lifeTime) =>
-            {
-                lifeTime.Duration = 30f;
-                lifeTime.EndAction = LifeTimeEndAction.Destroy;
-            });
-        }
-    }
-    static void HandleDraculaReturnHide(BuffSpawnContext ctx)
-    {
-        if (!_familiars) return;
-
-        if (ctx.BuffTarget.IsFollowingPlayer())
-        {
-            ctx.BuffEntity.Destroy();
-        }
-    }
-    static void ApplyConsumableToPlayer(Entity buffEntity, Entity player, PrefabGUID buffGuid, string prefabName, ulong steamId)
-    {
-        if (_potionStacking && !prefabName.Contains("holyresistance", StringComparison.OrdinalIgnoreCase))
-        {
-            buffEntity.Remove<RemoveBuffOnGameplayEvent>();
-            buffEntity.Remove<RemoveBuffOnGameplayEventEntry>();
-        }
-
-        if (_professions)
-        {
-            IProfession alchemyHandler = ProfessionFactory.GetProfession(buffGuid);
-            int level = alchemyHandler.GetProfessionLevel(steamId);
-            float duration = 1 + level / (float)MAX_PROFESSION_LEVEL;
-
-            buffEntity.With((ref LifeTime lifeTime) =>
-            {
-                if (!lifeTime.EndAction.Equals(LifeTimeEndAction.None))
-                {
-                    lifeTime.Duration *= duration;
-                }
-            });
-
-            if (!prefabName.Contains("holyresistance", StringComparison.OrdinalIgnoreCase) &&
-                buffEntity.TryGetBuffer<ModifyUnitStatBuff_DOTS>(out var statBuffer) && !statBuffer.IsEmpty)
-            {
-                for (int j = 0; j < statBuffer.Length; ++j)
-                {
-                    var statBuff = statBuffer[j];
-                    statBuff.Value *= duration;
-                    statBuffer[j] = statBuff;
-                }
-            }
-
-            if (buffEntity.Has<HealOnGameplayEvent>() && buffEntity.TryGetBuffer<CreateGameplayEventsOnTick>(out var tickBuffer) && !tickBuffer.IsEmpty)
-            {
-                var eventOnTick = tickBuffer[0];
-                eventOnTick.MaxTicks = (int)(eventOnTick.MaxTicks * duration);
-                tickBuffer[0] = eventOnTick;
-            }
-        }
-
-        if (_familiars && !buffGuid.Equals(_wranglerPotionBuff))
-        {
-            Entity familiar = Familiars.GetActiveFamiliar(player);
-            if (familiar.Exists())
-            {
-                if (buffEntity.Has<HealOnGameplayEvent>() && familiar.IsDisabled())
-                    return; // skip if disabled and heal‑based consumable
-
-                familiar.TryApplyBuff(buffGuid);
-            }
-        }
-    }
-    static void ApplyConsumableToFollower(Entity buffEntity, Entity playerCharacter, string prefabName)
-    {
-        if (_potionStacking && !prefabName.Contains("holyresistance", StringComparison.OrdinalIgnoreCase))
-        {
-            buffEntity.Remove<RemoveBuffOnGameplayEvent>();
-            buffEntity.Remove<RemoveBuffOnGameplayEventEntry>();
-        }
-
-        if (_familiars && !buffEntity.GetPrefabGuid().Equals(_wranglerPotionBuff))
-        {
-            Entity familiar = Familiars.GetActiveFamiliar(playerCharacter);
-            if (familiar.Exists())
-            {
-                if (buffEntity.Has<HealOnGameplayEvent>() && familiar.IsDisabled())
-                    return;
-
-                familiar.TryApplyBuff(buffEntity.GetPrefabGuid());
-            }
-        }
-    }
-    static void TryPreventDebuff(Entity buffEntity, Entity target, bool targetIsPlayer)
-    {
-        if (!targetIsPlayer) return;
-
-        Entity owner = buffEntity.GetOwner();
-        bool ownerPlayer = owner.IsPlayer();
-
-        bool prevent = false;
-
-        if (_gameMode == GameModeType.PvE)
-        {
-            prevent = ownerPlayer && !owner.Equals(target);
-        }
-        else if (_gameMode == GameModeType.PvP && target.HasBuff(_pvpProtectedBuff))
-        {
-            prevent = ownerPlayer && !owner.Equals(target);
-        }
-
-        if (!prevent && _familiars)
-        {
-            if (owner.IsFollowingPlayer() || owner.GetOwner().IsFollowingPlayer())
-                prevent = true;
-        }
-
-        if (prevent)
-        {
-            PreventDebuff(buffEntity);
         }
     }
 }

--- a/Patches/BuffSpawnServerPatches/BuffSpawnContext.cs
+++ b/Patches/BuffSpawnServerPatches/BuffSpawnContext.cs
@@ -1,0 +1,25 @@
+using ProjectM;
+using ProjectM.Network;
+using Unity.Entities;
+
+namespace Bloodcraft.Patches.BuffSpawnServerPatches;
+
+readonly struct BuffSpawnContext
+{
+    public Entity BuffEntity { get; init; }
+    public Entity Target { get; init; }
+    public PrefabGUID PrefabGuid { get; init; }
+    public string PrefabName { get; init; }
+    public bool IsPlayer { get; init; }
+    public ulong SteamId { get; init; }
+    public GameModeType GameMode { get; init; }
+    public bool EliteShardBearers { get; init; }
+    public bool Legacies { get; init; }
+    public bool Expertise { get; init; }
+    public bool TrueImmortal { get; init; }
+    public bool Familiars { get; init; }
+    public bool FamiliarPvP { get; init; }
+    public bool PotionStacking { get; init; }
+    public bool Professions { get; init; }
+    public ComponentLookup<BlockFeedBuff> BlockFeedLookup { get; init; }
+}

--- a/Patches/BuffSpawnServerPatches/BuffSpawnHandlerRegistry.cs
+++ b/Patches/BuffSpawnServerPatches/BuffSpawnHandlerRegistry.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using Bloodcraft.Patches.BuffSpawnServerPatches.Handlers;
+
+namespace Bloodcraft.Patches.BuffSpawnServerPatches;
+
+static class BuffSpawnHandlerRegistry
+{
+    static readonly List<IBuffSpawnHandler> _handlers = new()
+    {
+        new EliteSolarusHandler(),
+        new TrueImmortalHandler(),
+        new PveCombatHandler(),
+        new PvpCombatHandler(),
+        new VampiricCurseHandler(),
+        new WitchPigTransformationHandler(),
+        new PhasingHandler(),
+        new HighlordSwordHandler(),
+        new InkCrawlerDeathHandler(),
+        new ConsumableHandler(),
+        new AggroEmoteHandler(),
+        new UseRelicHandler(),
+        new CombatStanceHandler(),
+        new DraculaReturnHideHandler(),
+        new BatLandingHandler(),
+        new DefaultBuffHandler()
+    };
+
+    public static IEnumerable<IBuffSpawnHandler> Handlers => _handlers;
+}

--- a/Patches/BuffSpawnServerPatches/Handlers/AggroEmoteHandler.cs
+++ b/Patches/BuffSpawnServerPatches/Handlers/AggroEmoteHandler.cs
@@ -1,0 +1,21 @@
+using System;
+using Bloodcraft.Utilities;
+using ProjectM;
+using Unity.Entities;
+using static Bloodcraft.Utilities.Misc.PlayerBools;
+
+namespace Bloodcraft.Patches.BuffSpawnServerPatches.Handlers;
+
+sealed class AggroEmoteHandler : IBuffSpawnHandler
+{
+    public bool CanHandle(BuffSpawnContext ctx)
+        => ctx.PrefabName.Contains("emote_onaggro", StringComparison.OrdinalIgnoreCase);
+
+    public void Handle(BuffSpawnContext ctx)
+    {
+        if (ctx.Familiars && ctx.Target.TryGetFollowedPlayer(out Entity player) && !GetPlayerBool(player.GetSteamId(), VBLOOD_EMOTES_KEY))
+        {
+            ctx.BuffEntity.Destroy();
+        }
+    }
+}

--- a/Patches/BuffSpawnServerPatches/Handlers/BatLandingHandler.cs
+++ b/Patches/BuffSpawnServerPatches/Handlers/BatLandingHandler.cs
@@ -1,0 +1,23 @@
+using Bloodcraft.Utilities;
+using ProjectM;
+using ProjectM.Network;
+using Stunlock.Core;
+using Unity.Entities;
+
+namespace Bloodcraft.Patches.BuffSpawnServerPatches.Handlers;
+
+sealed class BatLandingHandler : IBuffSpawnHandler
+{
+    static readonly PrefabGUID BatLandingTravel = new(-371745443);
+
+    public bool CanHandle(BuffSpawnContext ctx)
+        => ctx.Familiars && ctx.IsPlayer && ctx.PrefabGuid.Equals(BatLandingTravel);
+
+    public void Handle(BuffSpawnContext ctx)
+    {
+        if (Familiars.AutoCallMap.TryRemove(ctx.Target, out Entity familiar) && familiar.Exists())
+        {
+            Familiars.CallFamiliar(ctx.Target, familiar, ctx.Target.GetUser(), ctx.SteamId);
+        }
+    }
+}

--- a/Patches/BuffSpawnServerPatches/Handlers/CombatStanceHandler.cs
+++ b/Patches/BuffSpawnServerPatches/Handlers/CombatStanceHandler.cs
@@ -1,0 +1,32 @@
+using Bloodcraft.Resources;
+using Bloodcraft.Utilities;
+using ProjectM;
+using Stunlock.Core;
+using Unity.Entities;
+
+namespace Bloodcraft.Patches.BuffSpawnServerPatches.Handlers;
+
+sealed class CombatStanceHandler : IBuffSpawnHandler
+{
+    static readonly PrefabGUID CombatStanceBuff = Buffs.CombatStanceBuff;
+    static readonly PrefabGUID EvolvedVampireBuff = Buffs.EvolvedVampireBuff;
+
+    public bool CanHandle(BuffSpawnContext ctx)
+        => ctx.PrefabGuid.Equals(CombatStanceBuff);
+
+    public void Handle(BuffSpawnContext ctx)
+    {
+        if (!ctx.IsPlayer)
+            return;
+
+        if (ctx.Target.HasBuff(EvolvedVampireBuff))
+        {
+            ctx.BuffEntity.Remove<SetOwnerRotateTowardsMouse>();
+        }
+        else if (ctx.Familiars && ctx.SteamId.HasActiveFamiliar())
+        {
+            Entity familiar = Familiars.GetActiveFamiliar(ctx.Target);
+            Familiars.SyncAggro(ctx.Target, familiar);
+        }
+    }
+}

--- a/Patches/BuffSpawnServerPatches/Handlers/ConsumableHandler.cs
+++ b/Patches/BuffSpawnServerPatches/Handlers/ConsumableHandler.cs
@@ -1,0 +1,106 @@
+using System;
+using Bloodcraft.Interfaces;
+using Bloodcraft.Resources;
+using Bloodcraft.Systems.Professions;
+using Bloodcraft.Utilities;
+using ProjectM;
+using ProjectM.Network;
+using Stunlock.Core;
+using Unity.Entities;
+
+namespace Bloodcraft.Patches.BuffSpawnServerPatches.Handlers;
+
+sealed class ConsumableHandler : IBuffSpawnHandler
+{
+    const int MaxProfessionLevel = ProfessionSystem.MAX_PROFESSION_LEVEL;
+    static readonly PrefabGUID WranglerPotionBuff = Buffs.WranglerPotionBuff;
+
+    public bool CanHandle(BuffSpawnContext ctx)
+        => ctx.PrefabName.Contains("consumable", StringComparison.OrdinalIgnoreCase) ||
+           ctx.PrefabName.Contains("elixir", StringComparison.OrdinalIgnoreCase);
+
+    public void Handle(BuffSpawnContext ctx)
+    {
+        if (ctx.IsPlayer)
+        {
+            ApplyConsumableToPlayer(ctx);
+        }
+        else if (ctx.Target.TryGetFollowedPlayer(out Entity playerChar))
+        {
+            ApplyConsumableToFollower(ctx, playerChar);
+        }
+    }
+
+    void ApplyConsumableToPlayer(BuffSpawnContext ctx)
+    {
+        if (ctx.PotionStacking && !ctx.PrefabName.Contains("holyresistance", StringComparison.OrdinalIgnoreCase))
+        {
+            ctx.BuffEntity.Remove<RemoveBuffOnGameplayEvent>();
+            ctx.BuffEntity.Remove<RemoveBuffOnGameplayEventEntry>();
+        }
+
+        if (ctx.Professions)
+        {
+            IProfession handler = ProfessionFactory.GetProfession(ctx.PrefabGuid);
+            int level = handler.GetProfessionLevel(ctx.SteamId);
+            float bonus = 1 + level / (float)MaxProfessionLevel;
+
+            ctx.BuffEntity.With((ref LifeTime lifeTime) =>
+            {
+                if (!lifeTime.EndAction.Equals(LifeTimeEndAction.None))
+                {
+                    lifeTime.Duration *= bonus;
+                }
+            });
+
+            if (!ctx.PrefabName.Contains("holyresistance", StringComparison.OrdinalIgnoreCase) &&
+                ctx.BuffEntity.TryGetBuffer<ModifyUnitStatBuff_DOTS>(out var statBuffer) && !statBuffer.IsEmpty)
+            {
+                for (int j = 0; j < statBuffer.Length; ++j)
+                {
+                    var statBuff = statBuffer[j];
+                    statBuff.Value *= bonus;
+                    statBuffer[j] = statBuff;
+                }
+            }
+
+            if (ctx.BuffEntity.Has<HealOnGameplayEvent>() && ctx.BuffEntity.TryGetBuffer<CreateGameplayEventsOnTick>(out var tickBuffer) && !tickBuffer.IsEmpty)
+            {
+                var eventsOnTick = tickBuffer[0];
+                eventsOnTick.MaxTicks = (int)(eventsOnTick.MaxTicks * bonus);
+                tickBuffer[0] = eventsOnTick;
+            }
+        }
+
+        if (ctx.Familiars && !ctx.PrefabGuid.Equals(WranglerPotionBuff))
+        {
+            Entity familiar = Familiars.GetActiveFamiliar(ctx.Target);
+            if (familiar.Exists())
+            {
+                if (ctx.BuffEntity.Has<HealOnGameplayEvent>() && familiar.IsDisabled())
+                    return;
+                familiar.TryApplyBuff(ctx.PrefabGuid);
+            }
+        }
+    }
+
+    void ApplyConsumableToFollower(BuffSpawnContext ctx, Entity playerChar)
+    {
+        if (ctx.PotionStacking && !ctx.PrefabName.Contains("holyresistance", StringComparison.OrdinalIgnoreCase))
+        {
+            ctx.BuffEntity.Remove<RemoveBuffOnGameplayEvent>();
+            ctx.BuffEntity.Remove<RemoveBuffOnGameplayEventEntry>();
+        }
+
+        if (ctx.Familiars && !ctx.PrefabGuid.Equals(WranglerPotionBuff))
+        {
+            Entity familiar = Familiars.GetActiveFamiliar(playerChar);
+            if (familiar.Exists())
+            {
+                if (ctx.BuffEntity.Has<HealOnGameplayEvent>() && familiar.IsDisabled())
+                    return;
+                familiar.TryApplyBuff(ctx.PrefabGuid);
+            }
+        }
+    }
+}

--- a/Patches/BuffSpawnServerPatches/Handlers/DefaultBuffHandler.cs
+++ b/Patches/BuffSpawnServerPatches/Handlers/DefaultBuffHandler.cs
@@ -1,0 +1,47 @@
+using Bloodcraft.Resources;
+using Bloodcraft.Utilities;
+using ProjectM;
+using Stunlock.Core;
+using Unity.Entities;
+
+namespace Bloodcraft.Patches.BuffSpawnServerPatches.Handlers;
+
+sealed class DefaultBuffHandler : IBuffSpawnHandler
+{
+    static readonly PrefabGUID PvPProtectedBuff = Buffs.PvPProtectedBuff;
+
+    public bool CanHandle(BuffSpawnContext ctx) => true;
+
+    public void Handle(BuffSpawnContext ctx)
+    {
+        if (!ctx.IsPlayer || ctx.Target.IsDueling())
+            return;
+
+        Entity owner = ctx.BuffEntity.GetOwner();
+        bool ownerPlayer = owner.IsPlayer();
+
+        bool prevent = false;
+
+        if (ctx.GameMode == GameModeType.PvE)
+        {
+            prevent = ownerPlayer && !owner.Equals(ctx.Target);
+        }
+        else if (ctx.GameMode == GameModeType.PvP && ctx.Target.HasBuff(PvPProtectedBuff))
+        {
+            prevent = ownerPlayer && !owner.Equals(ctx.Target);
+        }
+
+        if (!prevent && ctx.Familiars)
+        {
+            if (owner.IsFollowingPlayer() || owner.GetOwner().IsFollowingPlayer())
+            {
+                prevent = true;
+            }
+        }
+
+        if (prevent && ctx.BuffEntity.TryGetComponent(out Buff buff) && buff.BuffEffectType.Equals(BuffEffectType.Debuff))
+        {
+            ctx.BuffEntity.Destroy();
+        }
+    }
+}

--- a/Patches/BuffSpawnServerPatches/Handlers/DraculaReturnHideHandler.cs
+++ b/Patches/BuffSpawnServerPatches/Handlers/DraculaReturnHideHandler.cs
@@ -1,0 +1,23 @@
+using Bloodcraft.Resources;
+using Bloodcraft.Utilities;
+using ProjectM;
+using Stunlock.Core;
+using Unity.Entities;
+
+namespace Bloodcraft.Patches.BuffSpawnServerPatches.Handlers;
+
+sealed class DraculaReturnHideHandler : IBuffSpawnHandler
+{
+    static readonly PrefabGUID DraculaReturnHideBuff = Buffs.DraculaReturnHideBuff;
+
+    public bool CanHandle(BuffSpawnContext ctx)
+        => ctx.Familiars && ctx.PrefabGuid.Equals(DraculaReturnHideBuff);
+
+    public void Handle(BuffSpawnContext ctx)
+    {
+        if (ctx.Target.IsFollowingPlayer())
+        {
+            ctx.BuffEntity.Destroy();
+        }
+    }
+}

--- a/Patches/BuffSpawnServerPatches/Handlers/EliteSolarusHandler.cs
+++ b/Patches/BuffSpawnServerPatches/Handlers/EliteSolarusHandler.cs
@@ -1,0 +1,38 @@
+using Bloodcraft.Resources;
+using Bloodcraft.Utilities;
+using ProjectM;
+using Stunlock.Core;
+using Unity.Entities;
+
+namespace Bloodcraft.Patches.BuffSpawnServerPatches.Handlers;
+
+sealed class EliteSolarusHandler : IBuffSpawnHandler
+{
+    static readonly PrefabGUID GateBossFeedCompleteBuff = Buffs.GateBossFeedCompleteBuff;
+    static readonly PrefabGUID HolyBeamPowerBuff = Buffs.HolyBeamPowerBuff;
+    static readonly PrefabGUID Solarus = PrefabGUIDs.CHAR_ChurchOfLight_Paladin_VBlood;
+
+    public bool CanHandle(BuffSpawnContext ctx)
+        => ctx.EliteShardBearers && ctx.PrefabGuid.Equals(GateBossFeedCompleteBuff);
+
+    public void Handle(BuffSpawnContext ctx)
+    {
+        if (!ctx.Target.GetPrefabGuid().Equals(Solarus))
+            return;
+
+        if (ctx.Target.HasBuff(HolyBeamPowerBuff) || ctx.BlockFeedLookup.HasComponent(ctx.Target))
+            return;
+
+        if (ctx.Target.TryApplyAndGetBuff(HolyBeamPowerBuff, out Entity buffEntity))
+        {
+            if (buffEntity.Has<LifeTime>())
+            {
+                buffEntity.With((ref LifeTime lifeTime) =>
+                {
+                    lifeTime.Duration = 0f;
+                    lifeTime.EndAction = LifeTimeEndAction.None;
+                });
+            }
+        }
+    }
+}

--- a/Patches/BuffSpawnServerPatches/Handlers/HighlordSwordHandler.cs
+++ b/Patches/BuffSpawnServerPatches/Handlers/HighlordSwordHandler.cs
@@ -1,0 +1,33 @@
+using Bloodcraft.Resources;
+using Bloodcraft.Utilities;
+using ProjectM;
+using Stunlock.Core;
+using Unity.Entities;
+
+namespace Bloodcraft.Patches.BuffSpawnServerPatches.Handlers;
+
+sealed class HighlordSwordHandler : IBuffSpawnHandler
+{
+    static readonly PrefabGUID HighlordGroundSwordBossBuff = Buffs.HighlordGroundSwordBossBuff;
+    const float MinionLifetime = 30f;
+
+    public bool CanHandle(BuffSpawnContext ctx)
+        => ctx.Familiars && ctx.PrefabGuid.Equals(HighlordGroundSwordBossBuff);
+
+    public void Handle(BuffSpawnContext ctx)
+    {
+        if (!ctx.Target.TryGetFollowedPlayer(out Entity playerChar))
+            return;
+
+        Entity familiar = Familiars.GetActiveFamiliar(playerChar);
+        if (familiar.Exists() && familiar.TryGetBuff(HighlordGroundSwordBossBuff, out Entity buff))
+        {
+            buff.AddWith((ref AmplifyBuff amplify) => amplify.AmplifyModifier = -0.75f);
+            buff.AddWith((ref LifeTime lifeTime) =>
+            {
+                lifeTime.Duration = MinionLifetime;
+                lifeTime.EndAction = LifeTimeEndAction.Destroy;
+            });
+        }
+    }
+}

--- a/Patches/BuffSpawnServerPatches/Handlers/InkCrawlerDeathHandler.cs
+++ b/Patches/BuffSpawnServerPatches/Handlers/InkCrawlerDeathHandler.cs
@@ -1,0 +1,28 @@
+using Bloodcraft.Resources;
+using Bloodcraft.Utilities;
+using ProjectM;
+using Stunlock.Core;
+using Unity.Entities;
+
+namespace Bloodcraft.Patches.BuffSpawnServerPatches.Handlers;
+
+sealed class InkCrawlerDeathHandler : IBuffSpawnHandler
+{
+    static readonly PrefabGUID InkCrawlerDeathBuff = Buffs.InkCrawlerDeathBuff;
+    const float MinionLifetime = 30f;
+
+    public bool CanHandle(BuffSpawnContext ctx)
+        => ctx.Familiars && ctx.PrefabGuid.Equals(InkCrawlerDeathBuff);
+
+    public void Handle(BuffSpawnContext ctx)
+    {
+        if (!ctx.Target.TryGetFollowedPlayer(out _))
+            return;
+
+        ctx.BuffEntity.With((ref LifeTime lifeTime) =>
+        {
+            lifeTime.Duration = MinionLifetime;
+            lifeTime.EndAction = LifeTimeEndAction.Destroy;
+        });
+    }
+}

--- a/Patches/BuffSpawnServerPatches/Handlers/PhasingHandler.cs
+++ b/Patches/BuffSpawnServerPatches/Handlers/PhasingHandler.cs
@@ -1,0 +1,32 @@
+using Bloodcraft.Resources;
+using Bloodcraft.Utilities;
+using ProjectM;
+using ProjectM.Network;
+using Stunlock.Core;
+using Unity.Entities;
+
+namespace Bloodcraft.Patches.BuffSpawnServerPatches.Handlers;
+
+sealed class PhasingHandler : IBuffSpawnHandler
+{
+    static readonly PrefabGUID PhasingBuff = Buffs.PhasingBuff;
+
+    public bool CanHandle(BuffSpawnContext ctx)
+        => ctx.PrefabGuid.Equals(PhasingBuff);
+
+    public void Handle(BuffSpawnContext ctx)
+    {
+        if (!ctx.IsPlayer)
+            return;
+
+        if (ctx.Familiars && ctx.SteamId.HasDismissedFamiliar() && Familiars.AutoCallMap.TryRemove(ctx.Target, out Entity familiar))
+        {
+            Familiars.CallFamiliar(ctx.Target, familiar, ctx.Target.GetUser(), ctx.SteamId);
+        }
+
+        if (ctx.Legacies || ctx.Expertise)
+        {
+            Buffs.RefreshStats(ctx.Target);
+        }
+    }
+}

--- a/Patches/BuffSpawnServerPatches/Handlers/PveCombatHandler.cs
+++ b/Patches/BuffSpawnServerPatches/Handlers/PveCombatHandler.cs
@@ -1,0 +1,34 @@
+using Bloodcraft.Resources;
+using Bloodcraft.Utilities;
+using ProjectM;
+using Stunlock.Core;
+using Unity.Entities;
+
+namespace Bloodcraft.Patches.BuffSpawnServerPatches.Handlers;
+
+sealed class PveCombatHandler : IBuffSpawnHandler
+{
+    static readonly PrefabGUID PveCombatBuff = Buffs.PvECombatBuff;
+    static readonly PrefabGUID EvolvedVampireBuff = Buffs.EvolvedVampireBuff;
+
+    public bool CanHandle(BuffSpawnContext ctx)
+        => ctx.PrefabGuid.Equals(PveCombatBuff);
+
+    public void Handle(BuffSpawnContext ctx)
+    {
+        if (!ctx.IsPlayer)
+            return;
+
+        if (ctx.Target.HasBuff(EvolvedVampireBuff))
+        {
+            ctx.BuffEntity.Remove<SetOwnerRotateTowardsMouse>();
+        }
+
+        if (ctx.Familiars && ctx.SteamId.HasActiveFamiliar())
+        {
+            Entity familiar = Familiars.GetActiveFamiliar(ctx.Target);
+            Familiars.HandleFamiliarEnteringCombat(ctx.Target, familiar);
+            Familiars.SyncAggro(ctx.Target, familiar);
+        }
+    }
+}

--- a/Patches/BuffSpawnServerPatches/Handlers/PvpCombatHandler.cs
+++ b/Patches/BuffSpawnServerPatches/Handlers/PvpCombatHandler.cs
@@ -1,0 +1,34 @@
+using Bloodcraft.Resources;
+using Bloodcraft.Utilities;
+using ProjectM;
+using ProjectM.Network;
+using Stunlock.Core;
+using Unity.Entities;
+
+namespace Bloodcraft.Patches.BuffSpawnServerPatches.Handlers;
+
+sealed class PvpCombatHandler : IBuffSpawnHandler
+{
+    static readonly PrefabGUID PvpCombatBuff = Buffs.PvPCombatBuff;
+
+    public bool CanHandle(BuffSpawnContext ctx)
+        => ctx.Familiars && ctx.IsPlayer && ctx.PrefabGuid.Equals(PvpCombatBuff);
+
+    public void Handle(BuffSpawnContext ctx)
+    {
+        if (!ctx.SteamId.HasActiveFamiliar())
+            return;
+
+        Entity familiar = Familiars.GetActiveFamiliar(ctx.Target);
+
+        if (!ctx.FamiliarPvP)
+        {
+            User user = ctx.Target.GetUser();
+            Familiars.DismissFamiliar(ctx.Target, familiar, user, ctx.SteamId);
+        }
+        else
+        {
+            Familiars.HandleFamiliarEnteringCombat(ctx.Target, familiar);
+        }
+    }
+}

--- a/Patches/BuffSpawnServerPatches/Handlers/TrueImmortalHandler.cs
+++ b/Patches/BuffSpawnServerPatches/Handlers/TrueImmortalHandler.cs
@@ -1,0 +1,28 @@
+using Bloodcraft.Resources;
+using Bloodcraft.Utilities;
+using ProjectM;
+using ProjectM.Scripting;
+using Stunlock.Core;
+using Unity.Entities;
+
+namespace Bloodcraft.Patches.BuffSpawnServerPatches.Handlers;
+
+sealed class TrueImmortalHandler : IBuffSpawnHandler
+{
+    static readonly PrefabGUID BloodCurseBuff = Buffs.DraculaBloodCurseBuff;
+
+    public bool CanHandle(BuffSpawnContext ctx)
+        => ctx.TrueImmortal && ctx.IsPlayer && ctx.PrefabGuid.Equals(BloodCurseBuff);
+
+    public void Handle(BuffSpawnContext ctx)
+    {
+        if (!ctx.BuffEntity.Has<SpellTarget>())
+            return;
+
+        Entity spellTarget = ctx.BuffEntity.GetSpellTarget();
+        if (!spellTarget.IsVBloodOrGateBoss())
+        {
+            Shapeshifts.TrueImmortal(ctx.BuffEntity, ctx.Target);
+        }
+    }
+}

--- a/Patches/BuffSpawnServerPatches/Handlers/UseRelicHandler.cs
+++ b/Patches/BuffSpawnServerPatches/Handlers/UseRelicHandler.cs
@@ -1,0 +1,24 @@
+using Bloodcraft.Utilities;
+using ProjectM;
+using System;
+using Unity.Entities;
+
+namespace Bloodcraft.Patches.BuffSpawnServerPatches.Handlers;
+
+sealed class UseRelicHandler : IBuffSpawnHandler
+{
+    public bool CanHandle(BuffSpawnContext ctx)
+        => ctx.PrefabName.Contains("userelic", StringComparison.OrdinalIgnoreCase);
+
+    public void Handle(BuffSpawnContext ctx)
+    {
+        if (!ctx.Familiars || !ctx.IsPlayer)
+            return;
+
+        Entity familiar = Familiars.GetActiveFamiliar(ctx.Target);
+        if (familiar.Exists())
+        {
+            familiar.TryApplyBuff(ctx.BuffEntity.GetPrefabGuid());
+        }
+    }
+}

--- a/Patches/BuffSpawnServerPatches/Handlers/VampiricCurseHandler.cs
+++ b/Patches/BuffSpawnServerPatches/Handlers/VampiricCurseHandler.cs
@@ -1,0 +1,35 @@
+using Bloodcraft.Resources;
+using Bloodcraft.Utilities;
+using ProjectM;
+using Stunlock.Core;
+using Unity.Entities;
+
+namespace Bloodcraft.Patches.BuffSpawnServerPatches.Handlers;
+
+sealed class VampiricCurseHandler : IBuffSpawnHandler
+{
+    static readonly PrefabGUID VampiricCurseBuff = Buffs.BloodCurseBuff;
+    static readonly PrefabGUID TargetSwallowedBuff = Buffs.TargetSwallowedBuff;
+    const float TravelDuration = 7.5f;
+
+    public bool CanHandle(BuffSpawnContext ctx)
+        => ctx.Familiars && ctx.IsPlayer && ctx.PrefabGuid.Equals(VampiricCurseBuff);
+
+    public void Handle(BuffSpawnContext ctx)
+    {
+        if (ctx.BuffEntity.Has<GameplayEventListeners>())
+            return;
+
+        Entity familiar = Familiars.GetActiveFamiliar(ctx.Target);
+        if (!familiar.Exists())
+            return;
+
+        if (familiar.TryApplyAndGetBuffWithOwner(ctx.Target, TargetSwallowedBuff, out Entity buff))
+        {
+            if (buff.Has<LifeTime>())
+            {
+                buff.With((ref LifeTime lifeTime) => lifeTime.Duration = TravelDuration);
+            }
+        }
+    }
+}

--- a/Patches/BuffSpawnServerPatches/Handlers/WitchPigTransformationHandler.cs
+++ b/Patches/BuffSpawnServerPatches/Handlers/WitchPigTransformationHandler.cs
@@ -1,0 +1,23 @@
+using Bloodcraft.Resources;
+using Bloodcraft.Utilities;
+using ProjectM;
+using Stunlock.Core;
+using Unity.Entities;
+
+namespace Bloodcraft.Patches.BuffSpawnServerPatches.Handlers;
+
+sealed class WitchPigTransformationHandler : IBuffSpawnHandler
+{
+    static readonly PrefabGUID WitchPigTransformationBuff = Buffs.WitchPigTransformationBuff;
+
+    public bool CanHandle(BuffSpawnContext ctx)
+        => ctx.Familiars && ctx.PrefabGuid.Equals(WitchPigTransformationBuff);
+
+    public void Handle(BuffSpawnContext ctx)
+    {
+        if (ctx.Target.IsVBloodOrGateBoss())
+        {
+            ctx.BuffEntity.Destroy();
+        }
+    }
+}

--- a/Patches/BuffSpawnServerPatches/IBuffSpawnHandler.cs
+++ b/Patches/BuffSpawnServerPatches/IBuffSpawnHandler.cs
@@ -1,0 +1,7 @@
+namespace Bloodcraft.Patches.BuffSpawnServerPatches;
+
+interface IBuffSpawnHandler
+{
+    bool CanHandle(BuffSpawnContext ctx);
+    void Handle(BuffSpawnContext ctx);
+}


### PR DESCRIPTION
## Summary
- Encapsulate buff spawn data in a `BuffSpawnContext`
- Replace large switch with extensible handler registry
- Add dedicated handlers for each buff spawn case

## Testing
- `dotnet test Bloodcraft.Tests/Bloodcraft.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68ae22927ffc832dbc023b8415e6a512