### PR TITLE
doc: describe token mismatch reporting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,8 +52,8 @@ Current PRDs and task lists are stored in `.project-management/current-prd/`, wh
    Outputs are written to `translations/<iso-code>/<timestamp>/` (override with `--run-dir`). Verify the Argos model is installed before running translations: `argos-translate --from en --to tr - < /dev/null` (substitute the target code for `tr`).
    `--log-level` helps pinpoint skipped or untranslated strings. Any hashes listed in `skipped.csv` within the run directory must be manually translated and the script re‑run to confirm they are handled.
 4. **Fix tokens after manual translation.**
-   `python Tools/fix_tokens.py Resources/Localization/Messages/Turkish.json`
-   Run with `--check-only` (`python Tools/fix_tokens.py --check-only`) to fail fast if tokens were altered. After fixing tokens, re‑run the translator to ensure no hashes remain in `skipped.csv`.
+   `python Tools/fix_tokens.py Resources/Localization/Messages/Turkish.json --mismatches-file translations/tr/<timestamp>/token_mismatches.json`
+   Run with `--check-only` (`python Tools/fix_tokens.py --check-only`) to fail fast if tokens were altered. Review `token_mismatches.json` with `python Tools/analyze_skip_report.py translations/tr/<timestamp>/skipped.csv` before proceeding. After fixing tokens, re‑run the translator to ensure no hashes remain in `skipped.csv`.
 5. **Verify translations.**
    `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations --show-text`
    This ensures every hash is present and no English text remains.

--- a/Docs/Localization.md
+++ b/Docs/Localization.md
@@ -102,6 +102,13 @@ Argos models are stored under `Resources/Localization/Models/<LANG>` as split ar
 
    Any hashes listed in `skipped.csv` within the run directory must be
    translated manually. Re-run the translator until the file is empty.
+   After translating, capture placeholder issues alongside the skip
+   report:
+
+   ```bash
+   python Tools/fix_tokens.py Resources/Localization/Messages/<Language>.json --mismatches-file translations/<iso-code>/<timestamp>/token_mismatches.json
+   ```
+
    Summarise each run and fail fast on unresolved issues:
 
    ```bash
@@ -111,15 +118,19 @@ Argos models are stored under `Resources/Localization/Models/<LANG>` as split ar
    The script reports how many entries were translated or skipped and
    exits non-zero when any `token_mismatch` or `sentinel` problems remain.
 
-   To review skip categories at a glance, run:
+   To review skip categories and recurring token mismatch patterns at a glance, run:
 
    ```bash
    python Tools/analyze_skip_report.py translations/<iso-code>/<timestamp>/skipped.csv
    ```
 
-   This prints the number of rows per category so manual fixes can be prioritised.
+   The script prints the number of rows per category and also consumes
+   `token_mismatches.json` (if present) to highlight repeated
+   placeholder mismatch patterns.
 
-   Do not commit translations until `skipped.csv` is empty and `python Tools/fix_tokens.py --check-only` reports no token mismatches, confirming placeholder counts match the English file.
+   Do not commit translations until `skipped.csv` is empty and
+   `python Tools/fix_tokens.py --check-only` reports no token mismatches,
+   confirming placeholder counts match the English file.
 
    To extract hashes that were skipped due to token mismatches, scan the
    translation log:

--- a/README.md
+++ b/README.md
@@ -814,10 +814,16 @@ This process applies only to files under `Resources/Localization/Messages`.
    Reassemble the split Argos model and install it before running the translator (see [Docs/Localization.md](Docs/Localization.md#automated-translation-for-messages) or [model directories](#model-directories)).
    `python Tools/translate_argos.py Resources/Localization/Messages/<Language>.json --to <iso-code> --batch-size 100 --max-retries 3 --log-level INFO --overwrite`
    Outputs are saved under `translations/<iso-code>/<timestamp>/` (override with `--run-dir`). Verify the model is installed: `argos-translate --from en --to tr - < /dev/null` (replace `tr` with the target code). Any hashes listed in `skipped.csv` within the run directory must be manually translated and the script re-run to confirm they are handled.
-   Summarise skip categories to prioritise fixes:
+   Record token mismatch details alongside the skip report:
 
    ```bash
-   python Tools/analyze_skip_report.py translations/<iso-code>/<timestamp>/skipped.csv
+   python Tools/fix_tokens.py Resources/Localization/Messages/<Language>.json --mismatches-file translations/<iso-code>/<timestamp>/token_mismatches.json
+   ```
+
+   Summarise skip categories and recurring placeholder mismatch patterns to prioritise fixes:
+
+   ```bash
+   python Tools/analyze_skip_report.py translations/<iso-code>/<timestamp>/skipped.csv --mismatches translations/<iso-code>/<timestamp>/token_mismatches.json
    ```
 4. **Check and fix tokens.**
    ```bash


### PR DESCRIPTION
## Summary
- document how to capture token mismatch details via `fix_tokens.py --mismatches-file` and review them with `analyze_skip_report.py`
- note new token mismatch report in localization workflow
- update AGENTS workflow to remind contributors to review `token_mismatches.json`

## Testing
- `python Tools/fix_tokens.py Resources/Localization/Messages/German.json --mismatches-file translations/de/20250827-004305/token_mismatches.json --allow-mismatch`
- `python Tools/analyze_skip_report.py translations/de/20250827-004305/skipped.csv`
- `pytest Tools/test_analyze_skip_report.py`
- `pytest Tools/test_fix_tokens.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae8e0f346c832db86166cbcea30ba9