### PR TITLE
feat: validate translation targets

### DIFF
--- a/Tools/localization_pipeline.py
+++ b/Tools/localization_pipeline.py
@@ -191,6 +191,22 @@ def main() -> None:
                 check=False,
                 logger=logger,
             )
+            metrics_file_path = run_dir / "metrics.json"
+            expected_file = str(path.relative_to(ROOT))
+            if not metrics_file_path.is_file():
+                raise SystemExit(f"Missing metrics file in {run_dir}")
+            with metrics_file_path.open("r", encoding="utf-8") as mf:
+                metrics_data = json.load(mf)
+            if isinstance(metrics_data, list):
+                metrics_entry = metrics_data[-1] if metrics_data else {}
+            else:
+                metrics_entry = metrics_data
+            actual_file = metrics_entry.get("file")
+            if actual_file != expected_file:
+                raise SystemExit(
+                    f"Run directory {run_dir} metrics mismatch: {actual_file} != {expected_file}"
+                )
+
             report = run_dir / "skipped.csv"
             report_paths.append(report)
             t_end = timestamp()
@@ -199,7 +215,6 @@ def main() -> None:
                 "end": t_end,
                 "returncode": result.returncode,
             }
-            report = run_dir / "skipped.csv"
             skipped_counts: Dict[str, int] = {}
             if report.is_file():
                 with report.open("r", encoding="utf-8") as fp:

--- a/Tools/translate_argos.py
+++ b/Tools/translate_argos.py
@@ -527,6 +527,11 @@ def _run_translation(args, root: str) -> tuple[list[dict[str, str]], int, int, i
     fix_tokens_code = 0
     try:
         translator = argos_translate.get_translation_from_codes(args.src, args.dst)
+        if translator and translator.to_lang.code != args.dst:
+            raise SystemExit(
+                f"Argos model destination mismatch: expected {args.dst}, "
+                f"got {translator.to_lang.code}"
+            )
     except AttributeError:
         translator = None
     except Exception as e:
@@ -542,6 +547,11 @@ def _run_translation(args, root: str) -> tuple[list[dict[str, str]], int, int, i
             translator = argos_translate.get_translation_from_codes(
                 args.src, args.dst
             )
+            if translator and translator.to_lang.code != args.dst:
+                raise SystemExit(
+                    f"Argos model destination mismatch: expected {args.dst}, "
+                    f"got {translator.to_lang.code}"
+                )
         except AttributeError:
             translator = None
         except Exception as e:


### PR DESCRIPTION
## Summary
- ensure Argos translator matches requested destination language
- verify localization run directories align with recorded metrics

## Testing
- `pytest` *(fails: No Argos translation model for en->xx)*

------
https://chatgpt.com/codex/tasks/task_e_68ae388f9c34832d8a3f4fea6086c5b5