### PR TITLE
Add localized message paths for all languages

### DIFF
--- a/Services/LocalizationService.cs
+++ b/Services/LocalizationService.cs
@@ -106,7 +106,17 @@ internal class LocalizationService // the bones are from KindredCommands, ty Odj
         {"Italian", "Bloodcraft.Resources.Localization.Messages.Italian.json"},
         {"Hungarian", "Bloodcraft.Resources.Localization.Messages.Hungarian.json"},
         {"Brazilian", "Bloodcraft.Resources.Localization.Messages.Brazilian.json"},
-        {"Japanese", "Bloodcraft.Resources.Localization.Messages.Japanese.json"}
+        {"Japanese", "Bloodcraft.Resources.Localization.Messages.Japanese.json"},
+        {"Korean", "Bloodcraft.Resources.Localization.Messages.Korean.json"},
+        {"Latam", "Bloodcraft.Resources.Localization.Messages.Latam.json"},
+        {"Polish", "Bloodcraft.Resources.Localization.Messages.Polish.json"},
+        {"Russian", "Bloodcraft.Resources.Localization.Messages.Russian.json"},
+        {"SChinese", "Bloodcraft.Resources.Localization.Messages.SChinese.json"},
+        {"TChinese", "Bloodcraft.Resources.Localization.Messages.TChinese.json"},
+        {"Thai", "Bloodcraft.Resources.Localization.Messages.Thai.json"},
+        {"Turkish", "Bloodcraft.Resources.Localization.Messages.Turkish.json"},
+        {"Ukrainian", "Bloodcraft.Resources.Localization.Messages.Ukrainian.json"},
+        {"Vietnamese", "Bloodcraft.Resources.Localization.Messages.Vietnamese.json"}
     };
 
     static readonly Dictionary<uint, string> _messageDictionary = [];


### PR DESCRIPTION
## Summary
- include every message translation file in `_localizedMessagePaths`

## Testing
- `dotnet build` *(fails: check_localization_reply.py reported string literal usage)*

------
https://chatgpt.com/codex/tasks/task_e_68b520eb9bb0832d8ba47b2a53c521e9