### PR TITLE
Summarize token stats in localization pipeline

### DIFF
--- a/Docs/Localization.md
+++ b/Docs/Localization.md
@@ -452,6 +452,11 @@ When mismatches occur the `mismatches` array contains objects with `file`,
 `key`, `missing`, and `extra` fields so problematic entries can be traced
 quickly.
 
+The localization pipeline runs `summarize_token_stats.py` after tokens are
+fixed to highlight hashes with mismatched or reordered tokens. If any language
+reports a non-zero `token_mismatches` count in the metrics emitted by
+`fix_tokens.py`, the pipeline terminates with a failure status.
+
 ### Log analysis
 
 Use `analyze_translation_logs.py` to summarise unresolved issues across


### PR DESCRIPTION
## Summary
- Run `summarize_token_stats.py` after token fixing in the localization pipeline
- Fail pipeline when any language reports token mismatches
- Document token mismatch requirement and token stats summarization

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae2e599f20832d92a5576a190f9bc4