### PR TITLE
Record localization command durations

### DIFF
--- a/Tools/localization_pipeline.py
+++ b/Tools/localization_pipeline.py
@@ -16,6 +16,7 @@ import logging
 import subprocess
 import sys
 import signal
+import time
 import language_utils
 from datetime import datetime, timezone
 from pathlib import Path
@@ -55,10 +56,16 @@ def timestamp() -> str:
     """Return the current UTC time in ISO format."""
     return datetime.now(timezone.utc).isoformat()
 
-def run(cmd: list[str], *, check: bool = True, logger: logging.Logger) -> subprocess.CompletedProcess:
-    """Run a subprocess, returning the completed process."""
+def run(
+    cmd: list[str], *, check: bool = True, logger: logging.Logger
+) -> tuple[subprocess.CompletedProcess, float]:
+    """Run a subprocess, returning the completed process and duration."""
     logger.debug("+ %s", " ".join(str(c) for c in cmd))
-    return subprocess.run(cmd, check=check, cwd=ROOT)
+    start = time.monotonic()
+    proc = subprocess.run(cmd, check=check, cwd=ROOT)
+    duration = time.monotonic() - start
+    logger.debug("Command finished in %.2f seconds", duration)
+    return proc, duration
 
 def propagate_hashes(target: Path) -> None:
     """Copy new hashes from English into ``target`` while preserving translations."""
@@ -179,7 +186,7 @@ def main() -> None:
             t_start = timestamp()
             run_dir = ROOT / "translations" / code / datetime.now().strftime("%Y%m%d-%H%M%S")
             run_dirs.append(run_dir)
-            result = run(
+            result, duration = run(
                 [
                     sys.executable,
                     "Tools/translate_argos.py",
@@ -221,6 +228,7 @@ def main() -> None:
             lang_metrics["translation"] = {
                 "start": t_start,
                 "end": t_end,
+                "duration": duration,
                 "returncode": result.returncode,
             }
             skipped_counts: Dict[str, int] = {}
@@ -246,7 +254,7 @@ def main() -> None:
                     mismatches,
                     code,
                 )
-            validate_proc = run(
+            validate_proc, _ = run(
                 [sys.executable, "Tools/validate_translation_run.py", "--run-dir", str(run_dir)],
                 check=False,
                 logger=logger,
@@ -256,7 +264,7 @@ def main() -> None:
             logger.info("Fixing tokens for %s", name)
             t_fix_start = timestamp()
             metrics_file = ROOT / f"fix_tokens_{name}.json"
-            fix_proc = run(
+            fix_proc, _ = run(
                 [
                     sys.executable,
                     "Tools/fix_tokens.py",
@@ -350,7 +358,7 @@ def main() -> None:
             overall_ok &= success
 
         logger.info("Analyzing translation logs")
-        analysis_proc = run(
+        analysis_proc, _ = run(
             [sys.executable, "Tools/analyze_translation_logs.py"],
             check=False,
             logger=logger,
@@ -363,7 +371,7 @@ def main() -> None:
 
         logger.info("Verifying translations")
         metrics["steps"]["verification"] = {"start": timestamp()}
-        verify_proc = run(
+        verify_proc, duration = run(
             [
                 "dotnet",
                 "run",
@@ -377,7 +385,7 @@ def main() -> None:
             logger=logger,
         )
         metrics["steps"]["verification"].update(
-            {"end": timestamp(), "returncode": verify_proc.returncode}
+            {"end": timestamp(), "duration": duration, "returncode": verify_proc.returncode}
         )
         overall_ok &= verify_proc.returncode == 0
 

--- a/Tools/test_localization_pipeline_metrics.py
+++ b/Tools/test_localization_pipeline_metrics.py
@@ -36,7 +36,7 @@ def test_metrics_written(tmp_path, monkeypatch):
             (run_dir / "skipped.csv").write_text("hash,english,reason,category\n")
             target = cmd[cmd.index("Tools/translate_argos.py") + 1]
             (run_dir / "metrics.json").write_text(json.dumps({"file": target}))
-        return SimpleNamespace(returncode=0)
+        return SimpleNamespace(returncode=0), 0.0
 
     monkeypatch.setattr(localization_pipeline, "run", fake_run)
 
@@ -53,6 +53,7 @@ def test_metrics_written(tmp_path, monkeypatch):
     assert "French" in metrics["languages"]
     lang = metrics["languages"]["French"]
     assert lang["translation"]["returncode"] == 0
+    assert lang["translation"]["duration"] == 0.0
     assert lang["token_fix"]["returncode"] == 0
     assert lang["token_fix"]["tokens_restored"] == 0
     assert lang["token_fix"]["tokens_reordered"] == 0
@@ -64,6 +65,7 @@ def test_metrics_written(tmp_path, monkeypatch):
         "tokens_reordered": 0,
         "token_mismatches": 0,
     }
+    assert metrics["steps"]["verification"]["duration"] == 0.0
 
 
 def test_exit_code_on_skipped(tmp_path, monkeypatch):
@@ -84,7 +86,7 @@ def test_exit_code_on_skipped(tmp_path, monkeypatch):
                 writer.writerow({"hash": "h", "english": "Hello", "reason": "timeout"})
             target = cmd[cmd.index("Tools/translate_argos.py") + 1]
             (run_dir / "metrics.json").write_text(json.dumps({"file": target}))
-        return SimpleNamespace(returncode=0)
+        return SimpleNamespace(returncode=0), 0.0
 
     monkeypatch.setattr(localization_pipeline, "run", fake_run)
 
@@ -125,7 +127,7 @@ def test_custom_output_paths(tmp_path, monkeypatch):
             (run_dir / "skipped.csv").write_text("hash,english,reason,category\n")
             target = cmd[cmd.index("Tools/translate_argos.py") + 1]
             (run_dir / "metrics.json").write_text(json.dumps({"file": target}))
-        return SimpleNamespace(returncode=0)
+        return SimpleNamespace(returncode=0), 0.0
 
     monkeypatch.setattr(localization_pipeline, "run", fake_run)
 
@@ -153,7 +155,7 @@ def test_language_mismatch_detection(tmp_path, monkeypatch):
             (run_dir / "skipped.csv").write_text("hash,english,reason,category\n")
             target = cmd[cmd.index("Tools/translate_argos.py") + 1]
             (run_dir / "metrics.json").write_text(json.dumps({"file": target}))
-        return SimpleNamespace(returncode=0)
+        return SimpleNamespace(returncode=0), 0.0
 
     monkeypatch.setattr(localization_pipeline, "run", fake_run)
 
@@ -185,7 +187,7 @@ def test_wrong_language_detected(tmp_path, monkeypatch):
             (run_dir / "skipped.csv").write_text("hash,english,reason,category\n")
             target = cmd[cmd.index("Tools/translate_argos.py") + 1]
             (run_dir / "metrics.json").write_text(json.dumps({"file": target}))
-        return SimpleNamespace(returncode=0)
+        return SimpleNamespace(returncode=0), 0.0
 
     monkeypatch.setattr(localization_pipeline, "run", fake_run)
 


### PR DESCRIPTION
## Summary
- track execution time in the localization pipeline's `run` helper
- persist translation and verification durations in generated metrics
- extend localization pipeline metrics tests to cover new durations

## Testing
- `pytest Tools/test_localization_pipeline_metrics.py`


------
https://chatgpt.com/codex/tasks/task_e_68afdf30286c832da8a63f143f77d7bd