### PR TITLE
Drop unexpected tokens during placeholder replacement

### DIFF
--- a/Tools/test_fix_tokens_main.py
+++ b/Tools/test_fix_tokens_main.py
@@ -146,8 +146,11 @@ def test_normalization_merges_split_tokens(tmp_path, monkeypatch):
         ],
     )
 
-    with pytest.raises(SystemExit):
-        fix_tokens.main()
+    fix_tokens.main()
+    data = json.loads(target.read_text())
+    assert data["Messages"]["hash"] == "{a}"
+    metrics = json.loads(metrics_path.read_text())[-1]
+    assert metrics["tokens_removed"] == 1
 
 
 def test_exit_on_mismatch(tmp_path, monkeypatch):
@@ -159,7 +162,7 @@ def test_exit_on_mismatch(tmp_path, monkeypatch):
     )
     (root / "Resources" / "Localization" / "English.json").write_text(json.dumps({}))
     target = messages_dir / "Test.json"
-    target.write_text(json.dumps({"Messages": {"hash": "[[TOKEN_0]] [[TOKEN_1]]"}}))
+    target.write_text(json.dumps({"Messages": {"hash": ""}}))
     metrics_path = root / "metrics.json"
 
     monkeypatch.setattr(
@@ -192,7 +195,7 @@ def test_allow_mismatch(tmp_path, monkeypatch, caplog):
     (messages_dir / "English.json").write_text(json.dumps({"Messages": {"hash": "{a}"}}))
     (root / "Resources" / "Localization" / "English.json").write_text(json.dumps({}))
     target = messages_dir / "Test.json"
-    target.write_text(json.dumps({"Messages": {"hash": "[[TOKEN_0]] [[TOKEN_1]]"}}))
+    target.write_text(json.dumps({"Messages": {"hash": ""}}))
     metrics_path = root / "metrics.json"
 
     monkeypatch.setattr(

--- a/Tools/tests/test_fix_tokens.py
+++ b/Tools/tests/test_fix_tokens.py
@@ -1,0 +1,57 @@
+import json
+import sys
+
+import fix_tokens
+
+
+def test_replace_placeholders_drops_unexpected_tokens():
+    tokens = ["{x}"]
+    value = "start<color=red></color>{x}{y}"
+    new_value, replaced, mismatch, missing, extra, restored = fix_tokens.replace_placeholders(value, tokens)
+    assert new_value == "start{x}"
+    assert replaced and not mismatch and not missing
+    assert extra == ["<color=red>", "</color>", "{y}"]
+    assert not restored
+
+
+def test_check_only_passes_after_removal(tmp_path, monkeypatch):
+    root = tmp_path
+    messages_dir = root / "Resources" / "Localization" / "Messages"
+    messages_dir.mkdir(parents=True)
+    (messages_dir / "English.json").write_text(json.dumps({"Messages": {"hash": "start{x}"}}))
+    # minimal root-level English file for load_english_nodes
+    (root / "Resources" / "Localization" / "English.json").write_text(json.dumps({}))
+    target = messages_dir / "Test.json"
+    target.write_text(json.dumps({"Messages": {"hash": "start<color=red></color>{x}{y}"}}))
+    metrics_path = root / "metrics.json"
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "fix_tokens.py",
+            "--root",
+            str(root),
+            "--metrics-file",
+            str(metrics_path),
+            str(target),
+        ],
+    )
+    fix_tokens.main()
+    data = json.loads(target.read_text())
+    assert data["Messages"]["hash"] == "start{x}"
+    metrics = json.loads(metrics_path.read_text())[-1]
+    assert metrics["tokens_removed"] == 3
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "fix_tokens.py",
+            "--root",
+            str(root),
+            "--check-only",
+            str(target),
+        ],
+    )
+    fix_tokens.main()

--- a/Tools/tests/test_fix_tokens_705325693.py
+++ b/Tools/tests/test_fix_tokens_705325693.py
@@ -12,9 +12,9 @@ def test_replace_placeholders_preserves_quotes_705325693():
         "[PrestigeStat]",
         "</color>",
     ]
-    new_value, replaced, mismatch, missing, extra = fix_tokens.replace_placeholders(value, tokens)
+    new_value, replaced, mismatch, missing, extra, restored = fix_tokens.replace_placeholders(value, tokens)
     assert new_value == (
         "Familiar already has all prestige stats! (\"<color=white>.fam pr</color>\" "
         "instead of '<color=white>.fam pr [PrestigeStat] </color>')"
     )
-    assert replaced and not mismatch and not missing and not extra
+    assert replaced and not mismatch and not missing and not extra and not restored


### PR DESCRIPTION
## Summary
- Ignore placeholder tokens not found in the English baseline during replacement, removing stray tags/variables
- Track and log removed extras with a new `tokens_removed` metric and include them in check-only validation
- Test that unexpected tokens are discarded and that check-only mode passes after cleanup

## Testing
- `pytest Tools/test_fix_tokens_main.py Tools/tests/test_fix_tokens.py Tools/tests/test_fix_tokens_705325693.py Tools/tests/test_placeholder_roundtrip.py Tools/tests/test_placeholder_wrapping.py Tools/tests/test_localization_pipeline_metrics.py`

------
https://chatgpt.com/codex/tasks/task_e_68ba082046c4832dbb966484aab80cf9