### PR TITLE
chore: add quest progress localization hashes

### DIFF
--- a/Docs/MessageKeys.md
+++ b/Docs/MessageKeys.md
@@ -194,6 +194,7 @@ Auto-generated from `Resources/Localization/Messages/English.json`.
 | `2682530289` | You don't have the required amount of {_vampiricDust.GetLocalizedName()}!... |
 | `2687655344` | Your weapon stats have been reset for …! |
 | `2689850927` | Invalid familiar prestige stat type, use '.fam lst'... |
+| `2693194341` | Progress added to …: … … […/…] |
 | `2698551496` | Quests for … have been refreshed. |
 | `2709293439` | Your familiar is level [{xpData.Key}][{prestigeLevel}] and has {progress}... |
 | `2712082651` | Radius must be positive! |
@@ -304,6 +305,7 @@ Auto-generated from `Resources/Localization/Messages/English.json`.
 | `3648038609` | Player does not have an active … quest... |
 | `3664649404` | You can't challenge yourself! |
 | `3665962604` | Bonus Saplings(s)x… received from …, but some fell... |
+| `3678240084` | You've been awarded {0:F1}% of your total …! |
 | `3681675424` | Level must be between 0 and {ConfigService.MaxLevel}! |
 | `3706109126` | You have not prestiged in {parsedPrestigeType}. |
 | `3706417587` | Invalid quest type '{questTypeName}'. Valid values are: {string.Join(",... |

--- a/Resources/Localization/Messages/Brazilian.json
+++ b/Resources/Localization/Messages/Brazilian.json
@@ -22,6 +22,8 @@
     "1763623253": "Nova <color=#00FFFF>Missão Diária</color> disponível: <color=green>{0}</color> <color=white>{1}</color>x<color=#FFC0CB>{2}</color> [<color=white>{3}</color>/<color=yellow>{2}</color>]",
     "384069927": "Você recebeu <color=#ffd9eb>{0}</color>x<color=white>{1}</color> por completar sua {2}!",
     "1884892470": "Você recebeu <color=#ffd9eb>{0}</color>x<color=white>{1}</color> por completar sua {2}! Caiu no chão porque seu inventário estava cheio.",
+    "3678240084": "You've been awarded <color=yellow>{0:F1}%</color> of your total {1}!",
+    "2693194341": "Progress added to {0}: <color=green>{1}</color> <color=white>{2}</color> [<color=white>{3}</color>/<color=yellow>{4}</color>]",
     "3158650477": "Nenhum familiar no grupo de batalha!",
     "2673031653": "Grupo de batalha - {0}",
     "3637474013": "<color=green>{0}</color>{1}<color=white>{2}</color><color=#90EE90>{3}</color><color=white>{4}</color>! <color=yellow>{5}</color>",

--- a/Resources/Localization/Messages/English.json
+++ b/Resources/Localization/Messages/English.json
@@ -22,6 +22,8 @@
     "1763623253": "New \u003Ccolor=#00FFFF\u003EDaily Quest\u003C/color\u003E available: \u003Ccolor=green\u003E{0}\u003C/color\u003E \u003Ccolor=white\u003E{1}\u003C/color\u003Ex\u003Ccolor=#FFC0CB\u003E{2}\u003C/color\u003E [\u003Ccolor=white\u003E{3}\u003C/color\u003E/\u003Ccolor=yellow\u003E{2}\u003C/color\u003E]",
     "384069927": "You\u0027ve received \u003Ccolor=#ffd9eb\u003E{0}\u003C/color\u003Ex\u003Ccolor=white\u003E{1}\u003C/color\u003E for completing your {2}!",
     "1884892470": "You\u0027ve received \u003Ccolor=#ffd9eb\u003E{0}\u003C/color\u003Ex\u003Ccolor=white\u003E{1}\u003C/color\u003E for completing your {2}! It dropped on the ground because your inventory was full.",
+    "3678240084": "You\u0027ve been awarded \u003Ccolor=yellow\u003E{0:F1}%\u003C/color\u003E of your total {1}!",
+    "2693194341": "Progress added to {0}: \u003Ccolor=green\u003E{1}\u003C/color\u003E \u003Ccolor=white\u003E{2}\u003C/color\u003E [\u003Ccolor=white\u003E{3}\u003C/color\u003E/\u003Ccolor=yellow\u003E{4}\u003C/color\u003E]",
     "3158650477": "No familiars in battle group!",
     "2673031653": "Battle Group - {0}",
     "3637474013": "\u003Ccolor=green\u003E{0}\u003C/color\u003E{1} [\u003Ccolor=white\u003E{2}\u003C/color\u003E][\u003Ccolor=#90EE90\u003E{3}\u003C/color\u003E] added to \u003Ccolor=white\u003E{4}\u003C/color\u003E! (\u003Ccolor=yellow\u003E{5}\u003C/color\u003E)",

--- a/Resources/Localization/Messages/French.json
+++ b/Resources/Localization/Messages/French.json
@@ -22,6 +22,8 @@
     "1763623253": "Nouveau <color=#00FFFF>Quête quotidienne</color> disponible: <color=green>{0}</color><color=white>{1}</color>x<color=#FFC0CB>{2}</color><color=white>{3}</color><color=yellow>{2}</color>",
     "384069927": "Vous avez reçu <color=#ffd9eb>{0}</color>x<color=white>{1}</color> pour avoir complété votre {2} !",
     "1884892470": "Vous avez reçu <color=#ffd9eb>{0}</color>x<color=white>{1}</color> pour avoir complété votre {2} ! Il est tombé au sol parce que votre inventaire était complet.",
+    "3678240084": "You've been awarded <color=yellow>{0:F1}%</color> of your total {1}!",
+    "2693194341": "Progress added to {0}: <color=green>{1}</color> <color=white>{2}</color> [<color=white>{3}</color>/<color=yellow>{4}</color>]",
     "3158650477": "Pas de familiers dans le groupe de combat !",
     "2673031653": "Groupe tactique - {0}",
     "3637474013": "<color=green>{0}</color>{1}<color=white>{2}</color><color=#90EE90>{3}</color> ajouté à <color=white>{4}</color>! <color=yellow>{5}</color>",

--- a/Resources/Localization/Messages/German.json
+++ b/Resources/Localization/Messages/German.json
@@ -22,6 +22,8 @@
     "1763623253": "New <color=#00FFFF>Daily Quest</color> available: <color=green>{0}</color> <color=white>{1}</color>x<color=#FFC0CB>{2}</color> [<color=white>{3}</color>/<color=yellow>{2}</color>]",
     "384069927": "You've received <color=#ffd9eb>{0}</color>x<color=white>{1}</color> for completing your {2}!",
     "1884892470": "You've received <color=#ffd9eb>{0}</color>x<color=white>{1}</color> for completing your {2}! It dropped on the ground because your inventory was full.",
+    "3678240084": "You've been awarded <color=yellow>{0:F1}%</color> of your total {1}!",
+    "2693194341": "Progress added to {0}: <color=green>{1}</color> <color=white>{2}</color> [<color=white>{3}</color>/<color=yellow>{4}</color>]",
     "3158650477": "No familiars in battle group!",
     "2673031653": "Battle Group - {0}",
     "3637474013": "<color=green>{0}</color>{1} [<color=white>{2}</color>][<color=#90EE90>{3}</color>] added to <color=white>{4}</color>! (<color=yellow>{5}</color>)",

--- a/Resources/Localization/Messages/Hungarian.json
+++ b/Resources/Localization/Messages/Hungarian.json
@@ -22,6 +22,8 @@
     "1763623253": "New <color=#00FFFF>Daily Quest</color> available: <color=green>{0}</color> <color=white>{1}</color>x<color=#FFC0CB>{2}</color> [<color=white>{3}</color>/<color=yellow>{2}</color>]",
     "384069927": "Ön <color=#ffd9eb> {0} </color> x <color=white> {1} </color> -t kapott a {2} befejezéséért!",
     "1884892470": "Ön <color=#ffd9eb> {0} </color> x <color=white> {1} </color> -t kapott a {2} befejezéséért! A földre esett, mert tele volt a készleted.",
+    "3678240084": "You've been awarded <color=yellow>{0:F1}%</color> of your total {1}!",
+    "2693194341": "Progress added to {0}: <color=green>{1}</color> <color=white>{2}</color> [<color=white>{3}</color>/<color=yellow>{4}</color>]",
     "3158650477": "Nincs ismerős a harci csoportban!",
     "2673031653": "Battle Group - {0}",
     "3637474013": "<color=green>{0}</color> {1} <color=white>{2}</color> <color=#90EE90> {3} </color><color=white>{4}! (</color><color=yellow>{5}) </color>",

--- a/Resources/Localization/Messages/Italian.json
+++ b/Resources/Localization/Messages/Italian.json
@@ -22,6 +22,8 @@
     "1763623253": "New <color=#00FFFF>Daily Quest</color> available: <color=green>{0}</color> <color=white>{1}</color>x<color=#FFC0CB>{2}</color> [<color=white>{3}</color>/<color=yellow>{2}</color>]",
     "384069927": "Avete ricevuto <color=#ffd9eb>{0} </color>x<color=white>{1}</color> per aver completato il vostro {2}!",
     "1884892470": "Avete ricevuto <color=#ffd9eb>{0} </color>x<color=white>{1}</color> per aver completato il vostro {2}! E' caduto a terra perche' il tuo inventario era pieno.",
+    "3678240084": "You've been awarded <color=yellow>{0:F1}%</color> of your total {1}!",
+    "2693194341": "Progress added to {0}: <color=green>{1}</color> <color=white>{2}</color> [<color=white>{3}</color>/<color=yellow>{4}</color>]",
     "3158650477": "Nessun familiare nel gruppo di battaglia!",
     "2673031653": "Gruppo di battaglia - {0}",
     "3637474013": "<color=green>{0}</color> {1} <color=white>{2}</color><color=#90EE90>{3}</color> aggiunto TOKEN_ <color=white>{4}</color> <color=yellow>{5}</color>",

--- a/Resources/Localization/Messages/Japanese.json
+++ b/Resources/Localization/Messages/Japanese.json
@@ -22,6 +22,8 @@
     "1763623253": "New <color=#00FFFF>Daily Quest</color> available: <color=green>{0}</color> <color=white>{1}</color>x<color=#FFC0CB>{2}</color> [<color=white>{3}</color>/<color=yellow>{2}</color>]",
     "384069927": "<color=#ffd9eb>{0}</color>x<color=white>{1}</color>を受け取りました! {2}",
     "1884892470": "<color=#ffd9eb>{0}</color>x<color=white>{1}</color>を受け取りました! あなたの在庫がいっぱいだったので地面に落ちました。 {2}",
+    "3678240084": "You've been awarded <color=yellow>{0:F1}%</color> of your total {1}!",
+    "2693194341": "Progress added to {0}: <color=green>{1}</color> <color=white>{2}</color> [<color=white>{3}</color>/<color=yellow>{4}</color>]",
     "3158650477": "バトルグループに馴染みのない!",
     "2673031653": "バトルグループ - {0}",
     "3637474013": "<color=green>{0}</color>{1} <color=white>{2}</color><color=#90EE90>{3}{3}</color>に<color=white>{4}</color>に</color>を追加しました! (<color=yellow>{5}</color>))",

--- a/Resources/Localization/Messages/Korean.json
+++ b/Resources/Localization/Messages/Korean.json
@@ -22,6 +22,8 @@
     "1763623253": "New <color=#00FFFF>Daily Quest</color> available: <color=green>{0}</color> <color=white>{1}</color>x<color=#FFC0CB>{2}</color> [<color=white>{3}</color>/<color=yellow>{2}</color>]",
     "384069927": "You've received <color=#ffd9eb>{0}</color>x<color=white>{1}</color> for completing your {2}!",
     "1884892470": "You've received <color=#ffd9eb>{0}</color>x<color=white>{1}</color> for completing your {2}! It dropped on the ground because your inventory was full.",
+    "3678240084": "You've been awarded <color=yellow>{0:F1}%</color> of your total {1}!",
+    "2693194341": "Progress added to {0}: <color=green>{1}</color> <color=white>{2}</color> [<color=white>{3}</color>/<color=yellow>{4}</color>]",
     "3158650477": "전투 그룹에 익숙하지!",
     "2673031653": "배틀 그룹 - {0}",
     "3637474013": "<color=green>{0}</color>{1} [<color=white>{2}</color>][<color=#90EE90>{3}</color>] added to <color=white>{4}</color>! (<color=yellow>{5}</color>)",

--- a/Resources/Localization/Messages/Latam.json
+++ b/Resources/Localization/Messages/Latam.json
@@ -22,6 +22,8 @@
     "1763623253": "New <color=#00FFFF>Daily Quest</color> available: <color=green>{0}</color> <color=white>{1}</color>x<color=#FFC0CB>{2}</color> [<color=white>{3}</color>/<color=yellow>{2}</color>]",
     "384069927": "Usted ha recibido <color=#ffd9eb> {0} </color>x <color=white> {1} </color> para completar su {2}!",
     "1884892470": "Usted ha recibido <color=#ffd9eb> {0} </color>x <color=white> {1} </color> para completar su {2}! Se cayó sobre el suelo porque su inventario estaba lleno.",
+    "3678240084": "You've been awarded <color=yellow>{0:F1}%</color> of your total {1}!",
+    "2693194341": "Progress added to {0}: <color=green>{1}</color> <color=white>{2}</color> [<color=white>{3}</color>/<color=yellow>{4}</color>]",
     "3158650477": "¡Ningún familiar en el grupo de batalla!",
     "2673031653": "Grupo de batalla - {0}",
     "3637474013": "<color=green>{0}</color> {1} <color=white>{2}</color> <color=#90EE90>{3}</color> EN_ * * <color=white>{4}</color> <color=yellow>{5}</color>",

--- a/Resources/Localization/Messages/Polish.json
+++ b/Resources/Localization/Messages/Polish.json
@@ -22,6 +22,8 @@
     "1763623253": "New <color=#00FFFF>Daily Quest</color> available: <color=green>{0}</color> <color=white>{1}</color>x<color=#FFC0CB>{2}</color> [<color=white>{3}</color>/<color=yellow>{2}</color>]",
     "384069927": "Otrzymaliście <color=#ffd9eb> {0} </color> x <color=white> {1} </color> za ukończenie {2}!",
     "1884892470": "Otrzymaliście <color=#ffd9eb> {0} </color> x <color=white> {1} </color> za ukończenie {2}! Spadł na ziemię, bo twój inwentarz był pełny.",
+    "3678240084": "You've been awarded <color=yellow>{0:F1}%</color> of your total {1}!",
+    "2693194341": "Progress added to {0}: <color=green>{1}</color> <color=white>{2}</color> [<color=white>{3}</color>/<color=yellow>{4}</color>]",
     "3158650477": "Żadnych znajomych w grupie bojowej!",
     "2673031653": "Grupa bojowa - {0}",
     "3637474013": "<color=green> {0} </color> {1} <color=white> {2} </color> <color=#90EE90> {3} </color> dodaje się <color=white> {4} </color>! (<color=yellow> {5} </color>)",

--- a/Resources/Localization/Messages/Russian.json
+++ b/Resources/Localization/Messages/Russian.json
@@ -22,6 +22,8 @@
     "1763623253": "Новый <color=#00FFFF> Ежедневный поиск </color> доступен: <color=green>{0}</color><color=white>{1}</color>x<color=#FFC0CB>{2}</color><color=white>{3}/</color><color=yellow>{2} </color>",
     "384069927": "Вы получили <color=#ffd9eb>{0}</color>x<color=white>{1}</color> для завершения {2}!",
     "1884892470": "Вы получили <color=#ffd9eb>{0}</color>x<color=white>{1}</color> для завершения {2}! Он упал на землю, потому что ваш инвентарь был полон.",
+    "3678240084": "You've been awarded <color=yellow>{0:F1}%</color> of your total {1}!",
+    "2693194341": "Progress added to {0}: <color=green>{1}</color> <color=white>{2}</color> [<color=white>{3}</color>/<color=yellow>{4}</color>]",
     "3158650477": "Никаких знакомых в боевой группе!",
     "2673031653": "Боевая группа — {0}",
     "3637474013": "Токен_0Токен_1Токен_2Токен_3Токен_4Токен_5Токен_6Токен_7Токен_8Токен_9Токен_10Токен_11Токен_12 Токен_13Токен_14Токен_15 <color=green> {0} </color> {1} <color=white> {2} </color> <color=#90EE90> {3} </color> <color=white> {4} </color> <color=yellow> {5} </color>",

--- a/Resources/Localization/Messages/SChinese.json
+++ b/Resources/Localization/Messages/SChinese.json
@@ -22,6 +22,8 @@
     "1763623253": "新建 <color=#00FFFF> 每日查询 </color><color=green>{0} </color><color=white>{1} x </color><color=#FFC0CB>{2} </color><color=white>{3}/</color><color=yellow>{2} </color>",
     "384069927": "<color=#ffd9eb> {0} </color> x <color=white>{1}</color> 完成你的{2}!",
     "1884892470": "<color=#ffd9eb> {0} </color> x <color=white>{1}</color> 完成你的{2}! 它掉到地上是因为你的存货满了",
+    "3678240084": "You've been awarded <color=yellow>{0:F1}%</color> of your total {1}!",
+    "2693194341": "Progress added to {0}: <color=green>{1}</color> <color=white>{2}</color> [<color=white>{3}</color>/<color=yellow>{4}</color>]",
     "3158650477": "没有熟悉的战斗群!",
     "2673031653": "战斗集团 - {0}",
     "3637474013": "<color=green>{0}</color>{1}<color=white>{2}</color><color=#90EE90>{3}</color>,加上<color=white>{4}</color>! (<color=yellow>{5}</color>).",

--- a/Resources/Localization/Messages/Spanish.json
+++ b/Resources/Localization/Messages/Spanish.json
@@ -22,6 +22,8 @@
     "1763623253": "Nueva <color=#00FFFF>misión diaria</color> disponible: <color=green>{0}</color> <color=white>{1}</color>x<color=#FFC0CB>{2}</color> [<color=white>{3}</color>/<color=yellow>{2}</color>]",
     "384069927": "Usted ha recibido <color=#ffd9eb>{0}</color>x <color=white>{1}</color> para completar su {2}!",
     "1884892470": "Usted ha recibido <color=#ffd9eb>{0}</color>x <color=white>{1}</color> para completar su {2}! Se cayó sobre el suelo porque su inventario estaba lleno.",
+    "3678240084": "You've been awarded <color=yellow>{0:F1}%</color> of your total {1}!",
+    "2693194341": "Progress added to {0}: <color=green>{1}</color> <color=white>{2}</color> [<color=white>{3}</color>/<color=yellow>{4}</color>]",
     "3158650477": "¡Ningún familiar en el grupo de batalla!",
     "2673031653": "Grupo de batalla - {0}",
     "3637474013": "<color=green>{0}</color>{1} [<color=white>{2}</color>][<color=#90EE90>{3}</color>] añadido a <color=white>{4}</color>! (<color=yellow>{5}</color>)",

--- a/Resources/Localization/Messages/TChinese.json
+++ b/Resources/Localization/Messages/TChinese.json
@@ -22,6 +22,8 @@
     "1763623253": "新的 <color=#00FFFF>每日任務</color> 可用: <color=green>{0}</color> <color=white>{1}</color>x<color=#FFC0CB>{2}</color> [<color=white>{3}</color>/<color=yellow>{2}</color>]",
     "384069927": "<color=#ffd9eb> {0} </color> x <color=white>{1}</color> 完成你的{2}!",
     "1884892470": "<color=#ffd9eb> {0} </color> x <color=white>{1}</color> 完成你的{2}! 它掉在地上 因為你的數據滿了",
+    "3678240084": "You've been awarded <color=yellow>{0:F1}%</color> of your total {1}!",
+    "2693194341": "Progress added to {0}: <color=green>{1}</color> <color=white>{2}</color> [<color=white>{3}</color>/<color=yellow>{4}</color>]",
     "3158650477": "在戰鬥群組里沒有熟人!",
     "2673031653": "戰鬥群組 - {0}",
     "3637474013": "<color=green>{0}</color>{1}<color=white>{2}</color><color=#90EE90>{3} (</color><color=white>{4}) </color> <color=yellow>{5}</color>",

--- a/Resources/Localization/Messages/Thai.json
+++ b/Resources/Localization/Messages/Thai.json
@@ -22,6 +22,8 @@
     "1763623253": "New <color=#00FFFF>Daily Quest</color> available: <color=green>{0}</color> <color=white>{1}</color>x<color=#FFC0CB>{2}</color> [<color=white>{3}</color>/<color=yellow>{2}</color>]",
     "384069927": "You've received <color=#ffd9eb>{0}</color>x<color=white>{1}</color> for completing your {2}!",
     "1884892470": "You've received <color=#ffd9eb>{0}</color>x<color=white>{1}</color> for completing your {2}! It dropped on the ground because your inventory was full.",
+    "3678240084": "You've been awarded <color=yellow>{0:F1}%</color> of your total {1}!",
+    "2693194341": "Progress added to {0}: <color=green>{1}</color> <color=white>{2}</color> [<color=white>{3}</color>/<color=yellow>{4}</color>]",
     "3158650477": "ไม่คุ้นเคยกับกลุ่มรบ!",
     "2673031653": "Battle Group - {0}",
     "3637474013": "<color=green>{0}</color>{1} [<color=white>{2}</color>][<color=#90EE90>{3}</color>] added to <color=white>{4}</color>! (<color=yellow>{5}</color>)",

--- a/Resources/Localization/Messages/Turkish.json
+++ b/Resources/Localization/Messages/Turkish.json
@@ -22,6 +22,8 @@
     "1763623253": "FOKENTO_0Daily Quest</color> <color=green></color><color=white>{1}</color>{2}</color></color>{3}<color=white>{3}{3}</color>/{2} <color=#00FFFF> {0} <color=#FFC0CB> <color=yellow>",
     "384069927": "Ücretsin {0}</color></color>{1} </color>{2}'nızı tamamlamak için). <color=#ffd9eb> <color=white>",
     "1884892470": "Ücretsin {0}</color></color>{1} </color>{2}'nızı tamamlamak için). Yere düştü çünkü envanteriniz tamdı. <color=#ffd9eb> <color=white>",
+    "3678240084": "You've been awarded <color=yellow>{0:F1}%</color> of your total {1}!",
+    "2693194341": "Progress added to {0}: <color=green>{1}</color> <color=white>{2}</color> [<color=white>{3}</color>/<color=yellow>{4}</color>]",
     "3158650477": "Savaş grubunda tanıdık yok!",
     "2673031653": "Battle Group -TOZE_0) {0}",
     "3637474013": "FOKENTO_0{0}</color><color=white><color=white></color> <color=#90EE90></color>{1}{4}<color=white></color></color> </color>|<color=#90EE90> (<color=yellow>{5}</color>). <color=green> {2} {3} <color=white>",

--- a/Resources/Localization/Messages/Ukrainian.json
+++ b/Resources/Localization/Messages/Ukrainian.json
@@ -22,6 +22,8 @@
     "1763623253": "<color=#00FFFF>Daily Quest</color> <color=green>{0}</color> <color=white>{1}</color> кс<color=#FFC0CB>{2}</color></color> <color=white>{3}</color>/<color=yellow><color=yellow><color=yellow>TOKEN_TOKEN_TOKEN_TOKEN_TOKEN_TOKEN_TOKEN_TOKEN_TOKEN_TOKEN_TOKEN_TOKEN_TOKEN_TOKEN_TOKEN_{3} {2} </color>",
     "384069927": "<color=#ffd9eb> <color=#ffd9eb> {0}</color> // <color=white>{1}</color> </color> {2}!",
     "1884892470": "<color=#ffd9eb> <color=#ffd9eb> {0}</color> // <color=white>{1}</color> </color> {2}! Знизився на землі, тому що ваш інвентар був повним.",
+    "3678240084": "You've been awarded <color=yellow>{0:F1}%</color> of your total {1}!",
+    "2693194341": "Progress added to {0}: <color=green>{1}</color> <color=white>{2}</color> [<color=white>{3}</color>/<color=yellow>{4}</color>]",
     "3158650477": "Немає знайомих в бойовій групі!",
     "2673031653": "Битна група - {0}",
     "3637474013": "<color=green>{0}</color>{1} <color=white>{2}</color> <color=#90EE90>{3}{3}</color> <color=white>{4}{4}</color>! <color=yellow>{5}</color>)",

--- a/Resources/Localization/Messages/Vietnamese.json
+++ b/Resources/Localization/Messages/Vietnamese.json
@@ -22,6 +22,8 @@
     "1763623253": "New <color=#00FFFF>Daily Quest</color> available: <color=green>{0}</color> <color=white>{1}</color>x<color=#FFC0CB>{2}</color> [<color=white>{3}</color>/<color=yellow>{2}</color>]",
     "384069927": "<color=#ffd9eb> {0}) {0}) </color>x <color=white> {1} </color>) để hoàn thành {2}!",
     "1884892470": "<color=#ffd9eb> {0}) {0}) </color>x <color=white> {1} </color>) để hoàn thành {2}! Nó rơi xuống đất vì kho hàng của anh đầy rồi.",
+    "3678240084": "You've been awarded <color=yellow>{0:F1}%</color> of your total {1}!",
+    "2693194341": "Progress added to {0}: <color=green>{1}</color> <color=white>{2}</color> [<color=white>{3}</color>/<color=yellow>{4}</color>]",
     "3158650477": "Không quen thuộc với nhóm chiến đấu!",
     "2673031653": "Nhóm chiến đấu {0}",
     "3637474013": "<color=green> </color> <color=#90EE90> <color=#90EE90> {3} <color=white> {2} {0}) </color> <color=#90EE90> {3} {3} TOK_9 thêm TOK_10 TOK_11 <color=yellow> {5} </color> </color> {1} </color> <color=white> {4} </color>",

--- a/propagate_metrics.json
+++ b/propagate_metrics.json
@@ -1,7 +1,87 @@
 {
-  "/workspace/Bloodcraft/Resources/Localization/Messages/Vietnamese.json": {
-    "added": 0,
+  "/workspace/Bloodcraft/Resources/Localization/Messages/Brazilian.json": {
+    "added": 2,
     "removed": 0,
-    "unchanged": 428
+    "unchanged": 425
+  },
+  "/workspace/Bloodcraft/Resources/Localization/Messages/French.json": {
+    "added": 2,
+    "removed": 0,
+    "unchanged": 425
+  },
+  "/workspace/Bloodcraft/Resources/Localization/Messages/German.json": {
+    "added": 2,
+    "removed": 0,
+    "unchanged": 425
+  },
+  "/workspace/Bloodcraft/Resources/Localization/Messages/Hungarian.json": {
+    "added": 2,
+    "removed": 0,
+    "unchanged": 425
+  },
+  "/workspace/Bloodcraft/Resources/Localization/Messages/Italian.json": {
+    "added": 2,
+    "removed": 0,
+    "unchanged": 425
+  },
+  "/workspace/Bloodcraft/Resources/Localization/Messages/Japanese.json": {
+    "added": 2,
+    "removed": 0,
+    "unchanged": 425
+  },
+  "/workspace/Bloodcraft/Resources/Localization/Messages/Korean.json": {
+    "added": 2,
+    "removed": 0,
+    "unchanged": 425
+  },
+  "/workspace/Bloodcraft/Resources/Localization/Messages/Latam.json": {
+    "added": 2,
+    "removed": 0,
+    "unchanged": 425
+  },
+  "/workspace/Bloodcraft/Resources/Localization/Messages/Polish.json": {
+    "added": 2,
+    "removed": 0,
+    "unchanged": 425
+  },
+  "/workspace/Bloodcraft/Resources/Localization/Messages/Russian.json": {
+    "added": 2,
+    "removed": 0,
+    "unchanged": 425
+  },
+  "/workspace/Bloodcraft/Resources/Localization/Messages/SChinese.json": {
+    "added": 2,
+    "removed": 0,
+    "unchanged": 425
+  },
+  "/workspace/Bloodcraft/Resources/Localization/Messages/Spanish.json": {
+    "added": 2,
+    "removed": 0,
+    "unchanged": 425
+  },
+  "/workspace/Bloodcraft/Resources/Localization/Messages/TChinese.json": {
+    "added": 2,
+    "removed": 0,
+    "unchanged": 425
+  },
+  "/workspace/Bloodcraft/Resources/Localization/Messages/Thai.json": {
+    "added": 2,
+    "removed": 0,
+    "unchanged": 425
+  },
+  "/workspace/Bloodcraft/Resources/Localization/Messages/Turkish.json": {
+    "added": 2,
+    "removed": 0,
+    "unchanged": 425
+  },
+  "/workspace/Bloodcraft/Resources/Localization/Messages/Ukrainian.json": {
+    "added": 2,
+    "removed": 0,
+    "unchanged": 425
+  },
+  "/workspace/Bloodcraft/Resources/Localization/Messages/Vietnamese.json": {
+    "added": 2,
+    "removed": 0,
+    "unchanged": 425
   }
 }


### PR DESCRIPTION
## Summary
- hash quest XP award and progress messages for translation
- propagate hashes to all language files and regenerate message catalog

## Testing
- `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- generate-messages`
- `python Tools/propagate_hashes.py Resources/Localization/Messages/[!E]*.json --json`
- `python Tools/generate_message_catalog.py`
- `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations --show-text`


------
https://chatgpt.com/codex/tasks/task_e_68b76d0cda00832dbd65c39aeac503fd