### PR TITLE
Add guidance for `minor-feature` PR label

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,15 @@
 ## Why
 - 
 
+## `minor-feature` label guidance
+Use the `minor-feature` label for PRs that are intentionally narrow in scope. These PRs should usually:
+- touch only a few focused files.
+- avoid workflow, release, or config churn unless that churn is part of the intended feature.
+- include a short acceptance checklist.
+- avoid unrelated refactors while the feature is in flight.
+
+If the repository adopts label automation later, this guidance can serve as the starting point for a scope-check allowlist.
+
 ## Invariants protected
 - State what still remains true if this change partially fails or is retried.
 - Call out protections against data loss or duplication in relevant flows.
@@ -28,6 +37,7 @@ Applies especially to changes in areas such as:
 
 ## Acceptance checks
 - List 3-6 concrete scenarios you verified.
+- Keep the checklist short and focused for `minor-feature` PRs.
 - Prefer specific end-to-end or behavioral checks over generic statements like "tested locally".
 
 ## AI usage

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,10 +6,10 @@
 
 ## `minor-feature` label guidance
 Use the `minor-feature` label for PRs that are intentionally narrow in scope. These PRs should usually:
-- touch only a few focused files.
-- avoid workflow, release, or config churn unless that churn is part of the intended feature.
-- include a short acceptance checklist.
-- avoid unrelated refactors while the feature is in flight.
+- Touch only a few focused files.
+- Avoid workflow, release, or config churn unless that churn is part of the intended feature.
+- Include a short acceptance checklist.
+- Avoid unrelated refactors while the feature is in flight.
 
 If the repository adopts label automation later, this guidance can serve as the starting point for a scope-check allowlist.
 


### PR DESCRIPTION
### Motivation
- Provide explicit contributor guidance for the `minor-feature` label so PRs using it remain narrowly scoped and consistent, and so the guidance can later seed label automation allowlists.

### Description
- Add a new `minor-feature` label guidance section to the pull request template in ` .github/pull_request_template.md` that instructs authors to touch only a few focused files, avoid workflow/release/config churn unless intentional, include a short acceptance checklist, and avoid unrelated refactors.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc49f32054832d82623f3964ca36d7)