### PR TITLE
docs: clarify Argos model reassembly

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ Current PRDs and task lists are stored in `.project-management/current-prd/`, wh
 
 ### Translation Workflow
 
+0. **Reassemble Argos models for each language.** Rebuild and install the translation models before running any command that depends on them (translation, token fixing, or `check-translations`). Models are not persisted across sessions; use the reconstruction snippet below to restore them.
 1. **Refresh the English source.**
    `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- generate-messages`
 2. **Propagate new hashes.** Copy the refreshed `English.json` entries into each `Resources/Localization/Messages/<Language>.json` while preserving numeric hashes.

--- a/Docs/Localization.md
+++ b/Docs/Localization.md
@@ -6,6 +6,8 @@ Bloodcraft uses hash-based localization. Follow these steps when adding or editi
 
 Install the .NET 8 SDK and the .NET 6 runtime. Verify with `dotnet --list-runtimes` that `Microsoft.NETCore.App 6.0.x` is installed before running any `dotnet run` commands.
 
+Argos translation models are not persisted across sessions. At the start of every session—and before running any command that relies on them (`translate_argos.py`, `fix_tokens.py`, or `check-translations`)—reassemble and install the appropriate model for each language. The reconstruction snippet later in this guide shows the exact commands.
+
 Before introducing a new message, check the catalog in
 `Docs/MessageKeys.md` to avoid creating duplicate entries. Run
 `python Tools/generate_message_catalog.py` if you change
@@ -36,7 +38,7 @@ The script preserves existing translations, adds any new English hashes, and rem
 
 Only the JSON files in `Resources/Localization/Messages` contain user-facing messages. Use Argos Translate to automate translating these files.
 
-Argos models are stored under `Resources/Localization/Models/<LANG>` as split archives and must be reconstructed and installed at the start of each session:
+Argos models are stored under `Resources/Localization/Models/<LANG>` as split archives and must be reconstructed and installed at the start of each session before running the translator, token fixer, or `check-translations`:
 
 1. **Reassemble and install the model**
 


### PR DESCRIPTION
## Summary
- require Argos models to be rebuilt at the start of every translation session
- document model reassembly requirement across localization workflow

## Testing
- `~/.dotnet/dotnet test Bloodcraft.Tests/Bloodcraft.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68bb1c55e79c832d893c33789d6122b0