### PR TITLE
Use zipfile for Argos model extraction

### DIFF
--- a/Tools/ensure_argos_model.py
+++ b/Tools/ensure_argos_model.py
@@ -11,8 +11,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
-import subprocess
 from pathlib import Path
 import zipfile
 
@@ -41,12 +39,14 @@ def _combine_segments(model_dir: Path) -> Path:
 
 def _extract_archive(model_zip: Path) -> Path:
     """Extract ``model.zip`` and return the resulting ``.argosmodel`` path."""
-    subprocess.run(["unzip", "-o", model_zip.name], cwd=model_zip.parent, check=True)
+    with zipfile.ZipFile(model_zip, "r") as zf:
+        zf.extractall(model_zip.parent)
     argosmodel = next(model_zip.parent.glob("translate-*.argosmodel"), None)
     if argosmodel is None:
         raise FileNotFoundError(
             f"Failed to extract Argos model from {model_zip}."
         )
+    model_zip.unlink(missing_ok=True)
     return argosmodel
 
 

--- a/Tools/test_ensure_argos_model.py
+++ b/Tools/test_ensure_argos_model.py
@@ -71,6 +71,7 @@ def test_combine_and_extract_segments(tmp_path):
 
     argosmodel = ensure_argos_model._extract_archive(model_zip)
     assert argosmodel.is_file()
+    assert not model_zip.exists()
 
     with zipfile.ZipFile(argosmodel, "r") as zf:
         metadata = json.loads(zf.read("metadata.json").decode("utf-8"))


### PR DESCRIPTION
## Summary
- avoid `unzip` dependency by extracting Argos models with Python's `zipfile`
- clean up `model.zip` once extraction succeeds
- test extraction and cleanup behavior

## Testing
- `pytest Tools/test_ensure_argos_model.py -q`
- `python3 - <<'PY'
import sys, types, json, zipfile
from pathlib import Path

sys.path.insert(0, 'Tools')

installed = {}

def load_installed_languages():
    pass

def get_translation_from_codes(f, t):
    return installed.get((f, t))

def install_from_path(p):
    print('install_from_path called with', p)
    installed[('en', 'xx')] = object()

argos_translate_stub = types.SimpleNamespace(
    load_installed_languages=load_installed_languages,
    get_translation_from_codes=get_translation_from_codes,
)
argos_package_stub = types.SimpleNamespace(
    install_from_path=install_from_path
)

sys.modules['argostranslate'] = types.SimpleNamespace(translate=argos_translate_stub, package=argos_package_stub)
sys.modules['argostranslate.translate'] = argos_translate_stub
sys.modules['argostranslate.package'] = argos_package_stub

import ensure_argos_model

root = Path('tmp_repo2')
model_dir = root / 'Resources' / 'Localization' / 'Models' / 'xx'
model_dir.mkdir(parents=True, exist_ok=True)

argosmodel_path = model_dir / 'translate-en_xx.argosmodel'
with zipfile.ZipFile(argosmodel_path, 'w') as zf:
    zf.writestr('metadata.json', json.dumps({'from_code':'en','to_code':'xx'}))
orig_zip = model_dir / 'orig.zip'
with zipfile.ZipFile(orig_zip, 'w') as zf:
    zf.write(argosmodel_path, argosmodel_path.name)
data = orig_zip.read_bytes()
split_at = len(data)//2 or 1
(model_dir/'translate-en_xx.z00').write_bytes(data[:split_at])
(model_dir/'translate-en_xx.zip').write_bytes(data[split_at:])
argosmodel_path.unlink()
orig_zip.unlink()

installed_flag = ensure_argos_model.ensure_model('xx', root)
print('installed:', installed_flag)
print('model_zip exists after install:', (model_dir/'model.zip').exists())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68bc76fed764832dae60fa624e9895f0