### PR TITLE
Add Argos model preflight utility and integrate with translation scripts

### DIFF
--- a/Docs/Localization.md
+++ b/Docs/Localization.md
@@ -6,7 +6,13 @@ Bloodcraft uses hash-based localization. Follow these steps when adding or editi
 
 Install the .NET 8 SDK and the .NET 6 runtime. Verify with `dotnet --list-runtimes` that `Microsoft.NETCore.App 6.0.x` is installed before running any `dotnet run` commands.
 
-Argos translation models are not persisted across sessions. At the start of every session—and before running any command that relies on them (`translate_argos.py`, `fix_tokens.py`, or `check-translations`)—reassemble and install the appropriate model for each language. The reconstruction snippet later in this guide shows the exact commands.
+Argos translation models are not persisted across sessions. At the start of every session—and before running any command that relies on them (`translate_argos.py`, `fix_tokens.py`, or `check-translations`)—reconstruct and install the appropriate model for each language using the preflight utility:
+
+```bash
+python Tools/ensure_argos_model.py <iso-code>
+```
+
+Run this once per language per session. The script rebuilds the split archives under `Resources/Localization/Models/<iso-code>` and installs the Argos package if it is missing.
 
 Before introducing a new message, check the catalog in
 `Docs/MessageKeys.md` to avoid creating duplicate entries. Run
@@ -40,7 +46,15 @@ Only the JSON files in `Resources/Localization/Messages` contain user-facing mes
 
 Argos models are stored under `Resources/Localization/Models/<LANG>` as split archives and must be reconstructed and installed at the start of each session before running the translator, token fixer, or `check-translations`:
 
-1. **Reassemble and install the model**
+1. **Prepare the model**
+
+   ```bash
+   python Tools/ensure_argos_model.py <iso-code>
+   ```
+
+   The utility combines the split archives under `Resources/Localization/Models/<iso-code>`, verifies the metadata and installs the package if necessary.
+
+   To perform the steps manually:
 
    ```bash
    cd Resources/Localization/Models/<LANG>
@@ -49,8 +63,6 @@ Argos models are stored under `Resources/Localization/Models/<LANG>` as split ar
    unzip -p translate-*.argosmodel */metadata.json | jq '.from_code, .to_code'
    argos-translate install translate-*.argosmodel
    ```
-
-   Run these commands every session to rebuild the model archive and confirm the `from_code`/`to_code` pair.
 
 2. **Verify model installation**
 
@@ -538,7 +550,7 @@ python Tools/summarize_token_stats.py translations/de/<timestamp>/translate.log
 
 ## Troubleshooting & Notes
 
-- **Argos model installation**: If the `argos-translate install` subcommand is unavailable, reassemble the split archives as shown above and install using the Python API each session:
+- **Argos model installation**: If the `argos-translate install` subcommand is unavailable, run the preflight utility or manually reassemble the split archives and install using the Python API each session:
   ```bash
   cd Resources/Localization/Models/EN_ES
   cat translate-*.z[0-9][0-9] translate-*.zip > model.zip

--- a/Tools/ensure_argos_model.py
+++ b/Tools/ensure_argos_model.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Reconstruct and install Argos translation models.
+
+Ensures the Argos model for a given target language code is installed.
+If ``argostranslate`` reports the model missing, split archives under
+``Resources/Localization/Models/<code>`` are combined, extracted, and
+installed automatically.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+from pathlib import Path
+import zipfile
+
+from argostranslate import translate as argos_translate
+import argostranslate.package as argos_package
+
+
+def _combine_segments(model_dir: Path) -> Path:
+    """Combine split ``translate-*.z??`` parts into ``model.zip``.
+
+    Returns the path to the combined zip archive.
+    """
+    segments = sorted(model_dir.glob("translate-*.z[0-9][0-9]"))
+    zip_part = next(model_dir.glob("translate-*.zip"), None)
+    if not segments or zip_part is None:
+        raise FileNotFoundError(
+            f"Missing model segments in {model_dir}. Re-clone or download the model files."
+        )
+    model_zip = model_dir / "model.zip"
+    with model_zip.open("wb") as out:
+        for seg in segments:
+            out.write(seg.read_bytes())
+        out.write(zip_part.read_bytes())
+    return model_zip
+
+
+def _extract_archive(model_zip: Path) -> Path:
+    """Extract ``model.zip`` and return the resulting ``.argosmodel`` path."""
+    subprocess.run(["unzip", "-o", model_zip.name], cwd=model_zip.parent, check=True)
+    argosmodel = next(model_zip.parent.glob("translate-*.argosmodel"), None)
+    if argosmodel is None:
+        raise FileNotFoundError(
+            f"Failed to extract Argos model from {model_zip}."
+        )
+    return argosmodel
+
+
+def _verify_metadata(argosmodel: Path, code: str) -> None:
+    """Confirm the ``from_code`` and ``to_code`` match ``en`` and ``code``."""
+    with zipfile.ZipFile(argosmodel, "r") as zf:
+        metadata_name = next(
+            (n for n in zf.namelist() if n.endswith("metadata.json")), None
+        )
+        if metadata_name is None:
+            raise RuntimeError("metadata.json not found in Argos model")
+        metadata = json.loads(zf.read(metadata_name).decode("utf-8"))
+    from_code = metadata.get("from_code")
+    to_code = metadata.get("to_code")
+    if from_code != "en" or to_code != code:
+        raise RuntimeError(
+            f"Model metadata mismatch: expected en->{code}, got {from_code}->{to_code}"
+        )
+
+
+def ensure_model(code: str, root: Path) -> bool:
+    """Ensure Argos model for ``en`` -> ``code`` is installed.
+
+    Returns ``True`` if installation occurred, ``False`` if already installed.
+    """
+    argos_translate.load_installed_languages()
+    translator = argos_translate.get_translation_from_codes("en", code)
+    if translator is not None:
+        return False
+
+    model_dir = root / "Resources" / "Localization" / "Models" / code
+    if not model_dir.is_dir():
+        raise FileNotFoundError(f"Model directory {model_dir} does not exist")
+
+    model_zip = _combine_segments(model_dir)
+    argosmodel = _extract_archive(model_zip)
+    _verify_metadata(argosmodel, code)
+    argos_package.install_from_path(str(argosmodel))
+    argos_translate.load_installed_languages()
+    if argos_translate.get_translation_from_codes("en", code) is None:
+        raise RuntimeError(f"Failed to install Argos model for en->{code}")
+    return True
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description="Reconstruct and install the Argos model for a target language code"
+    )
+    ap.add_argument("code", help="Target language ISO code")
+    ap.add_argument(
+        "--root",
+        default=Path(__file__).resolve().parents[1],
+        help="Repository root (defaults to project root)",
+    )
+    args = ap.parse_args()
+    root = Path(args.root).resolve()
+    installed = ensure_model(args.code, root)
+    if installed:
+        print(f"Installed Argos model for en->{args.code}")
+    else:
+        print(f"Argos model for en->{args.code} already installed")
+
+
+if __name__ == "__main__":
+    main()

--- a/Tools/fix_tokens.py
+++ b/Tools/fix_tokens.py
@@ -12,6 +12,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List, Tuple
 
+from ensure_argos_model import ensure_model
+from language_utils import CODE_TO_LANG
+
+LANG_NAME_TO_CODE = {v: k for k, v in CODE_TO_LANG.items()}
+
 from translate_argos import normalize_tokens
 from token_patterns import (
     TOKEN_PATTERN,
@@ -360,6 +365,16 @@ def main() -> None:
         files = list((root / "Resources" / "Localization" / "Messages").glob("*.json"))
         files = [p for p in files if p.name != "English.json"]
         files += [p for p in (root / "Resources" / "Localization").glob("*.json") if p.name != "English.json"]
+
+    for path in files:
+        lang_code = LANG_NAME_TO_CODE.get(path.stem.lower())
+        if lang_code:
+            try:
+                ensure_model(lang_code, root)
+            except Exception as e:
+                logger.warning(
+                    "Argos model for en→%s not installed: %s", lang_code, e
+                )
 
     totals = Counters()
     all_mismatches: List[Dict[str, List[str]]] = []

--- a/Tools/translate.py
+++ b/Tools/translate.py
@@ -11,6 +11,8 @@ from typing import List
 from argostranslate import translate as argos_translate
 from language_utils import contains_english
 from translate_argos import normalize_tokens
+from ensure_argos_model import ensure_model
+from pathlib import Path
 from token_patterns import extract_tokens
 
 print(
@@ -55,10 +57,14 @@ def translate_batch(
     argos_translate.load_installed_languages()
     translator = argos_translate.get_translation_from_codes(src, dst)
     if translator is None:
-        raise RuntimeError(
-            f"No Argos translation model for {src}->{dst}. "
-            "Assemble or install the model, or run `.codex/install.sh`."
-        )
+        ensure_model(dst, Path(os.path.dirname(os.path.dirname(__file__))))
+        argos_translate.load_installed_languages()
+        translator = argos_translate.get_translation_from_codes(src, dst)
+        if translator is None:
+            raise RuntimeError(
+                f"No Argos translation model for {src}->{dst}. "
+                "Run Tools/ensure_argos_model.py to reconstruct it."
+            )
     joined = "\n".join(lines)
     for attempt in range(1, max_retries + 1):
         try:


### PR DESCRIPTION
## Summary
- add `Tools/ensure_argos_model.py` to rebuild & install split Argos model archives
- have translation utilities ensure required models are present or warn when missing
- document model preflight in `Docs/Localization.md`

## Testing
- `pytest Tools/test_language_utils.py Tools/test_fix_tokens_main.py`
- `python Tools/ensure_argos_model.py --help`
- `python Tools/translate_argos.py --help`
- `python Tools/fix_tokens.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68bb1ef3edf0832db5669f42b647b695