### PR TITLE
Fix run index JSON syntax

### DIFF
--- a/translations/run_index.json
+++ b/translations/run_index.json
@@ -676,7 +676,6 @@
     "status": "interrupted"
   },
   {
-  {
     "run_id": "6ae63984-3933-41b6-93df-01d906e290e2",
     "timestamp": "2025-08-31T02:08:55Z",
     "language": "uk",


### PR DESCRIPTION
## Summary
- remove stray opening brace and ensure final entry in run_index.json is properly closed

## Testing
- `jq . translations/run_index.json`


------
https://chatgpt.com/codex/tasks/task_e_68b3c9328964832db3fd1b375e0dcf27