### PR TITLE
Allow configuring placeholder wrap threshold

### DIFF
--- a/Tools/test_translate_argos_tokens.py
+++ b/Tools/test_translate_argos_tokens.py
@@ -147,9 +147,9 @@ def test_mixed_placeholders_round_trip_with_reorder():
 
 
 def test_many_placeholders_round_trip():
-    text = "".join(f"{{{i}}}" for i in range(40))
+    text = "".join(f"{{{i}}}" for i in range(15))
     safe, tokens = translate_argos.protect_strict(text)
-    assert len(tokens) == 40
+    assert len(tokens) == 15
     wrapped, mapping = translate_argos.wrap_placeholders(safe)
     unwrapped = translate_argos.unwrap_placeholders(wrapped, mapping)
     restored = translate_argos.unprotect(unwrapped, tokens)
@@ -157,7 +157,7 @@ def test_many_placeholders_round_trip():
 
 
 def test_unwrap_restores_translated_order():
-    count = 30
+    count = 15
     text = "".join(f"{{{i}}}" for i in range(count))
     safe, tokens = translate_argos.protect_strict(text)
     wrapped, mapping = translate_argos.wrap_placeholders(safe)
@@ -166,6 +166,18 @@ def test_unwrap_restores_translated_order():
     restored = translate_argos.unprotect(unwrapped, tokens)
     expected = "".join(f"{{{i}}}" for i in reversed(range(count)))
     assert restored == expected
+
+
+def test_wrap_threshold_boundary(monkeypatch):
+    monkeypatch.setattr(translate_argos, "PLACEHOLDER_WRAP_THRESHOLD", 10)
+    text = "".join(f"{{{i}}}" for i in range(10))
+    safe, _ = translate_argos.protect_strict(text)
+    wrapped, _ = translate_argos.wrap_placeholders(safe)
+    assert wrapped == safe
+    text2 = "".join(f"{{{i}}}" for i in range(11))
+    safe2, _ = translate_argos.protect_strict(text2)
+    wrapped2, _ = translate_argos.wrap_placeholders(safe2)
+    assert wrapped2 != safe2
 
 
 def test_extra_placeholders_trimmed(tmp_path, monkeypatch, caplog):

--- a/Tools/translate_argos.py
+++ b/Tools/translate_argos.py
@@ -115,7 +115,7 @@ class FatalTranslationError(Exception):
     """Raised when Argos Translate encounters an unrecoverable error."""
 
 PLACEHOLDER_BASE = 0xE000
-PLACEHOLDER_WRAP_THRESHOLD = 20
+PLACEHOLDER_WRAP_THRESHOLD = 10
 
 
 def wrap_placeholders(text: str) -> tuple[str, list[str]]:
@@ -1815,7 +1815,19 @@ def main():
         action="store_true",
         help="Rewrite output to match source token order when tokens are reordered",
     )
+    ap.add_argument(
+        "--wrap-threshold",
+        type=int,
+        default=10,
+        help=(
+            "Encode placeholders as private-use characters when the count "
+            "exceeds this threshold (default: 10)"
+        ),
+    )
     args = ap.parse_args()
+
+    global PLACEHOLDER_WRAP_THRESHOLD
+    PLACEHOLDER_WRAP_THRESHOLD = args.wrap_threshold
 
     if not args.target_file:
         overrides = {"pb": "Brazilian", "zh": "SChinese", "zt": "TChinese"}


### PR DESCRIPTION
## Summary
- add `--wrap-threshold` flag to translate_argos
- lower default placeholder wrapping threshold to 10
- test placeholder wrapping for thresholds below 20

## Testing
- `pytest Tools/test_translate_argos_tokens.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b788f3be14832dab1b3d46130a0e3e