### PR TITLE
Add tests for placeholder wrapping and sentinel normalization

### DIFF
--- a/Tools/tests/test_placeholder_wrapping.py
+++ b/Tools/tests/test_placeholder_wrapping.py
@@ -1,0 +1,17 @@
+import translate_argos
+
+
+def test_wrap_and_unwrap_preserves_tokens_over_threshold():
+    original = " ".join(f"[[TOKEN_{i}]]" for i in range(25))
+    wrapped, ids = translate_argos.wrap_placeholders(original)
+    assert len(ids) == 25
+    # Wrapped text should no longer contain explicit placeholders
+    assert not translate_argos.TOKEN_RE.search(wrapped)
+    unwrapped = translate_argos.unwrap_placeholders(wrapped, ids)
+    assert unwrapped == original
+
+
+def test_normalize_tokens_trims_sentinels():
+    text = "[[TOKEN_0]] [[ TOKEN_sentinel ]] TOKEN_SENTINEL [[TOKEN_1]]"
+    normalized = translate_argos.normalize_tokens(text)
+    assert normalized == "[[TOKEN_0]] [[TOKEN_1]]"


### PR DESCRIPTION
## Summary
- add unit tests covering wrap_placeholders/unwrap_placeholders round-trip over threshold
- ensure normalize_tokens trims stray TOKEN_SENTINEL markers

## Testing
- `PYTHONPATH=Tools pytest Tools/tests`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b4b8610218832da0b91653854bc441