### PR TITLE
feat: record retry metrics

### DIFF
--- a/Tools/validate_translation_run.py
+++ b/Tools/validate_translation_run.py
@@ -112,6 +112,23 @@ def main() -> None:
     if mismatch_path.exists():
         print(f"Token mismatch report: {mismatch_count} entries")
 
+    metrics_path = run_dir / "metrics.json"
+    try:
+        metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        metrics = []
+    if metrics:
+        entry = metrics[-1] if isinstance(metrics, list) else metrics
+        token_reorders = entry.get("token_reorders", 0)
+        token_mismatches = entry.get("token_mismatches", 0)
+        retry_attempts = entry.get("retry_attempts", 0)
+        retry_successes = entry.get("retry_successes", 0)
+        print(
+            "Metrics summary: "
+            f"{token_reorders} token reorders, {token_mismatches} token mismatches, "
+            f"{retry_attempts} retry attempts, {retry_successes} retry successes"
+        )
+
     def has_mismatch(counter: Counter[str]) -> bool:
         return any("token_mismatch" in k or "sentinel" in k for k in counter)
 


### PR DESCRIPTION
## Summary
- support new translate_argos CLI flags and auto-select target language file
- record retry statistics in metrics for translate_argos
- surface metrics summary in validate_translation_run

## Testing
- `pytest Tools/test_translate_argos_retry.py Tools/test_validate_translation_run.py -q`
- `python Tools/translate_argos.py --src en --tgt de --retry-mismatches --overwrite --out-dir translations/de/20250827-195029-retry --hash 2007397999 --hash 3729714988 --log-level INFO`
- `python Tools/validate_translation_run.py --run-dir translations/de/20250827-195029-retry`
- `python Tools/summarize_token_stats.py --run-dir translations/de/20250827-004305 --token-csv /tmp/old_tokens.csv`
- `python Tools/summarize_token_stats.py --run-dir translations/de/20250827-195029-retry --token-csv /tmp/new_tokens.csv`


------
https://chatgpt.com/codex/tasks/task_e_68af5fa8750c832d99fc4e756c6fc207