### PR TITLE
Persist skip report on interrupt and add SIGINT integration test

### DIFF
--- a/Tools/test_translate_argos_integration.py
+++ b/Tools/test_translate_argos_integration.py
@@ -208,3 +208,77 @@ translate_argos.main()
     assert completed.returncode != 0
 
     assert not report_path.exists()
+
+
+def test_report_and_metrics_written_on_sigint(tmp_path):
+    root = tmp_path
+    messages_dir = root / "Resources" / "Localization" / "Messages"
+    messages_dir.mkdir(parents=True)
+    english = {"Messages": {f"h{i}": f"Line {i}" for i in range(3)}}
+    (messages_dir / "English.json").write_text(json.dumps(english))
+
+    target_rel = "Resources/Localization/Messages/Test.json"
+    report_path = root / "skipped.csv"
+    metrics_path = root / "metrics.json"
+    tools_dir = Path(__file__).resolve().parent
+
+    script = textwrap.dedent(
+        f"""
+import os, sys, signal
+sys.path.insert(0, {str(tools_dir)!r})
+import translate_argos
+
+class DummyTranslator:
+    def translate(self, text):
+        return text
+
+class DummyCompleted:
+    def __init__(self, code=0):
+        self.returncode = code
+
+translate_argos.argos_translate.get_translation_from_codes = lambda s, d: DummyTranslator()
+translate_argos.argos_translate.load_installed_languages = lambda: None
+translate_argos.subprocess.run = lambda *a, **k: DummyCompleted()
+translate_argos.contains_english = lambda s: False
+
+original_unprotect = translate_argos.unprotect
+call_count = 0
+
+def killer(text, tokens):
+    global call_count
+    call_count += 1
+    if call_count == 2:
+        os.kill(os.getpid(), signal.SIGINT)
+    return original_unprotect(text, tokens)
+
+translate_argos.unprotect = killer
+
+sys.argv = [
+    "translate_argos.py",
+    {target_rel!r},
+    "--to",
+    "xx",
+    "--root",
+    {str(root)!r},
+    "--batch-size",
+    "2",
+    "--report-file",
+    {str(report_path)!r},
+    "--metrics-file",
+    {str(metrics_path)!r},
+    "--overwrite",
+]
+
+translate_argos.main()
+"""
+    )
+
+    runner = root / "runner.py"
+    runner.write_text(script)
+    completed = subprocess.run([sys.executable, str(runner)], cwd=root)
+    assert completed.returncode != 0
+
+    assert report_path.exists()
+    assert metrics_path.exists()
+    data = json.loads(metrics_path.read_text())
+    assert data[-1]["status"] == "interrupted"


### PR DESCRIPTION
## Summary
- ensure `translate_argos` writes `skipped.csv` and metrics on SIGINT/SIGTERM
- flush partial translations to disk before exiting
- add integration test verifying skipped report and metrics after SIGINT

## Testing
- `pytest Tools/test_translate_argos_integration.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af9a222f44832da155c62b16bbd0c4