### PR TITLE
Add persistence/grants/progression safety checklist to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,23 @@
 - Call out protections against data loss or duplication in relevant flows.
 - Examples for this codebase: entitlement and progression data remain preserved, starter-kit or reward grants do not duplicate on retry, and failed sync steps do not corrupt persisted player state.
 
+## Persistence / Grants / Progression Safety Checklist
+Complete this section when your change touches persistence, grants, progression, Eclipse sync, familiars, or config-driven state.
+
+Applies especially to changes in areas such as:
+- `Commands/MiscCommands.cs` starter-kit and grant flows.
+- `Services/EclipseService.cs` registration, config sync, and client progress delivery.
+- `Services/DataService.cs` persistence, save/load, and failure handling.
+- Progression systems and utilities, including leveling, legacies, expertise, professions, and related progression state.
+- Familiar systems and services, including unlocks, leveling, binding, prestige, and config-backed familiar state.
+
+- [ ] **Partial success:** If only part of the operation succeeds, what remains applied and what is rolled back?
+- [ ] **Retry safety:** Is it safe to retry after a timeout, restart, reconnect, or manual re-run?
+- [ ] **Duplicate triggers:** Can duplicate events, commands, hooks, or sync messages double-apply the change?
+- [ ] **Failure preservation:** What player, familiar, grant, or progression state must be preserved if the operation fails midway?
+- [ ] **Diagnostics:** Is there enough logging and contextual data to diagnose who failed, where, and why?
+- [ ] **Missing config/data:** What happens if config values, saved data, prefab references, unlock containers, or required records are missing?
+
 ## Acceptance checks
 - List 3-6 concrete scenarios you verified.
 - Prefer specific end-to-end or behavioral checks over generic statements like "tested locally".


### PR DESCRIPTION
### Motivation
- Ensure PRs that touch persistence, grants, progression, Eclipse sync, familiars, or config-driven state explicitly address partial success, retries, duplication, preserved state, diagnostics, and missing-data scenarios so regressions and data loss are avoided.

### Description
- Updated ` .github/pull_request_template.md` to add a `Persistence / Grants / Progression Safety Checklist` with checklist items for partial success, retry safety, duplicate triggers, failure preservation, diagnostics, and missing config/data, and pointed authors to relevant areas such as `Commands/MiscCommands.cs`, `Services/EclipseService.cs`, `Services/DataService.cs`, progression systems, and familiar systems.

### Testing
- No automated tests were executed because this is a documentation-only change; the template addition does not affect runtime code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc475f0d58832da6e9fbcc77b47e7c)