### PR TITLE
Guard against empty translation runs

### DIFF
--- a/Tools/translate_argos.py
+++ b/Tools/translate_argos.py
@@ -615,7 +615,7 @@ def _run_translation(args, root: str) -> tuple[list[dict[str, str]], int, int, i
 
     if not to_translate:
         logger.info("No messages need translation.")
-        return
+        return [], 0, 0, 0, 0, 0
 
     safe_lines: List[str] = []
     tokens_list: List[tuple[dict[str, str], bool]] = []
@@ -1946,6 +1946,13 @@ def main():
                     logger.info("Category counts: %s", dict(counts))
             except Exception:
                 logger.exception("Failed to write skip report")
+
+        if processed_total == 0:
+            msg = "No messages processed; verify input hashes and Argos model."
+            logger.error(msg)
+            exit_code = exit_code or 1
+            if not exit_msg:
+                exit_msg = msg
 
         summary_line = (
             f"Summary: {translated_total}/{processed_total} translated, {unresolved_total} skipped"


### PR DESCRIPTION
## Summary
- ensure `translate_argos.py` exits with an error when no messages are processed
- add regression test covering failure on empty translation run

## Testing
- `pytest Tools/test_translate_argos.py Tools/test_validate_translation_run.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68af9635a20c832daf481eb7d523f354