### PR TITLE
Consolidate translation summaries

### DIFF
--- a/Tools/test_translate_argos.py
+++ b/Tools/test_translate_argos.py
@@ -204,7 +204,8 @@ def test_summary_and_success_logged_at_info(tmp_path, monkeypatch, caplog):
     info_msgs = [rec.message for rec in caplog.records if rec.levelname == "INFO"]
     assert any("Processed" in m for m in info_msgs)
     assert any("Report breakdown" in m for m in info_msgs)
-    assert any("Summary:" in m for m in info_msgs)
+    summary_msgs = [m for m in info_msgs if m.startswith("Summary:")]
+    assert summary_msgs == ["Summary: 1/1 translated, 0 skipped"]
     assert any("Wrote translations to" in m for m in info_msgs)
 
     warn_msgs = [rec.message for rec in caplog.records if rec.levelname == "WARNING"]


### PR DESCRIPTION
## Summary
- Aggregate initial and retry translation metrics, emitting a single summary line after all attempts.
- Ensure translation handles token-only messages directly instead of skipping them.
- Update unit tests for the consolidated summary output.

## Testing
- `pytest Tools/test_translate_argos.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af3dd17740832da6de7ad98ca372b9