### PR TITLE
Handle dropped token placeholders

### DIFF
--- a/Tools/fix_tokens.py
+++ b/Tools/fix_tokens.py
@@ -32,6 +32,8 @@ def replace_placeholders(
             parts.append(token)
             last = m.end()
         parts.append(value[last:])
+        if len(tokens) > len(matches):
+            parts.extend(tokens[len(matches):])
         value = "".join(parts)
         replaced = True
     value = value.replace('\\"', '"').replace("\\'", "'")

--- a/Tools/test_fix_tokens.py
+++ b/Tools/test_fix_tokens.py
@@ -82,6 +82,31 @@ def test_replace_placeholders_with_various_tokens():
     assert replaced and not mismatch and not missing and not extra
 
 
+def test_replace_placeholders_restores_missing_token4_and_token5():
+    tokens = ["<a>", "</a>", "<b>", "</b>", "<c>", "</c>"]
+    value = " ".join(f"[[TOKEN_{i}]]" for i in range(4))
+    new_value, replaced, mismatch, missing, extra = fix_tokens.replace_placeholders(
+        value, tokens
+    )
+    assert new_value.replace(" ", "") == "<a></a><b></b><c></c>"
+    assert replaced and not mismatch and not missing and not extra
+
+
+def test_replace_placeholders_restores_missing_token4():
+    tokens = ["<a>", "</a>", "<b>", "</b>", "<c>", "</c>"]
+    value = " ".join(["[[TOKEN_0]]", "[[TOKEN_1]]", "[[TOKEN_2]]", "[[TOKEN_3]]", "[[TOKEN_5]]"])
+    new_value, replaced, mismatch, missing, extra = fix_tokens.replace_placeholders(
+        value, tokens
+    )
+    assert new_value.replace(" ", "") == "<a></a><b></b><c></c>"
+    assert replaced and not mismatch and not missing and not extra
+
+
+def test_normalize_tokens_single_bracket_forms():
+    assert translate_argos.normalize_tokens("[TOKEN_4]") == "[[TOKEN_4]]"
+    assert translate_argos.normalize_tokens("[token_5]") == "[[TOKEN_5]]"
+
+
 def test_normalization_merges_split_tokens(tmp_path, monkeypatch):
     root = tmp_path
     messages_dir = root / "Resources" / "Localization" / "Messages"

--- a/Tools/translate_argos.py
+++ b/Tools/translate_argos.py
@@ -205,6 +205,9 @@ def normalize_tokens(text: str) -> str:
         flags=re.I,
     )
 
+    # Normalise single-bracket forms like ``[TOKEN_4]``.
+    text = TOKEN_CLEAN.sub(lambda m: to_token(m.group(1)), text)
+
     # Catch bare ``TOKEN_x`` words and rewrite them to placeholder form.
     text = TOKEN_WORD.sub(lambda m: to_token(m.group(1)), text)
 


### PR DESCRIPTION
## Summary
- Ensure `fix_tokens` restores trailing placeholders, preserving tokens 4 and 5
- Normalize single-bracket token forms in `translate_argos`
- Add regression tests for Argos runs missing `[[TOKEN_4]]` or `[[TOKEN_5]]`

## Testing
- `pytest Tools/test_fix_tokens.py`


------
https://chatgpt.com/codex/tasks/task_e_68af66899fcc832d8dda0a53a1966bd3