### PR TITLE
Make placeholder wrap threshold configurable

### DIFF
--- a/Tools/test_translate_argos_tokens.py
+++ b/Tools/test_translate_argos_tokens.py
@@ -168,13 +168,14 @@ def test_unwrap_restores_translated_order():
     assert restored == expected
 
 
-def test_wrap_threshold_boundary(monkeypatch):
-    monkeypatch.setattr(translate_argos, "PLACEHOLDER_WRAP_THRESHOLD", 10)
-    text = "".join(f"{{{i}}}" for i in range(10))
+@pytest.mark.parametrize("threshold", [5, 10, 15])
+def test_wrap_threshold_boundary(monkeypatch, threshold):
+    monkeypatch.setattr(translate_argos, "PLACEHOLDER_WRAP_THRESHOLD", threshold)
+    text = "".join(f"{{{i}}}" for i in range(threshold))
     safe, _ = translate_argos.protect_strict(text)
     wrapped, _ = translate_argos.wrap_placeholders(safe)
     assert wrapped == safe
-    text2 = "".join(f"{{{i}}}" for i in range(11))
+    text2 = "".join(f"{{{i}}}" for i in range(threshold + 1))
     safe2, _ = translate_argos.protect_strict(text2)
     wrapped2, _ = translate_argos.wrap_placeholders(safe2)
     assert wrapped2 != safe2

--- a/Tools/translate_argos.py
+++ b/Tools/translate_argos.py
@@ -115,7 +115,8 @@ class FatalTranslationError(Exception):
     """Raised when Argos Translate encounters an unrecoverable error."""
 
 PLACEHOLDER_BASE = 0xE000
-PLACEHOLDER_WRAP_THRESHOLD = 10
+DEFAULT_WRAP_THRESHOLD = 10
+PLACEHOLDER_WRAP_THRESHOLD = DEFAULT_WRAP_THRESHOLD
 
 
 def wrap_placeholders(text: str) -> tuple[str, list[str]]:
@@ -1827,10 +1828,10 @@ def main():
     ap.add_argument(
         "--wrap-threshold",
         type=int,
-        default=10,
+        default=DEFAULT_WRAP_THRESHOLD,
         help=(
             "Encode placeholders as private-use characters when the count "
-            "exceeds this threshold (default: 10)"
+            "exceeds this threshold (default: %(default)s)"
         ),
     )
     args = ap.parse_args()


### PR DESCRIPTION
## Summary
- expose placeholder wrap threshold via `--wrap-threshold` flag (default 10)
- expand token wrapping tests to cover sub-20 thresholds

## Testing
- `pytest Tools/test_translate_argos_tokens.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba03489dec832dbb94b27b2ad98c68