### PR TITLE
Refine Turkish stopwords and allow English term

### DIFF
--- a/Tools/english_allowlist.txt
+++ b/Tools/english_allowlist.txt
@@ -10,3 +10,4 @@ PvP
 Steam
 Unity
 XP
+PvE

--- a/Tools/turkish_stopwords.txt
+++ b/Tools/turkish_stopwords.txt
@@ -1,5 +1,1 @@
-ve
-bir
-bu
 için
-de


### PR DESCRIPTION
## Summary
- remove overly generic Turkish stopwords to reduce false-positive language matches
- allow the term "PvE" in the English allowlist

## Testing
- `pytest Tools/test_language_utils.py`
- `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations --show-text`


------
https://chatgpt.com/codex/tasks/task_e_68b23010df10832da4b3d6ed19d3d79a