### PR TITLE
Run fix_tokens during translation

### DIFF
--- a/Docs/Localization.md
+++ b/Docs/Localization.md
@@ -196,7 +196,7 @@ python Tools/fix_tokens.py --check-only Resources/Localization/Messages/<Languag
 python Tools/fix_tokens.py Resources/Localization/Messages/<Language>.json
 ```
 
-Run the check-only mode first to fail fast if tokens were altered, then apply the fixes. Perform this validation after every translation pass and before committing changes.
+Run the check-only mode first to fail fast if tokens were altered, then apply the fixes. Perform this validation after every translation pass and before committing changes. The `localization_pipeline.py` script runs this step automatically with `--reorder` after each translation run.
 
 #### Lenient token checks
 
@@ -333,7 +333,9 @@ Language names correspond to the message file stems (``German.json`` → ``Germa
 The pipeline maps each name to its ISO code (for example, German → ``de``) and
 now verifies that translated strings contain words from that language. A run
 will fail if messages are produced in another language (e.g. Spanish text in
-German files).
+German files). After each translation run, `fix_tokens.py --reorder` executes
+automatically to restore placeholders and align their order with the English
+baseline, recording token restoration and reordering metrics per language.
 
 Override the output paths for aggregate metrics and skipped hashes with
 `--metrics-file` and `--skipped-file` (defaults are `localization_metrics.json`

--- a/Tools/tests/test_localization_pipeline_metrics.py
+++ b/Tools/tests/test_localization_pipeline_metrics.py
@@ -1,0 +1,60 @@
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import localization_pipeline
+
+
+def _setup_repo(tmp_path):
+    root = tmp_path
+    messages_dir = root / "Resources" / "Localization" / "Messages"
+    messages_dir.mkdir(parents=True)
+    english_path = messages_dir / "English.json"
+    english_path.write_text(json.dumps({"Messages": {"hash": "Hello"}}))
+    (messages_dir / "French.json").write_text(
+        json.dumps({"Messages": {"hash": "Bonjour"}})
+    )
+    return root, messages_dir, english_path
+
+
+def test_token_metrics_collected(tmp_path, monkeypatch):
+    root, messages_dir, english_path = _setup_repo(tmp_path)
+    monkeypatch.setattr(localization_pipeline, "ROOT", root)
+    monkeypatch.setattr(localization_pipeline, "MESSAGES_DIR", messages_dir)
+    monkeypatch.setattr(localization_pipeline, "ENGLISH_PATH", english_path)
+    monkeypatch.setattr(localization_pipeline, "LANGUAGE_CODES", {"French": "fr"})
+    monkeypatch.setattr(sys, "argv", ["localization_pipeline.py"])
+
+    def fake_run(cmd, *, check=True, logger):
+        if any("translate_argos.py" in c for c in cmd):
+            run_dir = Path(cmd[cmd.index("--run-dir") + 1])
+            run_dir.mkdir(parents=True, exist_ok=True)
+            (run_dir / "skipped.csv").write_text("hash,english,reason,category\n")
+            target = cmd[cmd.index("Tools/translate_argos.py") + 1]
+            (run_dir / "metrics.json").write_text(json.dumps({"file": target}))
+        elif any("fix_tokens.py" in c for c in cmd):
+            metrics_file = Path(cmd[cmd.index("--metrics-file") + 1])
+            metrics_file.write_text(
+                json.dumps(
+                    {
+                        "tokens_restored": 1,
+                        "tokens_reordered": 2,
+                        "token_mismatches": 0,
+                    }
+                )
+            )
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(localization_pipeline, "run", fake_run)
+
+    localization_pipeline.main()
+
+    metrics = json.loads((root / "localization_metrics.json").read_text())
+    lang = metrics["languages"]["French"]
+    assert lang["token_fix"]["tokens_restored"] == 1
+    assert lang["token_fix"]["tokens_reordered"] == 2
+    totals = metrics["steps"]["token_fix"]["totals"]
+    assert totals["tokens_restored"] == 1
+    assert totals["tokens_reordered"] == 2


### PR DESCRIPTION
## Summary
- Run `fix_tokens.py --reorder` after each `translate_argos.py` invocation in the localization pipeline
- Capture token restoration metrics with a new test covering `tokens_restored` and `tokens_reordered`
- Document automatic token fixing in the localization guide

## Testing
- `pytest Tools/test_localization_pipeline_metrics.py -q`
- `pytest Tools/tests/test_localization_pipeline_metrics.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ae805585cc832d80794da6ef3ac193