### PR TITLE
feat: summarize top missing tokens

### DIFF
--- a/Tools/summarize_token_stats.py
+++ b/Tools/summarize_token_stats.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import csv
 import json
+from collections import Counter
 from pathlib import Path
 from typing import Dict, List, Tuple
 
@@ -26,14 +27,21 @@ def _load_metrics(path: Path) -> List[dict]:
         return []
 
 
-def _aggregate(entries: List[dict]) -> Dict[str, Dict[str, int | str]]:
+def _aggregate(entries: List[dict]) -> Tuple[Dict[str, Dict[str, int | str]], Dict[str, int]]:
     stats: Dict[str, Dict[str, int | str]] = {}
+    token_counts: Counter[str] = Counter()
     for entry in entries:
         file = entry.get("file", "")
         failures = entry.get("failures", {})
+        mismatch_details = entry.get("token_mismatch_details", {})
         for hash_id, info in entry.get("hash_stats", {}).items():
             mismatch = info.get("original_tokens") != info.get("translated_tokens")
             if hash_id in failures:
+                mismatch = True
+            details = mismatch_details.get(hash_id, {})
+            missing = details.get("missing") or info.get("missing") or []
+            extra = details.get("extra") or info.get("extra") or []
+            if missing or extra:
                 mismatch = True
             reordered = bool(info.get("reordered"))
             if mismatch or reordered:
@@ -43,7 +51,9 @@ def _aggregate(entries: List[dict]) -> Dict[str, Dict[str, int | str]]:
                 if reordered:
                     record["reorders"] += 1
                 record["file"] = file
-    return stats
+            for token in missing:
+                token_counts[str(token)] += 1
+    return stats, dict(token_counts)
 
 
 def _sort_rows(stats: Dict[str, Dict[str, int | str]]) -> List[Tuple[str, int, int, str]]:
@@ -74,6 +84,30 @@ def _write_csv(rows: List[Tuple[str, int, int, str]], path: Path) -> None:
             writer.writerow(row)
 
 
+def _sort_token_rows(token_counts: Dict[str, int]) -> List[Tuple[str, int]]:
+    rows = sorted(token_counts.items(), key=lambda r: (-r[1], r[0]))
+    return rows
+
+
+def _print_token_table(rows: List[Tuple[str, int]]) -> None:
+    if not rows:
+        return
+    header = ("token", "count")
+    widths = [max(len(str(x)) for x in col) for col in zip(*(rows + [header]))]
+    fmt = "{:<%d} {:>%d}" % tuple(widths)
+    print(fmt.format(*header))
+    for row in rows:
+        print(fmt.format(*row))
+
+
+def _write_token_csv(rows: List[Tuple[str, int]], path: Path) -> None:
+    with path.open("w", newline="", encoding="utf-8") as fp:
+        writer = csv.writer(fp)
+        writer.writerow(["token", "count"])
+        for row in rows:
+            writer.writerow(row)
+
+
 def main() -> None:
     ap = argparse.ArgumentParser(description="Summarize token stats from metrics.json")
     ap.add_argument(
@@ -92,6 +126,11 @@ def main() -> None:
         help="Optional CSV output file",
     )
     ap.add_argument(
+        "--token-csv",
+        type=Path,
+        help="Optional CSV output for top missing tokens",
+    )
+    ap.add_argument(
         "--top",
         type=int,
         default=0,
@@ -105,13 +144,21 @@ def main() -> None:
     if metrics_path is None:
         metrics_path = ROOT / "metrics.json"
     entries = _load_metrics(metrics_path)
-    stats = _aggregate(entries)
+    stats, token_counts = _aggregate(entries)
     rows = _sort_rows(stats)
+    token_rows = _sort_token_rows(token_counts)
     if args.top and args.top > 0:
         rows = rows[: args.top]
+        token_rows = token_rows[: args.top]
 
     if args.csv:
         _write_csv(rows, args.csv)
+    if args.token_csv:
+        _write_token_csv(token_rows, args.token_csv)
+    if token_rows:
+        print("Top missing tokens:")
+        _print_token_table(token_rows)
+        print()
     _print_table(rows)
 
 

--- a/Tools/test_summarize_token_stats.py
+++ b/Tools/test_summarize_token_stats.py
@@ -13,12 +13,7 @@ def test_aggregate():
                 "1": {"original_tokens": 1, "translated_tokens": 0, "reordered": False},
                 "2": {"original_tokens": 1, "translated_tokens": 1, "reordered": True},
             },
-            "run_id": "1",
-            "log_file": "log",
-            "report_file": "report",
-            "metrics_file": "metrics",
-            "python_version": "3",
-            "argos_version": "1",
+            "token_mismatch_details": {"1": {"missing": ["4"], "extra": []}},
         },
         {
             "file": "b.json",
@@ -26,37 +21,54 @@ def test_aggregate():
             "hash_stats": {
                 "2": {"original_tokens": 1, "translated_tokens": 1, "reordered": False}
             },
-            "run_id": "2",
-            "python_version": "3",
+            "token_mismatch_details": {"2": {"missing": ["4", "5"], "extra": []}},
         },
     ]
-    stats = sts._aggregate(entries)
+    stats, token_counts = sts._aggregate(entries)
     assert stats == {
         "1": {"mismatches": 1, "reorders": 0, "file": "a.json"},
-        "2": {"mismatches": 0, "reorders": 1, "file": "a.json"},
+        "2": {"mismatches": 1, "reorders": 1, "file": "b.json"},
     }
+    assert token_counts == {"4": 2, "5": 1}
 
 
 def test_run_dir_cli(tmp_path, monkeypatch, capsys):
     metrics = tmp_path / "metrics.json"
     metrics.write_text(
-        json.dumps([
-            {
-                "file": "a.json",
-                "failures": {"1": "token mismatch"},
-                "hash_stats": {
-                    "1": {
-                        "original_tokens": 1,
-                        "translated_tokens": 0,
-                        "reordered": False,
-                    }
-                },
-            }
-        ])
+        json.dumps(
+            [
+                {
+                    "file": "a.json",
+                    "failures": {},
+                    "hash_stats": {
+                        "1": {
+                            "original_tokens": 1,
+                            "translated_tokens": 0,
+                            "reordered": False,
+                        }
+                    },
+                    "token_mismatch_details": {
+                        "1": {"missing": ["4"], "extra": []}
+                    },
+                }
+            ]
+        )
     )
+    token_csv = tmp_path / "tokens.csv"
     monkeypatch.setattr(
-        sys, "argv", ["summarize_token_stats.py", "--run-dir", str(tmp_path)]
+        sys,
+        "argv",
+        [
+            "summarize_token_stats.py",
+            "--run-dir",
+            str(tmp_path),
+            "--token-csv",
+            str(token_csv),
+        ],
     )
     sts.main()
     out = capsys.readouterr().out
+    assert out.splitlines()[0] == "Top missing tokens:"
     assert "hash" in out
+    assert token_csv.exists()
+    assert token_csv.read_text().strip().splitlines()[1] == "4,1"


### PR DESCRIPTION
## Summary
- handle missing and extra token lists while aggregating token statistics
- report and optionally export top missing tokens across runs
- cover missing token summary via tests

## Testing
- `pytest Tools/test_summarize_token_stats.py::test_aggregate -q`
- `pytest Tools/test_summarize_token_stats.py::test_run_dir_cli -q`
- `pytest Tools/test_summarize_token_stats.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af53618de0832d8d8092812ec26f50