### PR TITLE
Improve token reordering and placeholder wrapping

### DIFF
--- a/Tools/translate_argos.py
+++ b/Tools/translate_argos.py
@@ -115,7 +115,7 @@ class FatalTranslationError(Exception):
     """Raised when Argos Translate encounters an unrecoverable error."""
 
 PLACEHOLDER_BASE = 0xE000
-DEFAULT_WRAP_THRESHOLD = 10
+DEFAULT_WRAP_THRESHOLD = 5
 PLACEHOLDER_WRAP_THRESHOLD = DEFAULT_WRAP_THRESHOLD
 
 


### PR DESCRIPTION
## Summary
- Wrap Argos placeholders more aggressively by lowering the default threshold to 5
- Reorder tokens using explicit match spans to support repeated and nested placeholders
- Add regression tests for multi-token lines covering reordering and restoration of dropped tokens

## Testing
- `PYTHONPATH=Tools pytest Tools/tests/test_fix_tokens.py Tools/test_translate_argos_tokens.py`

------
https://chatgpt.com/codex/tasks/task_e_68ba1874e74c832d97349641371b585d