### PR TITLE
ci: add PR scope check workflow and script

### DIFF
--- a/.codex/scripts/pr-scope-check.sh
+++ b/.codex/scripts/pr-scope-check.sh
@@ -9,7 +9,7 @@ append_summary() {
     local message="$1"
 
     if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
-        printf '%b\n' "$message" >> "$GITHUB_STEP_SUMMARY"
+        printf '%s\n' "$message" >> "$GITHUB_STEP_SUMMARY"
     fi
 }
 

--- a/.codex/scripts/pr-scope-check.sh
+++ b/.codex/scripts/pr-scope-check.sh
@@ -53,7 +53,7 @@ if [[ -z "$RANGE" ]]; then
     exit 1
 fi
 
-if ! changed_output="$(git diff --name-only --diff-filter=ACMR "$RANGE")"; then
+if ! changed_output="$(git diff --name-only --diff-filter=ACMRDT "$RANGE")"; then
     echo "Unable to inspect changed files for range: $RANGE" >&2
     exit 1
 fi
@@ -61,9 +61,9 @@ fi
 mapfile -t CHANGED_PATHS < <(printf '%s\n' "$changed_output")
 
 if [[ ${#CHANGED_PATHS[@]} -eq 0 || ( ${#CHANGED_PATHS[@]} -eq 1 && -z "${CHANGED_PATHS[0]}" ) ]]; then
-    echo "No added or modified tracked files detected in $RANGE."
+    echo "No changed tracked files detected in $RANGE."
     append_summary "## PR scope check"
-    append_summary "No added or modified tracked files detected in \`$RANGE\`."
+    append_summary "No changed tracked files detected in \`$RANGE\`."
     exit 0
 fi
 

--- a/.codex/scripts/pr-scope-check.sh
+++ b/.codex/scripts/pr-scope-check.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+WORKFLOW_PREFIX=".github/workflows/"
+LOCALIZATION_PREFIX="Resources/Localization/"
+RELEASE_FILES=("Bloodcraft.csproj" "CHANGELOG.md" "thunderstore.toml")
+
+append_summary() {
+    local message="$1"
+
+    if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+        printf '%b\n' "$message" >> "$GITHUB_STEP_SUMMARY"
+    fi
+}
+
+emit_group() {
+    local title="$1"
+    shift
+    local -a items=("$@")
+
+    echo "$title"
+    append_summary "$title"
+
+    if [[ ${#items[@]} -eq 0 ]]; then
+        echo "- none"
+        append_summary "- none"
+        return
+    fi
+
+    local item
+    for item in "${items[@]}"; do
+        echo "- $item"
+        append_summary "- \`$item\`"
+    done
+}
+
+is_release_file() {
+    local path="$1"
+    local release_file
+
+    for release_file in "${RELEASE_FILES[@]}"; do
+        if [[ "$path" == "$release_file" ]]; then
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+RANGE="${1:-}"
+if [[ -z "$RANGE" ]]; then
+    echo "Usage: $0 <git-diff-range>" >&2
+    exit 1
+fi
+
+if ! changed_output="$(git diff --name-only --diff-filter=ACMR "$RANGE")"; then
+    echo "Unable to inspect changed files for range: $RANGE" >&2
+    exit 1
+fi
+
+mapfile -t CHANGED_PATHS < <(printf '%s\n' "$changed_output")
+
+if [[ ${#CHANGED_PATHS[@]} -eq 0 || ( ${#CHANGED_PATHS[@]} -eq 1 && -z "${CHANGED_PATHS[0]}" ) ]]; then
+    echo "No added or modified tracked files detected in $RANGE."
+    append_summary "## PR scope check"
+    append_summary "No added or modified tracked files detected in \`$RANGE\`."
+    exit 0
+fi
+
+WORKFLOW_FILES=()
+LOCALIZATION_FILES=()
+RELEASE_CHANGED=()
+OTHER_FILES=()
+HIGH_RISK_GROUPS=()
+
+for path in "${CHANGED_PATHS[@]}"; do
+    if [[ "$path" == "$WORKFLOW_PREFIX"* ]]; then
+        WORKFLOW_FILES+=("$path")
+        continue
+    fi
+
+    if [[ "$path" == "$LOCALIZATION_PREFIX"* ]]; then
+        LOCALIZATION_FILES+=("$path")
+        continue
+    fi
+
+    if is_release_file "$path"; then
+        RELEASE_CHANGED+=("$path")
+        continue
+    fi
+
+    OTHER_FILES+=("$path")
+done
+
+if [[ ${#WORKFLOW_FILES[@]} -gt 0 ]]; then
+    HIGH_RISK_GROUPS+=("workflow")
+fi
+
+if [[ ${#LOCALIZATION_FILES[@]} -gt 0 ]]; then
+    HIGH_RISK_GROUPS+=("localization")
+fi
+
+if [[ ${#RELEASE_CHANGED[@]} -gt 0 ]]; then
+    HIGH_RISK_GROUPS+=("release/versioning")
+fi
+
+TOTAL_CHANGED=${#CHANGED_PATHS[@]}
+HIGH_RISK_COUNT=${#HIGH_RISK_GROUPS[@]}
+
+append_summary "## PR scope check"
+append_summary "Changed files inspected: **$TOTAL_CHANGED**"
+
+echo "Changed files inspected: $TOTAL_CHANGED"
+emit_group "### Workflow changes" "${WORKFLOW_FILES[@]}"
+emit_group "### Localization changes" "${LOCALIZATION_FILES[@]}"
+emit_group "### Release/versioning changes" "${RELEASE_CHANGED[@]}"
+emit_group "### Other changed files" "${OTHER_FILES[@]}"
+
+STATUS="pass"
+REASON="No broad-scope path combination detected."
+
+if [[ $HIGH_RISK_COUNT -gt 1 ]]; then
+    STATUS="fail"
+    REASON="Multiple high-risk path groups were modified together: ${HIGH_RISK_GROUPS[*]}."
+elif [[ $HIGH_RISK_COUNT -eq 1 && ${#OTHER_FILES[@]} -gt 0 ]]; then
+    STATUS="warn"
+    REASON="A high-risk path group was modified alongside other files: ${HIGH_RISK_GROUPS[0]}."
+fi
+
+append_summary ""
+append_summary "**Status:** $STATUS"
+append_summary "$REASON"
+
+echo "Status: $STATUS"
+echo "$REASON"
+
+if [[ ${#WORKFLOW_FILES[@]} -gt 0 ]]; then
+    echo "::warning title=Workflow files changed::Workflow definitions changed in this PR. Review CI/CD impact carefully."
+fi
+
+if [[ ${#LOCALIZATION_FILES[@]} -gt 0 ]]; then
+    echo "::warning title=Localization files changed::Localization resources changed in this PR. Confirm translation and fallback coverage."
+fi
+
+if [[ ${#RELEASE_CHANGED[@]} -gt 0 ]]; then
+    echo "::warning title=Release/versioning files changed::Release metadata changed in this PR. Confirm versioning and changelog intent."
+fi
+
+if [[ "$STATUS" == "warn" ]]; then
+    echo "::warning title=Potentially broad PR scope::$REASON"
+    exit 0
+fi
+
+if [[ "$STATUS" == "fail" ]]; then
+    echo "::error title=Unexpectedly broad PR scope::$REASON"
+    exit 1
+fi

--- a/.github/workflows/pr-scope-check.yml
+++ b/.github/workflows/pr-scope-check.yml
@@ -1,0 +1,34 @@
+name: PR Scope Check
+
+'on':
+  pull_request:
+
+jobs:
+  pr-scope-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine diff range
+        id: diff_range
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          base_ref="origin/${GITHUB_BASE_REF}"
+          git fetch --no-tags origin "${GITHUB_BASE_REF}"
+          merge_base="$(git merge-base HEAD "${base_ref}")"
+          range="${merge_base}..HEAD"
+
+          echo "range=${range}" >> "$GITHUB_OUTPUT"
+          echo "Using diff range: ${range}"
+
+      - name: Summarize PR scope
+        shell: bash
+        run: |
+          set -euo pipefail
+          ./.codex/scripts/pr-scope-check.sh "${{ steps.diff_range.outputs.range }}"


### PR DESCRIPTION
### Motivation
- Prevent unexpectedly broad PRs by providing an automated, easily-tunable path-based check that highlights changes to CI/workflows, localization, and release/versioning metadata.
- Keep the first iteration simple and deterministic by using path rules instead of semantic inference so it can be tuned over time.

### Description
- Add a reusable script `./.codex/scripts/pr-scope-check.sh` that lists changed files for a given git diff range, groups them into `workflow`, `localization`, `release/versioning`, and `other` buckets, writes a job summary to `GITHUB_STEP_SUMMARY`, and emits workflow annotations.
- Add a `pull_request` workflow `/.github/workflows/pr-scope-check.yml` that computes the merge-base diff range against the PR base branch and invokes the script to produce a CI-visible summary.
- Enforce a simple rule set where multiple high-risk groups together cause a failing check, a single high-risk group mixed with other files produces a warning, and targeted changes pass, with explicit warnings for changed workflows, localization, or release files.

### Testing
- Ran a shell syntax check with `bash -n .codex/scripts/pr-scope-check.sh` and it succeeded.
- Validated the workflow YAML with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/pr-scope-check.yml')"` and it succeeded (`YAML OK`).
- Exercised the script in temporary git repositories using representative diffs to confirm it emits summaries, produces a `warn` when a high-risk group is mixed with other files, and `fail` when multiple high-risk groups are modified together, and those scenarios behaved as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc2ed2c4a4832d9e19114048d2824f)