### PR TITLE
chore: update Korean localization

### DIFF
--- a/Resources/Localization/Messages/Korean.json
+++ b/Resources/Localization/Messages/Korean.json
@@ -422,6 +422,11 @@
     "3060695596": "Second unarmed slot set to <color=white>{0}</color> for <color=green>{1}</color>.",
     "3097011724": "Invalid class, use '<color=white>.class l</color>' to see options.",
     "3102592194": "적극적인 친밀감을 찾을 수 없습니다!",
-    "2844729307": "Your familiar has prestiged [<color=#90EE90>{prestigeLevel}</color>]; the accumulated knowledge allowed them to retain their level!"
+    "2844729307": "Your familiar has prestiged [<color=#90EE90>{prestigeLevel}</color>]; the accumulated knowledge allowed them to retain their level!",
+    "3002809107": "GUID {guidHash}를 사용한 프리팹!",
+    "2597161495": "hovered 법인 없음!",
+    "2660507905": "성 심장!",
+    "182159004": "Familiar 활동 없음!",
+    "2336012040": "이름 '{oldName}' 에 '{newName}'!"
   }
 }

--- a/fix_tokens_metrics.json
+++ b/fix_tokens_metrics.json
@@ -5432,5 +5432,527 @@
         ]
       }
     ]
+  },
+  {
+    "timestamp": "2025-08-30T19:24:44Z",
+    "tokens_restored": 0,
+    "tokens_reordered": 0,
+    "token_mismatches": 12,
+    "mismatches": [
+      {
+        "file": "Resources/Localization/Messages/Korean.json",
+        "key": "2007397999",
+        "missing": [],
+        "extra": [
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "<color=white>",
+          "{2}",
+          "{2}",
+          "{2}"
+        ]
+      },
+      {
+        "file": "Resources/Localization/Messages/Korean.json",
+        "key": "1407688215",
+        "missing": [],
+        "extra": [
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "<color=white>",
+          "{2}",
+          "{2}"
+        ]
+      },
+      {
+        "file": "Resources/Localization/Messages/Korean.json",
+        "key": "2712718738",
+        "missing": [],
+        "extra": [
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "{FamiliarPrestigeStats[value]}",
+          "{FamiliarPrestigeStats[value]}",
+          "{FamiliarPrestigeStats[value]}",
+          "{FamiliarPrestigeStats[value]}",
+          "{FamiliarPrestigeStats[value]}",
+          "{FamiliarPrestigeStats[value]}",
+          "{FamiliarPrestigeStats[value]}",
+          "{FamiliarPrestigeStats[value]}",
+          "{FamiliarPrestigeStats[value]}",
+          "{FamiliarPrestigeStats[value]}",
+          "{FamiliarPrestigeStats[value]}",
+          "{FamiliarPrestigeStats[value]}",
+          "{FamiliarPrestigeStats[value]}",
+          "{FamiliarPrestigeStats[value]}",
+          "{FamiliarPrestigeStats[value]}",
+          "{FamiliarPrestigeStats[value]}"
+        ]
+      },
+      {
+        "file": "Resources/Localization/Messages/Korean.json",
+        "key": "2402733055",
+        "missing": [],
+        "extra": [
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>"
+        ]
+      },
+      {
+        "file": "Resources/Localization/Messages/Korean.json",
+        "key": "3961332984",
+        "missing": [],
+        "extra": [
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>"
+        ]
+      },
+      {
+        "file": "Resources/Localization/Messages/Korean.json",
+        "key": "3343555659",
+        "missing": [],
+        "extra": [
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "<color=#90EE90>",
+          "{parsedPrestigeType}",
+          "{parsedPrestigeType}"
+        ]
+      },
+      {
+        "file": "Resources/Localization/Messages/Korean.json",
+        "key": "1440482998",
+        "missing": [],
+        "extra": [
+          "<color=green>",
+          "<color=green>",
+          "<color=green>",
+          "<color=green>",
+          "<color=green>",
+          "{playerInfo.User.CharacterName.Value}",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>"
+        ]
+      },
+      {
+        "file": "Resources/Localization/Messages/Korean.json",
+        "key": "3591926048",
+        "missing": [],
+        "extra": [
+          "</color>"
+        ]
+      },
+      {
+        "file": "Resources/Localization/Messages/Korean.json",
+        "key": "719993404",
+        "missing": [],
+        "extra": [
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "<color=white>"
+        ]
+      },
+      {
+        "file": "Resources/Localization/Messages/Korean.json",
+        "key": "3761416018",
+        "missing": [],
+        "extra": [
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "{playerInfo.User.CharacterName.Value}",
+          "{playerInfo.User.CharacterName.Value}",
+          "{playerInfo.User.CharacterName.Value}",
+          "{playerInfo.User.CharacterName.Value}",
+          "{playerInfo.User.CharacterName.Value}",
+          "{playerInfo.User.CharacterName.Value}",
+          "{playerInfo.User.CharacterName.Value}"
+        ]
+      },
+      {
+        "file": "Resources/Localization/Messages/Korean.json",
+        "key": "1826355702",
+        "missing": [],
+        "extra": [
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "{playerInfo.User.CharacterName.Value}",
+          "{playerInfo.User.CharacterName.Value}",
+          "{playerInfo.User.CharacterName.Value}",
+          "{playerInfo.User.CharacterName.Value}",
+          "{playerInfo.User.CharacterName.Value}",
+          "{playerInfo.User.CharacterName.Value}",
+          "{playerInfo.User.CharacterName.Value}"
+        ]
+      },
+      {
+        "file": "Resources/Localization/Messages/Korean.json",
+        "key": "3254231727",
+        "missing": [],
+        "extra": [
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>",
+          "</color>"
+        ]
+      }
+    ]
+  },
+  {
+    "timestamp": "2025-08-30T19:25:40Z",
+    "tokens_restored": 0,
+    "tokens_reordered": 0,
+    "token_mismatches": 11,
+    "mismatches": [
+      {
+        "file": "Resources/Localization/Messages/Korean.json",
+        "key": "3125006928",
+        "missing": [
+          "{FamiliarPrestigeStats[value]}",
+          "{value + 1}"
+        ],
+        "extra": [
+          "{0}",
+          "{1}"
+        ]
+      },
+      {
+        "file": "Resources/Localization/Messages/Korean.json",
+        "key": "705325693",
+        "missing": [
+          "[PrestigeStat]"
+        ],
+        "extra": []
+      },
+      {
+        "file": "Resources/Localization/Messages/Korean.json",
+        "key": "2712718738",
+        "missing": [
+          "{prestigeLevel}",
+          "{FamiliarPrestigeStats[value]}"
+        ],
+        "extra": [
+          "{0}",
+          "{1}"
+        ]
+      },
+      {
+        "file": "Resources/Localization/Messages/Korean.json",
+        "key": "11642316",
+        "missing": [
+          "{exoLevel}",
+          "{PrestigeTypeToMaxPrestiges[parsedPrestigeType]}",
+          "{(int)Shapeshifts.CalculateFormDuration(exoLevel)}"
+        ],
+        "extra": [
+          "{0}",
+          "{1}",
+          "{2}"
+        ]
+      },
+      {
+        "file": "Resources/Localization/Messages/Korean.json",
+        "key": "3468772905",
+        "missing": [
+          "{parsedPrestigeType}",
+          "{PrestigeTypeToMaxPrestiges[parsedPrestigeType]}"
+        ],
+        "extra": [
+          "{0}",
+          "{1}"
+        ]
+      },
+      {
+        "file": "Resources/Localization/Messages/Korean.json",
+        "key": "1066178325",
+        "missing": [
+          "[Name]"
+        ],
+        "extra": []
+      },
+      {
+        "file": "Resources/Localization/Messages/Korean.json",
+        "key": "54858227",
+        "missing": [
+          "{prestigeLevel}",
+          "{newXP.Key}",
+          "{FamiliarPrestigeStats[value]}"
+        ],
+        "extra": [
+          "{0}",
+          "{1}",
+          "{2}"
+        ]
+      },
+      {
+        "file": "Resources/Localization/Messages/Korean.json",
+        "key": "1081599663",
+        "missing": [
+          "[Name]"
+        ],
+        "extra": []
+      },
+      {
+        "file": "Resources/Localization/Messages/Korean.json",
+        "key": "2129553669",
+        "missing": [
+          "[PlayerName]"
+        ],
+        "extra": []
+      },
+      {
+        "file": "Resources/Localization/Messages/Korean.json",
+        "key": "20873033",
+        "missing": [
+          "[Class]"
+        ],
+        "extra": []
+      },
+      {
+        "file": "Resources/Localization/Messages/Korean.json",
+        "key": "4140406916",
+        "missing": [
+          "[Class]"
+        ],
+        "extra": []
+      }
+    ]
+  },
+  {
+    "timestamp": "2025-08-30T19:26:44Z",
+    "tokens_restored": 0,
+    "tokens_reordered": 0,
+    "token_mismatches": 11,
+    "mismatches": [
+      {
+        "file": "Resources/Localization/Messages/Korean.json",
+        "key": "3125006928",
+        "missing": [
+          "{FamiliarPrestigeStats[value]}",
+          "{value + 1}"
+        ],
+        "extra": [
+          "{0}",
+          "{1}"
+        ]
+      },
+      {
+        "file": "Resources/Localization/Messages/Korean.json",
+        "key": "705325693",
+        "missing": [
+          "[PrestigeStat]"
+        ],
+        "extra": []
+      },
+      {
+        "file": "Resources/Localization/Messages/Korean.json",
+        "key": "2712718738",
+        "missing": [
+          "{prestigeLevel}",
+          "{FamiliarPrestigeStats[value]}"
+        ],
+        "extra": [
+          "{0}",
+          "{1}"
+        ]
+      },
+      {
+        "file": "Resources/Localization/Messages/Korean.json",
+        "key": "11642316",
+        "missing": [
+          "{exoLevel}",
+          "{PrestigeTypeToMaxPrestiges[parsedPrestigeType]}",
+          "{(int)Shapeshifts.CalculateFormDuration(exoLevel)}"
+        ],
+        "extra": [
+          "{0}",
+          "{1}",
+          "{2}"
+        ]
+      },
+      {
+        "file": "Resources/Localization/Messages/Korean.json",
+        "key": "3468772905",
+        "missing": [
+          "{parsedPrestigeType}",
+          "{PrestigeTypeToMaxPrestiges[parsedPrestigeType]}"
+        ],
+        "extra": [
+          "{0}",
+          "{1}"
+        ]
+      },
+      {
+        "file": "Resources/Localization/Messages/Korean.json",
+        "key": "1066178325",
+        "missing": [
+          "[Name]"
+        ],
+        "extra": []
+      },
+      {
+        "file": "Resources/Localization/Messages/Korean.json",
+        "key": "54858227",
+        "missing": [
+          "{prestigeLevel}",
+          "{newXP.Key}",
+          "{FamiliarPrestigeStats[value]}"
+        ],
+        "extra": [
+          "{0}",
+          "{1}",
+          "{2}"
+        ]
+      },
+      {
+        "file": "Resources/Localization/Messages/Korean.json",
+        "key": "1081599663",
+        "missing": [
+          "[Name]"
+        ],
+        "extra": []
+      },
+      {
+        "file": "Resources/Localization/Messages/Korean.json",
+        "key": "2129553669",
+        "missing": [
+          "[PlayerName]"
+        ],
+        "extra": []
+      },
+      {
+        "file": "Resources/Localization/Messages/Korean.json",
+        "key": "20873033",
+        "missing": [
+          "[Class]"
+        ],
+        "extra": []
+      },
+      {
+        "file": "Resources/Localization/Messages/Korean.json",
+        "key": "4140406916",
+        "missing": [
+          "[Class]"
+        ],
+        "extra": []
+      }
+    ]
   }
 ]

--- a/propagate_metrics.json
+++ b/propagate_metrics.json
@@ -1,5 +1,5 @@
 {
-  "/workspace/Bloodcraft/Resources/Localization/Messages/Japanese.json": {
+  "/workspace/Bloodcraft/Resources/Localization/Messages/Korean.json": {
     "added": 5,
     "removed": 0,
     "unchanged": 423

--- a/translations/run_index.json
+++ b/translations/run_index.json
@@ -564,5 +564,49 @@
     "metrics_file": "/workspace/Bloodcraft/metrics_ja.json",
     "success_rate": 1.0,
     "status": "success"
+  },
+  {
+    "run_id": "9256b7f2-b2e2-4dcd-bd80-6386138c853e",
+    "timestamp": "2025-08-30T19:24:20Z",
+    "language": "ko",
+    "run_dir": "/workspace/Bloodcraft/translations/ko/20250830-192310",
+    "log_file": "/workspace/Bloodcraft/translations/ko/20250830-192310/translate.log",
+    "report_file": "/workspace/Bloodcraft/translations/ko/20250830-192310/skipped.csv",
+    "metrics_file": "/workspace/Bloodcraft/translations/ko/20250830-192310/metrics.json",
+    "success_rate": 0,
+    "status": "interrupted"
+  },
+  {
+    "run_id": "2f22e5c9-2b70-4c9b-a3d6-13a8793afdd1",
+    "timestamp": "2025-08-30T19:24:45Z",
+    "language": "ko",
+    "run_dir": "/workspace/Bloodcraft/translations/ko/20250830-192437",
+    "log_file": "/workspace/Bloodcraft/translations/ko/20250830-192437/translate.log",
+    "report_file": "/workspace/Bloodcraft/translations/ko/20250830-192437/skipped.csv",
+    "metrics_file": "/workspace/Bloodcraft/translations/ko/20250830-192437/metrics.json",
+    "success_rate": 1.0,
+    "status": "success"
+  },
+  {
+    "run_id": "85e2d713-de6b-4e14-93f0-2ac8584d4840",
+    "timestamp": "2025-08-30T19:25:41Z",
+    "language": "ko",
+    "run_dir": "/workspace/Bloodcraft/translations/ko/20250830-192534",
+    "log_file": "/workspace/Bloodcraft/translations/ko/20250830-192534/translate.log",
+    "report_file": "/workspace/Bloodcraft/translations/ko/20250830-192534/skipped.csv",
+    "metrics_file": "/workspace/Bloodcraft/translations/ko/20250830-192534/metrics.json",
+    "success_rate": 1.0,
+    "status": "success"
+  },
+  {
+    "run_id": "0c33c082-dab5-43de-9c0f-a6393fe51f82",
+    "timestamp": "2025-08-30T19:26:45Z",
+    "language": "ko",
+    "run_dir": "/workspace/Bloodcraft/translations/ko/20250830-192637",
+    "log_file": "/workspace/Bloodcraft/translations/ko/20250830-192637/translate.log",
+    "report_file": "/workspace/Bloodcraft/translations/ko/20250830-192637/skipped.csv",
+    "metrics_file": "/workspace/Bloodcraft/translations/ko/20250830-192637/metrics.json",
+    "success_rate": 1.0,
+    "status": "success"
   }
 ]


### PR DESCRIPTION
## Summary
- propagate hashes and translate new Korean messages
- update translation run metrics

## Testing
- `python Tools/fix_tokens.py Resources/Localization/Messages/Korean.json --check-only` *(fails: token mismatches detected)*
- `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations --show-text`


------
https://chatgpt.com/codex/tasks/task_e_68b34e56b068832da7f20b86d39e1c98