### PR TITLE
ci: add translation check

### DIFF
--- a/.github/workflows/check-translations.yml
+++ b/.github/workflows/check-translations.yml
@@ -1,0 +1,24 @@
+name: Check Translations
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  check-translations:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install argostranslate
+      - name: Verify translations
+        run: |
+          set -e
+          python Tools/fix_tokens.py --check-only --reorder Resources/Localization/Messages/*.json
+          dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 .RECIPEPREFIX := >
 
-.PHONY: fix-tokens
+.PHONY: fix-tokens check-translations
 
 fix-tokens:
 > python Tools/fix_tokens.py --reorder Resources/Localization/Messages/*.json
+
+check-translations:
+> python Tools/fix_tokens.py --check-only --reorder Resources/Localization/Messages/*.json
+> dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations
 


### PR DESCRIPTION
## Summary
- run token and translation verification on push or PR
- add make target for local translation validation

## Testing
- `python Tools/fix_tokens.py --check-only --reorder Resources/Localization/Messages/*.json` *(fails: token mismatches detected)*
- `dotnet run --project Bloodcraft.csproj -p:RunGenerateREADME=false -- check-translations` *(fails: untranslated strings found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3281de30832d80ae8f87e38636e1