### PR TITLE
feat: track token mismatch details

### DIFF
--- a/Tools/analyze_skip_report.py
+++ b/Tools/analyze_skip_report.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import csv
+import json
 import sys
 from collections import Counter
 from pathlib import Path
@@ -23,11 +24,31 @@ def summarize_report(path: Path) -> Counter[str]:
     return counts
 
 
+def summarize_mismatches(path: Path) -> Counter[str]:
+    """Return counts of mismatch patterns from `path` if it exists."""
+    counts: Counter[str] = Counter()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return counts
+    for entry in data:
+        missing = ",".join(sorted(entry.get("missing") or [])) or "-"
+        extra = ",".join(sorted(entry.get("extra") or [])) or "-"
+        key = f"missing:{missing}|extra:{extra}"
+        counts[key] += 1
+    return counts
+
+
 def main() -> None:
     ap = argparse.ArgumentParser(
         description="Group skipped rows by category and print counts",
     )
     ap.add_argument("report", type=Path, help="Path to skipped.csv report")
+    ap.add_argument(
+        "--mismatches",
+        type=Path,
+        help="Path to token_mismatches.json (defaults to sibling of report)",
+    )
     args = ap.parse_args()
 
     report_path = args.report
@@ -40,8 +61,15 @@ def main() -> None:
         print(f"Report not found: {report_path}", file=sys.stderr)
         sys.exit(1)
 
+    mismatch_path = args.mismatches or report_path.with_name("token_mismatches.json")
+    mismatch_counts = summarize_mismatches(mismatch_path)
+
     for category, count in sorted(counts.items()):
         print(f"{category}: {count}")
+    if mismatch_counts:
+        print("Token mismatch patterns:")
+        for pattern, count in sorted(mismatch_counts.items()):
+            print(f"  {pattern}: {count}")
 
     sys.exit(0)
 

--- a/Tools/fix_tokens.py
+++ b/Tools/fix_tokens.py
@@ -234,6 +234,10 @@ def main() -> None:
     )
     ap.set_defaults(reorder=True)
     ap.add_argument("--metrics-file", help="Write JSON metrics to this path")
+    ap.add_argument(
+        "--mismatches-file",
+        help="Write token mismatch details to this JSON path",
+    )
     ap.add_argument("--baseline-file", default="Resources/Localization/Messages/English.json", help="Baseline English messages file")
     ap.add_argument("--log-level", default="INFO", help="Logging level (default: INFO)")
     ap.add_argument("paths", nargs="*", help="Specific localization JSON files to process")
@@ -312,6 +316,12 @@ def main() -> None:
         existing.append(entry)
         with open(metrics_path, "w", encoding="utf-8") as f:
             json.dump(existing, f, indent=2)
+
+    if args.mismatches_file:
+        mismatches_path = Path(args.mismatches_file).resolve()
+        mismatches_path.parent.mkdir(parents=True, exist_ok=True)
+        with mismatches_path.open("w", encoding="utf-8") as fp:
+            json.dump(all_mismatches, fp, indent=2, ensure_ascii=False)
 
     if totals.token_mismatches:
         msg = f"{totals.token_mismatches} token mismatches detected"

--- a/Tools/test_analyze_skip_report.py
+++ b/Tools/test_analyze_skip_report.py
@@ -1,4 +1,5 @@
 import csv
+import json
 from collections import Counter
 import sys
 from pathlib import Path
@@ -20,13 +21,33 @@ def test_summarize_report(tmp_path):
     assert counts == Counter({"identical": 2, "token_mismatch": 1, "unknown": 1})
 
 
+def test_summarize_mismatches(tmp_path):
+    path = tmp_path / "token_mismatches.json"
+    data = [
+        {"file": "a", "key": "k", "missing": ["[[TOKEN_1]]"], "extra": []},
+        {"file": "b", "key": "k", "missing": ["[[TOKEN_1]]"], "extra": []},
+        {"file": "c", "key": "k", "missing": [], "extra": ["[[TOKEN_2]]"]},
+    ]
+    path.write_text(json.dumps(data), encoding="utf-8")
+    counts = asr.summarize_mismatches(path)
+    assert counts == Counter({
+        "missing:[[TOKEN_1]]|extra:-": 2,
+        "missing:-|extra:[[TOKEN_2]]": 1,
+    })
+
+
 def test_main_cli(tmp_path, monkeypatch, capsys):
     report = tmp_path / "skipped.csv"
     report.write_text("hash,english,reason,category\n1,a,r,identical\n", encoding="utf-8")
+    mismatch = tmp_path / "token_mismatches.json"
+    mismatch.write_text(
+        json.dumps([{ "file": "f", "key": "k", "missing": ["[[TOKEN_1]]"], "extra": [] }]),
+        encoding="utf-8",
+    )
     monkeypatch.setattr(sys, "argv", ["analyze_skip_report.py", str(report)])
     with pytest.raises(SystemExit) as exc:
         asr.main()
     assert exc.value.code == 0
     captured = capsys.readouterr().out.strip().splitlines()
-    assert captured == ["identical: 1"]
+    assert captured == ["identical: 1", "Token mismatch patterns:", "  missing:[[TOKEN_1]]|extra:-: 1"]
 


### PR DESCRIPTION
## Summary
- write token mismatch details to a new JSON report in fix_tokens
- analyze skip reports alongside token mismatch patterns
- surface token mismatch report in validate_translation_run output

## Testing
- `pytest Tools/test_analyze_skip_report.py Tools/test_validate_translation_run.py`
- `pytest Tools/test_fix_tokens.py`
- `python Tools/validate_translation_run.py --run-dir "$tmpdir"`


------
https://chatgpt.com/codex/tasks/task_e_68ae8b17fe4c832d8b390c0bdd7380c9