### PR TITLE
feat: log identical translations

### DIFF
--- a/Docs/Localization.md
+++ b/Docs/Localization.md
@@ -114,11 +114,14 @@ Argos models are stored under `Resources/Localization/Models/<LANG>` as split ar
 4. **Handle skipped rows**
 
    Any hashes listed in `skipped.csv` within the run directory must be
-   translated manually. The translator automatically retries lines that
-   consist solely of `[[TOKEN_n]]` placeholders with `--lenient-tokens`,
-   but hashes that still output only placeholders are flagged under the
-   `sentinel` category and require manual translation. Re-run the
-   translator until the file is empty. After translating, capture
+   translated manually. After the pipeline retries problematic hashes, it
+   writes an `identical.csv` file for any entries that still match the
+   English source exactly; review and translate those rows as well. The
+   translator automatically retries lines that consist solely of
+   `[[TOKEN_n]]` placeholders with `--lenient-tokens`, but hashes that
+   still output only placeholders are flagged under the `sentinel`
+   category and require manual translation. Re-run the translator until
+   the file is empty. After translating, capture
    placeholder issues alongside the skip report:
 
    ```bash


### PR DESCRIPTION
## Summary
- log hashes with identical translations to `identical.csv` for manual review
- document the new report for translators
- cover `identical.csv` generation with a test

## Testing
- `pytest Tools/test_localization_pipeline_metrics.py -q`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bb078141b0832db905947defbed837