### PR TITLE
Validate Argos model presence before translation

### DIFF
--- a/Tools/test_translate_argos.py
+++ b/Tools/test_translate_argos.py
@@ -38,6 +38,19 @@ def test_raises_when_segments_present_without_model():
         assert "cd Resources/Localization/Models/xx" in str(err.value)
 
 
+def test_raises_when_model_missing(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        translate_argos.argos_translate,
+        "get_translation_from_codes",
+        lambda src, dst: None,
+    )
+    with pytest.raises(RuntimeError) as err:
+        ensure_model_installed(str(tmp_path), "xx")
+    msg = str(err.value)
+    assert "Reassemble or install the model" in msg
+    assert "Resources/Localization/Models/xx" in msg
+
+
 def test_run_dir_creates_outputs(tmp_path, monkeypatch):
     root = tmp_path
     messages_dir = root / "Resources" / "Localization" / "Messages"


### PR DESCRIPTION
## Summary
- Verify Argos models are installed by checking `argos_translate.get_translation_from_codes('en', dst)` and provide guidance for reassembling or installing missing models.
- Add unit test for missing Argos model to ensure informative error is raised.

## Testing
- `./.venv/bin/pytest Tools/test_translate_argos.py::test_raises_when_model_missing Tools/test_translate_argos.py::test_raises_when_segments_present_without_model -q`


------
https://chatgpt.com/codex/tasks/task_e_68afab7496dc832d9599a6e422ef51ce