### PR TITLE
ci: stop mutating thunderstore metadata in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,27 +114,6 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore
 
-      - name: Update thunderstore.toml
-        if: github.event_name != 'pull_request' && (steps.version_guard.outputs.should_build == 'true' || github.event_name == 'workflow_dispatch')
-        run: |
-          if [ -z "${{ env.version }}" ]; then
-            echo "Version is empty; skipping thunderstore.toml update."
-            exit 0
-          fi
-
-          sed -i "s/versionNumber = \".*\"/versionNumber = \"${{ env.version }}\"/" thunderstore.toml
-
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
-
-          if [ -n "$(git status --porcelain thunderstore.toml)" ]; then
-            git add thunderstore.toml
-            git commit -m "chore: Update thunderstore.toml version to ${{ env.version }}"
-            git push origin HEAD:${{ github.ref }}
-          else
-            echo "No changes to commit in thunderstore.toml"
-          fi
-
       - name: Build (Release)
         if: github.event_name == 'pull_request' || steps.version_guard.outputs.should_build == 'true' || github.event_name == 'workflow_dispatch'
         run: |


### PR DESCRIPTION
### Motivation
- Prevent CI validation jobs from mutating the repository by removing the step that edited, committed, and pushed `thunderstore.toml`, and rely on publish-time versioning instead.

### Description
- Remove the `Update thunderstore.toml` step from `.github/workflows/build.yml` so build/PR validation remains read-only and keep the existing release workflow (which uses `tcli publish --package-version`) as the publish-time source of truth for package versioning.

### Testing
- Confirmed the modified workflow file parses with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build.yml")'` and ran `git diff --check` with no reported issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc9121ce70832db75bfaf9b2dd76ea)