### PR TITLE
Handle token-only lines without translation

### DIFF
--- a/Tools/test_translate_argos.py
+++ b/Tools/test_translate_argos.py
@@ -692,7 +692,7 @@ def test_sentinel_missing_repaired(tmp_path, monkeypatch, caplog):
     assert rows == []
     data = json.loads((root / target_rel).read_text())
     assert data["Messages"]["hash"] == "{name}"
-    assert "hash: sentinel missing, reinserting" in caplog.text
+    assert "sentinel missing" not in caplog.text
 
 
 def test_sentinel_only_report(tmp_path, monkeypatch):
@@ -741,12 +741,11 @@ def test_sentinel_only_report(tmp_path, monkeypatch):
         ],
     )
 
-    with pytest.raises(SystemExit) as exc:
-        translate_argos.main()
-    assert exc.value.code == 1
+    translate_argos.main()
     rows = list(csv.DictReader(report_path.open()))
-    assert rows[0]["category"] == "sentinel"
-    assert "sentinel only" in rows[0]["reason"]
+    assert rows == []
+    data = json.loads((root / target_rel).read_text())
+    assert data["Messages"]["hash"] == "{name}"
 
 
 def test_placeholder_only_report(tmp_path, monkeypatch):

--- a/Tools/test_validate_translation_run.py
+++ b/Tools/test_validate_translation_run.py
@@ -1,5 +1,4 @@
 import csv
-import csv
 import json
 import subprocess
 import sys
@@ -59,3 +58,30 @@ def test_success_without_issues(tmp_path: Path) -> None:
     assert "Token mismatch report: 0 entries" in proc.stdout
     summary = json.loads((run_dir / "token_mismatch_summary.json").read_text(encoding="utf-8"))
     assert summary == {}
+
+
+def test_copied_lines_count_as_translated(tmp_path: Path) -> None:
+    run_dir = tmp_path
+    (run_dir / "translate.log").write_text(
+        "hash1: SKIPPED (copied)\n", encoding="utf-8"
+    )
+    _write_csv(
+        run_dir / "skipped.csv",
+        [
+            {
+                "hash": "h1",
+                "english": "e",
+                "reason": "copied",
+                "category": "copied",
+            }
+        ],
+    )
+    (run_dir / "token_mismatches.json").write_text("[]", encoding="utf-8")
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--run-dir", str(run_dir)],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0
+    assert "Log results: 1 TRANSLATED, 0 SKIPPED" in proc.stdout
+    assert "copied" not in proc.stdout

--- a/Tools/translate_argos.py
+++ b/Tools/translate_argos.py
@@ -819,11 +819,9 @@ def _run_translation(
     for key, text in to_translate:
         safe, tokens = protect_strict(text)
         token_only = TOKEN_RE.sub("", safe).strip() == ""
-        if token_only and args.lenient_tokens and len(tokens) > 1:
+        if token_only:
             pretranslated.append((key, english[key], tokens))
             continue
-        if token_only:
-            safe += f" {TOKEN_SENTINEL}"
         safe_lines.append(safe)
         tokens_list.append((tokens, token_only))
         keys.append(key)

--- a/Tools/validate_translation_run.py
+++ b/Tools/validate_translation_run.py
@@ -32,11 +32,11 @@ def summarize_log(path: Path) -> tuple[int, int, Counter[str]]:
                 if not m:
                     continue
                 status, reason = m.group(1), (m.group(2) or "")
-                if status == "TRANSLATED":
+                cleaned = reason.strip().lower().replace(" ", "_")
+                if status == "TRANSLATED" or cleaned == "copied":
                     translated += 1
                 else:
                     skipped += 1
-                    cleaned = reason.strip().lower().replace(" ", "_")
                     if cleaned:
                         reasons[cleaned] += 1
     except FileNotFoundError:
@@ -51,7 +51,10 @@ def summarize_skipped(path: Path) -> Counter[str]:
             reader = csv.DictReader(fp)
             for row in reader:
                 cat = (row.get("category") or "unknown").strip() or "unknown"
-                counts[cat] += 1
+                cleaned = cat.lower().replace(" ", "_")
+                if cleaned == "copied":
+                    continue
+                counts[cleaned] += 1
     except FileNotFoundError:
         pass
     return counts


### PR DESCRIPTION
## Summary
- Short-circuit token-only lines in the translation script by copying the English text directly
- Ignore copied token-only lines in validation metrics so they count as translated
- Exercise the new behavior with additional tests

## Testing
- `pytest Tools/test_validate_translation_run.py Tools/test_translate_argos.py`
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-6.0` *(fails: Package 'dotnet-sdk-6.0' has no installation candidate)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0586bb88832da0b9dd6c3be904c3