### PR TITLE
chore: update Spanish translations

### DIFF
--- a/Resources/Localization/Messages/Spanish.json
+++ b/Resources/Localization/Messages/Spanish.json
@@ -419,10 +419,10 @@
     "3097011724": "Clase inválida, utilice '<color=white>.clase l</color> para ver opciones.",
     "3102592194": "¡No pude encontrar un familiar activo!",
     "2844729307": "Tu familiar ha reconocido <color=#90EE90>{prestigeLevel}</color>; el conocimiento acumulado les permitió mantener su nivel!",
-    "3002809107": "Prefab with GUID {guidHash} not found!",
-    "2597161495": "No hovered entity!",
-    "2660507905": "No Castle Heart!",
-    "182159004": "No Familiar Active!",
-    "2336012040": "Renamed '{oldName}' to '{newName}'!"
+    "3002809107": "¡Prefab con GUID {guidHash} no encontrado!",
+    "2597161495": "¡No hay entidad bajo el cursor!",
+    "2660507905": "¡No hay Corazón del Castillo!",
+    "182159004": "¡No hay Familiar activo!",
+    "2336012040": "¡Se renombró '{oldName}' a '{newName}'!"
   }
 }


### PR DESCRIPTION
## Summary
- translate pending Spanish strings for game messages

## Testing
- `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- generate-messages` (fails: check_localization_reply.py exit 1)
- `python Tools/propagate_hashes.py Resources/Localization/Messages/Spanish.json`
- `python Tools/translate_argos.py Resources/Localization/Messages/Spanish.json --to es --batch-size 100 --max-retries 3 --log-level INFO --hash 182159004 --hash 2336012040 --hash 2597161495 --hash 2660507905 --hash 3002809107`
- `python Tools/fix_tokens.py Resources/Localization/Messages/Spanish.json --check-only`
- `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations --show-text` (fails: check_localization_reply.py exit 1)

------
https://chatgpt.com/codex/tasks/task_e_68b5c6d61770832d8fd560161d40ef3c