### PR TITLE
Record removed token counts in translation metrics

### DIFF
--- a/Tools/test_translate_argos_tokens.py
+++ b/Tools/test_translate_argos_tokens.py
@@ -240,6 +240,7 @@ def test_extra_placeholders_trimmed(tmp_path, monkeypatch, caplog):
     run_dir = next((root / "translations" / "xx").iterdir())
     metrics = json.loads((run_dir / "metrics.json").read_text())
     assert metrics[0]["hash_stats"]["hash"]["removed_tokens"] == 1
+    assert metrics[0]["tokens_removed"] == 1
 
     monkeypatch.setattr(
         sys, "argv", ["fix_tokens.py", "--root", str(root), "--check-only", target_rel]

--- a/Tools/translate_argos.py
+++ b/Tools/translate_argos.py
@@ -628,6 +628,7 @@ def _finalize_metrics(
             "timeouts": 0,
             "token_reorders": 0,
             "token_mismatches": 0,
+            "tokens_removed": 0,
             "token_mismatch_details": {},
             "failures": {},
             "hash_stats": {},
@@ -662,6 +663,7 @@ def write_failure_metrics(args, error, *, status: str = "failed") -> None:
         timeouts=0,
         token_reorders=0,
         token_mismatches=0,
+        tokens_removed=0,
         retry_attempts=0,
         retry_successes=0,
         retry_missing_tokens=0,
@@ -1438,6 +1440,9 @@ def _run_translation(
             for stats in token_stats.values()
             if stats.get("missing_tokens") or stats.get("removed_tokens")
         )
+        tokens_removed = sum(
+            stats.get("removed_tokens", 0) for stats in token_stats.values()
+        )
         retry_attempts = sum(1 for stats in token_stats.values() if stats.get("retry_attempted"))
         retry_successes = sum(1 for stats in token_stats.values() if stats.get("retry_succeeded"))
         retry_missing_tokens = sum(
@@ -1463,6 +1468,7 @@ def _run_translation(
             "timeouts": timeouts_count,
             "token_reorders": token_reorders,
             "token_mismatches": token_mismatches,
+            "tokens_removed": tokens_removed,
             "retry_attempts": retry_attempts,
             "retry_successes": retry_successes,
             "retry_missing_tokens": retry_missing_tokens,
@@ -1483,6 +1489,9 @@ def _run_translation(
         retry_successes = sum(1 for stats in token_stats.values() if stats.get("retry_succeeded"))
         retry_missing_tokens = sum(stats.get("retry_missing_tokens", 0) for stats in token_stats.values())
         retry_extra_tokens = sum(stats.get("retry_extra_tokens", 0) for stats in token_stats.values())
+        tokens_removed = sum(
+            stats.get("removed_tokens", 0) for stats in token_stats.values()
+        )
         _append_metrics_entry(
             args,
             status="interrupted",
@@ -1491,6 +1500,7 @@ def _run_translation(
             timeouts=timeouts_count,
             token_reorders=token_reorders,
             token_mismatches=token_mismatches,
+            tokens_removed=tokens_removed,
             retry_attempts=retry_attempts,
             retry_successes=retry_successes,
             retry_missing_tokens=retry_missing_tokens,
@@ -1516,6 +1526,9 @@ def _run_translation(
         retry_extra_tokens = sum(
             stats.get("retry_extra_tokens", 0) for stats in token_stats.values()
         )
+        tokens_removed = sum(
+            stats.get("removed_tokens", 0) for stats in token_stats.values()
+        )
         _append_metrics_entry(
             args,
             status="failed",
@@ -1524,6 +1537,7 @@ def _run_translation(
             timeouts=timeouts_count,
             token_reorders=token_reorders,
             token_mismatches=token_mismatches,
+            tokens_removed=tokens_removed,
             retry_attempts=retry_attempts,
             retry_successes=retry_successes,
             retry_missing_tokens=retry_missing_tokens,
@@ -1721,6 +1735,9 @@ def _run_dry_run(
         for stats in token_stats.values()
         if stats.get("missing_tokens") or stats.get("removed_tokens")
     )
+    tokens_removed = sum(
+        stats.get("removed_tokens", 0) for stats in token_stats.values()
+    )
 
     _append_metrics_entry(
         args,
@@ -1730,6 +1747,7 @@ def _run_dry_run(
         timeouts=0,
         token_reorders=token_reorders,
         token_mismatches=token_mismatches,
+        tokens_removed=tokens_removed,
         token_mismatch_details=token_mismatch_details,
         failures={k: v[0] for k, v in failures.items()},
         hash_stats=token_stats,
@@ -2227,6 +2245,7 @@ def main():
                     timeouts=0,
                     token_reorders=0,
                     token_mismatches=0,
+                    tokens_removed=0,
                     token_mismatch_details={},
                     failures={},
                     hash_stats={},
@@ -2244,6 +2263,7 @@ def main():
                 timeouts=0,
                 token_reorders=0,
                 token_mismatches=0,
+                tokens_removed=0,
                 token_mismatch_details={},
                 failures={},
                 hash_stats={},

--- a/metrics_ja.json
+++ b/metrics_ja.json
@@ -127,5 +127,2243 @@
         "reordered": false
       }
     }
+  },
+  {
+    "run_id": "71b6f104-fd73-4b72-93d5-fc7a39d1d2f4",
+    "log_file": "/workspace/Bloodcraft/translations/ja/20250905-011059/translate.log",
+    "report_file": "/workspace/Bloodcraft/translations/ja/20250905-011059/skipped.csv",
+    "metrics_file": "/workspace/Bloodcraft/metrics_ja.json",
+    "git_commit": "c5443aea",
+    "python_version": "3.11.12",
+    "argos_version": "1.8.0",
+    "model_version": "unknown",
+    "cli_args": {
+      "target_file": "Resources/Localization/Messages/Japanese.json",
+      "src": "en",
+      "dst": "ja",
+      "root": "/workspace/Bloodcraft",
+      "run_dir": "/workspace/Bloodcraft/translations/ja/20250905-011059",
+      "batch_size": 100,
+      "max_retries": 3,
+      "timeout": 60,
+      "overwrite": true,
+      "hashes": null,
+      "log_level": "INFO",
+      "verbose": false,
+      "log_file": "/workspace/Bloodcraft/translations/ja/20250905-011059/translate.log",
+      "report_file": "/workspace/Bloodcraft/translations/ja/20250905-011059/skipped.csv",
+      "metrics_file": "/workspace/Bloodcraft/metrics_ja.json",
+      "dry_run": true,
+      "lenient_tokens": false,
+      "retry_mismatches": false,
+      "fix_order": false,
+      "wrap_threshold": 5,
+      "run_index_file": "/workspace/Bloodcraft/translations/run_index.json"
+    },
+    "run_dir": "/workspace/Bloodcraft/translations/ja/20250905-011059",
+    "file": "Resources/Localization/Messages/Japanese.json",
+    "timestamp": "2025-09-05T01:10:59Z",
+    "status": "failed",
+    "processed": 427,
+    "successes": 374,
+    "timeouts": 0,
+    "token_reorders": 0,
+    "token_mismatches": 0,
+    "tokens_removed": 0,
+    "token_mismatch_details": {},
+    "failures": {
+      "117473441": "identical to source",
+      "1519182060": "identical to source",
+      "1763623253": "stray brackets",
+      "3678240084": "identical to source",
+      "2693194341": "stray brackets",
+      "3637474013": "token mismatch () [3eb41622]",
+      "1106946472": "contains English",
+      "2967576286": "identical to source",
+      "3320998835": "contains English",
+      "3815983891": "stray brackets",
+      "2198487874": "identical to source",
+      "4205622287": "identical to source",
+      "1080442941": "identical to source",
+      "277002471": "identical to source",
+      "4193529612": "identical to source",
+      "3925002747": "identical to source",
+      "685629961": "identical to source",
+      "4066783686": "stray brackets",
+      "215076014": "identical to source",
+      "1716911803": "identical to source",
+      "2321621014": "contains English",
+      "2213724716": "identical to source",
+      "2191580006": "token mismatch () [3eb41622]",
+      "2709293439": "token mismatch () [3eb41622]",
+      "2794958495": "contains English",
+      "54858227": "token mismatch () [3eb41622]",
+      "860320001": "token mismatch () [3eb41622]",
+      "4009901629": "token mismatch () [3eb41622]",
+      "2051256929": "identical to source",
+      "4066899438": "identical to source",
+      "2320898349": "identical to source",
+      "2316405313": "contains English",
+      "3399068440": "identical to source",
+      "3066749917": "token mismatch () [3eb41622]",
+      "2511919794": "identical to source",
+      "2978826451": "token mismatch () [3eb41622]",
+      "3938781329": "token mismatch () [3eb41622]",
+      "931800025": "contains English",
+      "3402815477": "identical to source",
+      "2537547396": "identical to source",
+      "1652346821": "identical to source",
+      "1416519130": "identical to source",
+      "2286869349": "token mismatch () [3eb41622]",
+      "370730849": "token mismatch () [3eb41622]",
+      "800655279": "stray brackets",
+      "885434933": "identical to source",
+      "2383766993": "identical to source",
+      "421960942": "identical to source",
+      "2740121583": "identical to source",
+      "1248377615": "identical to source",
+      "2814501768": "identical to source",
+      "3987763597": "identical to source",
+      "2772168133": "stray brackets"
+    },
+    "hash_stats": {
+      "3439613370": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "1491097539": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "117473441": {
+        "original_tokens": 7,
+        "translated_tokens": 7,
+        "reordered": false
+      },
+      "1519182060": {
+        "original_tokens": 5,
+        "translated_tokens": 5,
+        "reordered": false
+      },
+      "606627316": {
+        "original_tokens": 4,
+        "translated_tokens": 4,
+        "reordered": false
+      },
+      "2007397999": {
+        "original_tokens": 10,
+        "translated_tokens": 10,
+        "reordered": false
+      },
+      "1407688215": {
+        "original_tokens": 7,
+        "translated_tokens": 7,
+        "reordered": false
+      },
+      "2252098529": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "3115116616": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "2972244104": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "4110714393": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "3997845506": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "3141472524": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "2576121314": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "3665962604": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "3324923525": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "3054245516": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "2786260061": {
+        "original_tokens": 2,
+        "translated_tokens": 2,
+        "reordered": false
+      },
+      "311765273": {
+        "original_tokens": 2,
+        "translated_tokens": 2,
+        "reordered": false
+      },
+      "1763623253": {
+        "original_tokens": 17,
+        "translated_tokens": 17,
+        "reordered": false
+      },
+      "384069927": {
+        "original_tokens": 7,
+        "translated_tokens": 7,
+        "reordered": false
+      },
+      "1884892470": {
+        "original_tokens": 7,
+        "translated_tokens": 7,
+        "reordered": false
+      },
+      "3678240084": {
+        "original_tokens": 5,
+        "translated_tokens": 5,
+        "reordered": false
+      },
+      "2693194341": {
+        "original_tokens": 13,
+        "translated_tokens": 13,
+        "reordered": false
+      },
+      "3158650477": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "2673031653": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "3637474013": {
+        "original_tokens": 16,
+        "translated_tokens": 18,
+        "reordered": true
+      },
+      "2932385107": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "1076291728": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "1420278477": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "3546356968": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "2169578147": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "223311103": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "2155028867": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "2689850927": {
+        "original_tokens": 2,
+        "translated_tokens": 2,
+        "reordered": false
+      },
+      "3125006928": {
+        "original_tokens": 8,
+        "translated_tokens": 8,
+        "reordered": false
+      },
+      "2846646667": {
+        "original_tokens": 2,
+        "translated_tokens": 2,
+        "reordered": false
+      },
+      "705325693": {
+        "original_tokens": 5,
+        "translated_tokens": 5,
+        "reordered": false
+      },
+      "2712718738": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "872190851": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "3466860311": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "3720524051": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "3543031585": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "1106946472": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "2164633984": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "1293896668": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "2147420594": {
+        "original_tokens": 4,
+        "translated_tokens": 4,
+        "reordered": false
+      },
+      "999548370": {
+        "original_tokens": 4,
+        "translated_tokens": 4,
+        "reordered": false
+      },
+      "460602473": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "442755566": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "2967576286": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "1597216248": {
+        "original_tokens": 2,
+        "translated_tokens": 2,
+        "reordered": false
+      },
+      "2747211297": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "2761429858": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "327031724": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "625301684": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "3944404979": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "2979158417": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "2350508902": {
+        "original_tokens": 2,
+        "translated_tokens": 2,
+        "reordered": false
+      },
+      "1897692916": {
+        "original_tokens": 2,
+        "translated_tokens": 2,
+        "reordered": false
+      },
+      "9816116": {
+        "original_tokens": 5,
+        "translated_tokens": 5,
+        "reordered": false
+      },
+      "3729714988": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "2402733055": {
+        "original_tokens": 12,
+        "translated_tokens": 12,
+        "reordered": false
+      },
+      "3961332984": {
+        "original_tokens": 12,
+        "translated_tokens": 12,
+        "reordered": false
+      },
+      "145841390": {
+        "original_tokens": 4,
+        "translated_tokens": 4,
+        "reordered": false
+      },
+      "2076214502": {
+        "original_tokens": 2,
+        "translated_tokens": 2,
+        "reordered": false
+      },
+      "1641131342": {
+        "original_tokens": 2,
+        "translated_tokens": 2,
+        "reordered": false
+      },
+      "484801240": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "11642316": {
+        "original_tokens": 9,
+        "translated_tokens": 9,
+        "reordered": false
+      },
+      "836746607": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "2332227846": {
+        "original_tokens": 2,
+        "translated_tokens": 2,
+        "reordered": false
+      },
+      "3706109126": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "1689690159": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "3055902112": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "3468772905": {
+        "original_tokens": 4,
+        "translated_tokens": 4,
+        "reordered": false
+      },
+      "3343555659": {
+        "original_tokens": 9,
+        "translated_tokens": 9,
+        "reordered": false
+      },
+      "101395383": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "3878313095": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "1411528307": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "3318828181": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "830139985": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "2461283441": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "3320998835": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "947905559": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "1182925736": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "1687700552": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "1763729577": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "1711247206": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "3882215894": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "1884272339": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "816810753": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "3587073963": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "1440482998": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "2659109549": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "2178615132": {
+        "original_tokens": 2,
+        "translated_tokens": 2,
+        "reordered": false
+      },
+      "1797973559": {
+        "original_tokens": 2,
+        "translated_tokens": 2,
+        "reordered": false
+      },
+      "985830382": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "3170250471": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "3591926048": {
+        "original_tokens": 18,
+        "translated_tokens": 18,
+        "reordered": false
+      },
+      "3489173133": {
+        "original_tokens": 4,
+        "translated_tokens": 4,
+        "reordered": false
+      },
+      "3863739608": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "4023020194": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "736301693": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "27929505": {
+        "original_tokens": 2,
+        "translated_tokens": 2,
+        "reordered": false
+      },
+      "1880632188": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "2008856310": {
+        "original_tokens": 2,
+        "translated_tokens": 2,
+        "reordered": false
+      },
+      "3274700132": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "719993404": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "2128999876": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "2252129438": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "2480816305": {
+        "original_tokens": 9,
+        "translated_tokens": 9,
+        "reordered": false
+      },
+      "3013651462": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "2965167816": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "3084457547": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "2202242526": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "2998300513": {
+        "original_tokens": 4,
+        "translated_tokens": 4,
+        "reordered": false
+      },
+      "3761416018": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "1826355702": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "2712082651": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "1846116445": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "446698782": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "313887201": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "121410310": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "4061888430": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "3361608225": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "18401539": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "3335571950": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "2194796157": {
+        "original_tokens": 2,
+        "translated_tokens": 2,
+        "reordered": false
+      },
+      "4126149106": {
+        "original_tokens": 2,
+        "translated_tokens": 2,
+        "reordered": false
+      },
+      "4258273173": {
+        "original_tokens": 2,
+        "translated_tokens": 2,
+        "reordered": false
+      },
+      "1680589832": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "1381058165": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "3815983891": {
+        "original_tokens": 18,
+        "translated_tokens": 18,
+        "reordered": false
+      },
+      "2198487874": {
+        "original_tokens": 4,
+        "translated_tokens": 4,
+        "reordered": false
+      },
+      "4205622287": {
+        "original_tokens": 5,
+        "translated_tokens": 5,
+        "reordered": false
+      },
+      "1080442941": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "277002471": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "4193529612": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "3925002747": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "685629961": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "4066783686": {
+        "original_tokens": 9,
+        "translated_tokens": 9,
+        "reordered": false
+      },
+      "215076014": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "1716911803": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "863911874": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "1066178325": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "2462277004": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "1977482431": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "2321621014": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "854134032": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "321106656": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "2465841402": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "698362524": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "1575879194": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "823180732": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "3236338434": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "2213724716": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "4289445665": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "3279926559": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "2724064627": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "2648123409": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "2179875375": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "2721627196": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "1976698463": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "3052690511": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "3195375072": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "3380184352": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "3498334942": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "4255236631": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "2191580006": {
+        "original_tokens": 7,
+        "translated_tokens": 12,
+        "reordered": true
+      },
+      "1809964020": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "1057363547": {
+        "original_tokens": 8,
+        "translated_tokens": 8,
+        "reordered": false
+      },
+      "780970161": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "615667259": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "210979117": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "744989655": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "3960937922": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "3219279796": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "2720898024": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "3946665029": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "2709293439": {
+        "original_tokens": 15,
+        "translated_tokens": 16,
+        "reordered": true
+      },
+      "2794958495": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "488752679": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "1440602422": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "2526362535": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "701382701": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "802918832": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "1391708521": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "3235862068": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "54858227": {
+        "original_tokens": 9,
+        "translated_tokens": 10,
+        "reordered": true
+      },
+      "3334433396": {
+        "original_tokens": 11,
+        "translated_tokens": 11,
+        "reordered": false
+      },
+      "2169705185": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "1469754031": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "628275031": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "2474938940": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "4055019293": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "1939118629": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "1516467471": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "284459823": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "2165480178": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "1581983564": {
+        "original_tokens": 2,
+        "translated_tokens": 2,
+        "reordered": false
+      },
+      "2682530289": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "53933494": {
+        "original_tokens": 2,
+        "translated_tokens": 2,
+        "reordered": false
+      },
+      "2486628899": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "3170335283": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "1354182381": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "318734715": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "1228611582": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "3819833139": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "1081599663": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "3628025920": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "480925981": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "3862629133": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "3182929151": {
+        "original_tokens": 4,
+        "translated_tokens": 4,
+        "reordered": false
+      },
+      "1894878159": {
+        "original_tokens": 4,
+        "translated_tokens": 4,
+        "reordered": false
+      },
+      "4162514026": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "907868427": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "2129553669": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "2968342812": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "3664649404": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "2228202821": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "349704338": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "2817263998": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "1231839381": {
+        "original_tokens": 5,
+        "translated_tokens": 5,
+        "reordered": false
+      },
+      "3761848707": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "2557313311": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "1836101498": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "2271729042": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "1955962459": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "4007697799": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "2563987683": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "3823143990": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "3878896595": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "334075444": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "1952946751": {
+        "original_tokens": 2,
+        "translated_tokens": 2,
+        "reordered": false
+      },
+      "860320001": {
+        "original_tokens": 8,
+        "translated_tokens": 9,
+        "reordered": true
+      },
+      "1985982508": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "677562659": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "1677522996": {
+        "original_tokens": 2,
+        "translated_tokens": 2,
+        "reordered": false
+      },
+      "4009901629": {
+        "original_tokens": 8,
+        "translated_tokens": 9,
+        "reordered": true
+      },
+      "707311945": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "2402916111": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "3719118489": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "563018011": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "3751423711": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "998944061": {
+        "original_tokens": 2,
+        "translated_tokens": 2,
+        "reordered": false
+      },
+      "1496603105": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "107297214": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "743696282": {
+        "original_tokens": 15,
+        "translated_tokens": 15,
+        "reordered": false
+      },
+      "2051256929": {
+        "original_tokens": 7,
+        "translated_tokens": 7,
+        "reordered": false
+      },
+      "400324857": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "3681675424": {
+        "original_tokens": 5,
+        "translated_tokens": 5,
+        "reordered": false
+      },
+      "2437634726": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "1254994229": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "317079168": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "1548584430": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "2935471585": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "134200388": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "216725398": {
+        "original_tokens": 13,
+        "translated_tokens": 13,
+        "reordered": false
+      },
+      "1201875369": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "2095668308": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "2554001784": {
+        "original_tokens": 7,
+        "translated_tokens": 7,
+        "reordered": false
+      },
+      "3320804900": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "2410464917": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "947371822": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "714432788": {
+        "original_tokens": 10,
+        "translated_tokens": 10,
+        "reordered": false
+      },
+      "173404118": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "24953571": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "2497805382": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "2645405211": {
+        "original_tokens": 2,
+        "translated_tokens": 2,
+        "reordered": false
+      },
+      "677404705": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "1562141642": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "2001389111": {
+        "original_tokens": 2,
+        "translated_tokens": 2,
+        "reordered": false
+      },
+      "20873033": {
+        "original_tokens": 5,
+        "translated_tokens": 5,
+        "reordered": false
+      },
+      "4140406916": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "1282509635": {
+        "original_tokens": 2,
+        "translated_tokens": 2,
+        "reordered": false
+      },
+      "501637283": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "3938051122": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "167244174": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "3730830670": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "349267262": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "4066899438": {
+        "original_tokens": 2,
+        "translated_tokens": 2,
+        "reordered": false
+      },
+      "2320898349": {
+        "original_tokens": 2,
+        "translated_tokens": 2,
+        "reordered": false
+      },
+      "3756348742": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "1769980541": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "4003734136": {
+        "original_tokens": 4,
+        "translated_tokens": 4,
+        "reordered": false
+      },
+      "2069903402": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "2817800174": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "2316405313": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "2303740299": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "3125108847": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "3399068440": {
+        "original_tokens": 30,
+        "translated_tokens": 30,
+        "reordered": false
+      },
+      "1345204457": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "3732046729": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "479209254": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "1443941563": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "3066749917": {
+        "original_tokens": 16,
+        "translated_tokens": 18,
+        "reordered": true
+      },
+      "1465975319": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "1945389717": {
+        "original_tokens": 4,
+        "translated_tokens": 4,
+        "reordered": false
+      },
+      "2511919794": {
+        "original_tokens": 7,
+        "translated_tokens": 7,
+        "reordered": false
+      },
+      "508045935": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "52573990": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "1904876515": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "3706417587": {
+        "original_tokens": 2,
+        "translated_tokens": 2,
+        "reordered": false
+      },
+      "1095669519": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "3112026815": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "881612152": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "2978826451": {
+        "original_tokens": 16,
+        "translated_tokens": 18,
+        "reordered": true
+      },
+      "1669157395": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "2346236465": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "835889078": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "361092587": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "2272306226": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "4226920647": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "1695244872": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "2428442751": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "1271017097": {
+        "original_tokens": 5,
+        "translated_tokens": 5,
+        "reordered": false
+      },
+      "3938781329": {
+        "original_tokens": 7,
+        "translated_tokens": 12,
+        "reordered": true
+      },
+      "3139406824": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "3055272330": {
+        "original_tokens": 11,
+        "translated_tokens": 11,
+        "reordered": false
+      },
+      "66882170": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "617911048": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "1651916565": {
+        "original_tokens": 4,
+        "translated_tokens": 4,
+        "reordered": false
+      },
+      "931800025": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "3402815477": {
+        "original_tokens": 30,
+        "translated_tokens": 30,
+        "reordered": false
+      },
+      "493237764": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "3326145371": {
+        "original_tokens": 15,
+        "translated_tokens": 15,
+        "reordered": false
+      },
+      "2537547396": {
+        "original_tokens": 7,
+        "translated_tokens": 7,
+        "reordered": false
+      },
+      "842146063": {
+        "original_tokens": 5,
+        "translated_tokens": 5,
+        "reordered": false
+      },
+      "566938273": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "2828720719": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "3097544876": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "1446811317": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "1652346821": {
+        "original_tokens": 2,
+        "translated_tokens": 2,
+        "reordered": false
+      },
+      "1416519130": {
+        "original_tokens": 2,
+        "translated_tokens": 2,
+        "reordered": false
+      },
+      "2137562404": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "2698551496": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "2286869349": {
+        "original_tokens": 8,
+        "translated_tokens": 9,
+        "reordered": true
+      },
+      "4273383622": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "370730849": {
+        "original_tokens": 8,
+        "translated_tokens": 9,
+        "reordered": true
+      },
+      "1315865629": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "3744708697": {
+        "original_tokens": 2,
+        "translated_tokens": 2,
+        "reordered": false
+      },
+      "3648038609": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "692006723": {
+        "original_tokens": 2,
+        "translated_tokens": 2,
+        "reordered": false
+      },
+      "2174214346": {
+        "original_tokens": 4,
+        "translated_tokens": 4,
+        "reordered": false
+      },
+      "1218917876": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "1105957988": {
+        "original_tokens": 7,
+        "translated_tokens": 7,
+        "reordered": false
+      },
+      "800655279": {
+        "original_tokens": 16,
+        "translated_tokens": 16,
+        "reordered": false
+      },
+      "3499636759": {
+        "original_tokens": 8,
+        "translated_tokens": 8,
+        "reordered": false
+      },
+      "2615857787": {
+        "original_tokens": 5,
+        "translated_tokens": 5,
+        "reordered": false
+      },
+      "743202161": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "3914295487": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "4052165110": {
+        "original_tokens": 9,
+        "translated_tokens": 9,
+        "reordered": false
+      },
+      "2121377442": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "935039462": {
+        "original_tokens": 8,
+        "translated_tokens": 8,
+        "reordered": false
+      },
+      "4049081768": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "1757634753": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "3637584655": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "835968431": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "559704045": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "2637421818": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "2323778454": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "3613050716": {
+        "original_tokens": 4,
+        "translated_tokens": 4,
+        "reordered": false
+      },
+      "9562573": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "2421466322": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "885434933": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "2214985381": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "2316242941": {
+        "original_tokens": 4,
+        "translated_tokens": 4,
+        "reordered": false
+      },
+      "203356865": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "132267140": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "608689499": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "2383766993": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "1899346128": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "1178832936": {
+        "original_tokens": 11,
+        "translated_tokens": 11,
+        "reordered": false
+      },
+      "1223341524": {
+        "original_tokens": 15,
+        "translated_tokens": 15,
+        "reordered": false
+      },
+      "3443164458": {
+        "original_tokens": 2,
+        "translated_tokens": 2,
+        "reordered": false
+      },
+      "4052025947": {
+        "original_tokens": 2,
+        "translated_tokens": 2,
+        "reordered": false
+      },
+      "421960942": {
+        "original_tokens": 2,
+        "translated_tokens": 2,
+        "reordered": false
+      },
+      "2740121583": {
+        "original_tokens": 2,
+        "translated_tokens": 2,
+        "reordered": false
+      },
+      "1248377615": {
+        "original_tokens": 4,
+        "translated_tokens": 4,
+        "reordered": false
+      },
+      "406861876": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "1014495694": {
+        "original_tokens": 4,
+        "translated_tokens": 4,
+        "reordered": false
+      },
+      "1762641650": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "2495105303": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "861952046": {
+        "original_tokens": 5,
+        "translated_tokens": 5,
+        "reordered": false
+      },
+      "85794626": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "2925666850": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "1318067012": {
+        "original_tokens": 8,
+        "translated_tokens": 8,
+        "reordered": false
+      },
+      "2577116713": {
+        "original_tokens": 2,
+        "translated_tokens": 2,
+        "reordered": false
+      },
+      "179462471": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "1744159514": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "2471836655": {
+        "original_tokens": 2,
+        "translated_tokens": 2,
+        "reordered": false
+      },
+      "2814501768": {
+        "original_tokens": 7,
+        "translated_tokens": 7,
+        "reordered": false
+      },
+      "3987763597": {
+        "original_tokens": 5,
+        "translated_tokens": 5,
+        "reordered": false
+      },
+      "2772168133": {
+        "original_tokens": 4,
+        "translated_tokens": 4,
+        "reordered": false
+      },
+      "2731743065": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "110573833": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "3116249505": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "4177199465": {
+        "original_tokens": 4,
+        "translated_tokens": 4,
+        "reordered": false
+      },
+      "3105730177": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "3060176103": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "206072549": {
+        "original_tokens": 2,
+        "translated_tokens": 2,
+        "reordered": false
+      },
+      "3540014872": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "159434725": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "1446796844": {
+        "original_tokens": 2,
+        "translated_tokens": 2,
+        "reordered": false
+      },
+      "1214712585": {
+        "original_tokens": 2,
+        "translated_tokens": 2,
+        "reordered": false
+      },
+      "159604155": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "3182899806": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "3133295357": {
+        "original_tokens": 18,
+        "translated_tokens": 18,
+        "reordered": false
+      },
+      "4190631897": {
+        "original_tokens": 4,
+        "translated_tokens": 4,
+        "reordered": false
+      },
+      "1641855254": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "2881393089": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "2997561401": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "2687655344": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "1454481026": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "2508084566": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "3227554981": {
+        "original_tokens": 9,
+        "translated_tokens": 9,
+        "reordered": false
+      },
+      "1369871380": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "1601487032": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "3060695596": {
+        "original_tokens": 6,
+        "translated_tokens": 6,
+        "reordered": false
+      },
+      "3097011724": {
+        "original_tokens": 2,
+        "translated_tokens": 2,
+        "reordered": false
+      },
+      "3102592194": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "2844729307": {
+        "original_tokens": 3,
+        "translated_tokens": 3,
+        "reordered": false
+      },
+      "3002809107": {
+        "original_tokens": 1,
+        "translated_tokens": 1,
+        "reordered": false
+      },
+      "2597161495": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "2660507905": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "182159004": {
+        "original_tokens": 0,
+        "translated_tokens": 0,
+        "reordered": false
+      },
+      "2336012040": {
+        "original_tokens": 2,
+        "translated_tokens": 2,
+        "reordered": false
+      }
+    },
+    "dry_run": true,
+    "sentinel_retry_hashes": []
   }
 ]


### PR DESCRIPTION
## Summary
- track removed placeholder tokens in translation run metrics
- exercise metrics in tests and update Japanese metrics sample

## Testing
- `pytest Tools/test_translate_argos_tokens.py Tools/test_translate_argos_retry.py`
- `python Tools/translate_argos.py Resources/Localization/Messages/Japanese.json --to ja --batch-size 100 --max-retries 3 --log-level INFO --overwrite --metrics-file metrics_ja.json --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_68ba369d20a4832db4f7ec341b96bb81