### PR TITLE
Align SDK policy across local setup and CI

### DIFF
--- a/.codex/install.sh
+++ b/.codex/install.sh
@@ -5,13 +5,19 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 PROJECT_PATH="$REPO_ROOT/Bloodcraft.csproj"
 INSTALL_DIR="${DOTNET_INSTALL_DIR:-$HOME/.dotnet}"
-CHANNEL="${DOTNET_INSTALL_CHANNEL:-8.0}"
+SDK_CHANNEL="${DOTNET_INSTALL_CHANNEL:-8.0}"
+TARGET_FRAMEWORK="net6.0"
 BEPINEX_PLUGIN_DIR="${BEPINEX_PLUGIN_DIR:-}"
 DOTNET_INSTALLED=0
-REQUIRED_SDK_MAJOR="${CHANNEL%%.*}"
+MINIMUM_SDK_MAJOR="${SDK_CHANNEL%%.*}"
 PYTHON_COMMANDS=(python3 python)
 PYTHON_DEPENDENCY="PyYAML"
 PYTHON_DEPENDENCY_IMPORT="yaml"
+
+print_sdk_policy() {
+    echo "Using .NET SDK channel $SDK_CHANNEL or newer to build target framework $TARGET_FRAMEWORK."
+    echo "This repository targets $TARGET_FRAMEWORK for BepInEx compatibility, but requires SDK major $MINIMUM_SDK_MAJOR+ because it uses modern preview C# features."
+}
 
 sdk_meets_minimum_version() {
     if ! command -v dotnet >/dev/null 2>&1; then
@@ -28,7 +34,7 @@ sdk_meets_minimum_version() {
     local sdk_major
     sdk_major="${sdk_version%%.*}"
 
-    [ "$sdk_major" -ge "$REQUIRED_SDK_MAJOR" ]
+    [ "$sdk_major" -ge "$MINIMUM_SDK_MAJOR" ]
 }
 
 install_dotnet() {
@@ -37,9 +43,7 @@ install_dotnet() {
     install_script="$(mktemp)"
 
     curl -sSL https://dot.net/v1/dotnet-install.sh -o "$install_script"
-
-    bash "$install_script" --install-dir "$INSTALL_DIR" --channel "$CHANNEL"
-
+    bash "$install_script" --install-dir "$INSTALL_DIR" --channel "$SDK_CHANNEL"
     rm -f "$install_script"
 
     export DOTNET_ROOT="$INSTALL_DIR"
@@ -59,12 +63,12 @@ install_dotnet() {
 
 python_dependency_is_available() {
     local python_command="$1"
-    "$python_command" - <<PY >/dev/null 2>&1
+    "$python_command" - <<PYTHON_CHECK >/dev/null 2>&1
 import importlib.util
 import sys
 
 sys.exit(0 if importlib.util.find_spec("${PYTHON_DEPENDENCY_IMPORT}") else 1)
-PY
+PYTHON_CHECK
 }
 
 install_python_dependency() {
@@ -72,12 +76,10 @@ install_python_dependency() {
 
     echo "Ensuring $PYTHON_DEPENDENCY is available for $python_command..."
 
-    # Try to make sure pip is available; treat ensurepip as best-effort.
     if ! "$python_command" -m pip --version >/dev/null 2>&1; then
         "$python_command" -m ensurepip --upgrade >/dev/null 2>&1 || true
     fi
 
-    # Re-check pip availability after ensurepip.
     if ! "$python_command" -m pip --version >/dev/null 2>&1; then
         echo "pip is not available for $python_command, so $PYTHON_DEPENDENCY cannot be installed automatically." >&2
         echo "Please install $PYTHON_DEPENDENCY manually for this Python, for example:" >&2
@@ -85,7 +87,6 @@ install_python_dependency() {
         return 1
     fi
 
-    # Install the dependency with explicit error handling so set -e does not hide the cause.
     if ! "$python_command" -m pip install --user --upgrade "$PYTHON_DEPENDENCY"; then
         echo "Failed to install $PYTHON_DEPENDENCY for $python_command." >&2
         echo "You may need to check your network connection, permissions, or install it manually, e.g.:" >&2
@@ -123,12 +124,14 @@ ensure_python_dependency() {
     fi
 }
 
+print_sdk_policy
+
 if command -v dotnet >/dev/null 2>&1; then
     echo ".NET SDK already installed: $(dotnet --version)"
     if sdk_meets_minimum_version; then
         DOTNET_INSTALLED=1
     else
-        echo ".NET SDK $(dotnet --version) is older than the required major version $REQUIRED_SDK_MAJOR; installing channel $CHANNEL into $INSTALL_DIR"
+        echo ".NET SDK $(dotnet --version) is older than the required major version $MINIMUM_SDK_MAJOR; installing channel $SDK_CHANNEL into $INSTALL_DIR"
         install_dotnet
     fi
 else
@@ -148,7 +151,7 @@ dotnet restore "$PROJECT_PATH"
 echo "Building Bloodcraft project..."
 dotnet build "$PROJECT_PATH" --configuration Release --no-restore -p:RunGenerateREADME=false
 
-DLL_PATH="$REPO_ROOT/bin/Release/net6.0/Bloodcraft.dll"
+DLL_PATH="$REPO_ROOT/bin/Release/$TARGET_FRAMEWORK/Bloodcraft.dll"
 if [ ! -f "$DLL_PATH" ]; then
     echo "Build failed: $DLL_PATH not found." >&2
     exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,13 +13,19 @@ on:
 env:
   DOTNET_SDK_VERSION: 8.0.x
   TARGET_FRAMEWORK: net6.0
+  RELEASE_ASSET_NAME: prerelease-package
 
 jobs:
   build:
     name: build-validation
     permissions:
-      contents: write
+      contents: read
     runs-on: ubuntu-latest
+    outputs:
+      csproj_file: ${{ steps.discover_csproj.outputs.csproj_file }}
+      dll_name: ${{ steps.get_dll_name.outputs.dll_name }}
+      version: ${{ steps.extract_version.outputs.version }}
+      should_publish: ${{ steps.version_guard.outputs.should_build }}
 
     steps:
       - name: Checkout
@@ -67,12 +73,13 @@ jobs:
         run: |
           version=$(xmllint --xpath "string(//Project/PropertyGroup/Version)" "${{ steps.discover_csproj.outputs.csproj_file }}")
           echo "version=$version" >> "$GITHUB_ENV"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Determine build eligibility
         if: github.event_name != 'pull_request'
         id: version_guard
         run: |
-          if [ -z "${{ env.version }}" ]; then
+          if [ -z "${{ steps.extract_version.outputs.version }}" ]; then
             echo "Unable to determine current version; continuing build to avoid false negative."
             echo "should_build=true" >> "$GITHUB_OUTPUT"
             exit 0
@@ -85,9 +92,9 @@ jobs:
           fi
 
           git fetch --force --tags
-          latest_tag=$(git tag -l 'v*' --sort=-v:refname | head -n 1)
+          latest_tag=$(git tag -l 'v*' --sort=-v:refname | grep -Ev '-' | head -n 1)
           latest_version=${latest_tag#v}
-          current_version="${{ env.version }}"
+          current_version="${{ steps.extract_version.outputs.version }}"
 
           if [ -z "$latest_version" ]; then
             echo "No previous tagged release detected; proceeding with build."
@@ -127,26 +134,50 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             dotnet build "${{ steps.discover_csproj.outputs.csproj_file }}" --configuration Release --no-restore -p:RunGenerateREADME=false
-          elif [ -n "${{ env.version }}" ]; then
-            dotnet build "${{ steps.discover_csproj.outputs.csproj_file }}" --configuration Release --no-restore -p:Version=${{ env.version }} -p:RunGenerateREADME=false
+          elif [ -n "${{ steps.extract_version.outputs.version }}" ]; then
+            dotnet build "${{ steps.discover_csproj.outputs.csproj_file }}" --configuration Release --no-restore -p:Version=${{ steps.extract_version.outputs.version }} -p:RunGenerateREADME=false
           else
             dotnet build "${{ steps.discover_csproj.outputs.csproj_file }}" --configuration Release --no-restore -p:RunGenerateREADME=false
           fi
 
+      - name: Upload pre-release assets
+        if: github.event_name != 'pull_request' && (steps.version_guard.outputs.should_build == 'true' || github.event_name == 'workflow_dispatch') && steps.extract_version.outputs.version != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.RELEASE_ASSET_NAME }}
+          if-no-files-found: error
+          path: |
+            ./bin/Release/${{ env.TARGET_FRAMEWORK }}/${{ steps.get_dll_name.outputs.dll_name }}.dll
+            ./CHANGELOG.md
+
+  publish_prerelease:
+    name: publish-prerelease
+    if: github.event_name != 'pull_request' && (needs.build.outputs.should_publish == 'true' || github.event_name == 'workflow_dispatch') && needs.build.outputs.version != ''
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download pre-release assets
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.RELEASE_ASSET_NAME }}
+          path: ./release-assets
+
       - name: GH Release (pre-release)
         uses: softprops/action-gh-release@v2
-        if: github.event_name != 'pull_request' && (steps.version_guard.outputs.should_build == 'true' || github.event_name == 'workflow_dispatch') && env.version != ''
         with:
           body: |
-            Automated pre-release for version ${{ env.version }} generated from this GitHub Actions build.
+            Automated pre-release for version ${{ needs.build.outputs.version }} generated from this GitHub Actions build.
             - Commit: ${{ github.sha }}
             - Run: ${{ github.run_id }}
-          name: Pre-release v${{ env.version }}
+          name: Pre-release v${{ needs.build.outputs.version }}
           fail_on_unmatched_files: true
           prerelease: true
-          tag_name: v${{ env.version }}-pre
+          tag_name: v${{ needs.build.outputs.version }}-pre
           files: |
-            ./bin/Release/${{ env.TARGET_FRAMEWORK }}/${{ steps.get_dll_name.outputs.dll_name }}.dll
-            CHANGELOG.md
+            ./release-assets/${{ needs.build.outputs.dll_name }}.dll
+            ./release-assets/CHANGELOG.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,11 +10,15 @@ on:
       - codex/feature-testing
   workflow_dispatch:
 
+env:
+  DOTNET_SDK_VERSION: 8.0.x
+  TARGET_FRAMEWORK: net6.0
+
 jobs:
   build:
     name: build-validation
     permissions:
-      contents: read
+      contents: write
     runs-on: ubuntu-latest
 
     steps:
@@ -24,35 +28,45 @@ jobs:
           fetch-depth: 1
           fetch-tags: false
 
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_SDK_VERSION }}
+          cache: true
+          cache-dependency-path: Bloodcraft.csproj
+
       - name: Discover .csproj
         id: discover_csproj
         run: |
-          # Find the first .csproj outside bin/obj directories.
-          # Adjust if you have multiple .csproj files.
           csproj_file=$(find . -type f -name '*.csproj' \
             -not -path '*/bin/*' \
             -not -path '*/obj/*' \
             -not -path '*/.codex/*' | head -n 1)
-          
-          echo "csproj_file=$csproj_file" >> $GITHUB_OUTPUT
-        
+
+          if [ -z "$csproj_file" ]; then
+            echo "Unable to locate a .csproj file." >&2
+            exit 1
+          fi
+
+          echo "csproj_file=$csproj_file" >> "$GITHUB_OUTPUT"
+
       - name: Get DLL name
         id: get_dll_name
         run: |
           csproj="${{ steps.discover_csproj.outputs.csproj_file }}"
           dll_name=$(basename "$csproj" .csproj)
-          echo "dll_name=$dll_name" >> $GITHUB_OUTPUT
+          echo "dll_name=$dll_name" >> "$GITHUB_OUTPUT"
 
       - name: Install xmllint
         if: github.event_name != 'pull_request'
-        run: sudo apt-get update && sudo apt-get install -y libxml2-utils
+        run: sudo apt-get update && sudo apt-get install --yes libxml2-utils
 
       - name: Extract version from .csproj
         if: github.event_name != 'pull_request'
         id: extract_version
         run: |
           version=$(xmllint --xpath "string(//Project/PropertyGroup/Version)" "${{ steps.discover_csproj.outputs.csproj_file }}")
-          echo "version=$version" >> $GITHUB_ENV
+          echo "version=$version" >> "$GITHUB_ENV"
 
       - name: Determine build eligibility
         if: github.event_name != 'pull_request'
@@ -60,25 +74,24 @@ jobs:
         run: |
           if [ -z "${{ env.version }}" ]; then
             echo "Unable to determine current version; continuing build to avoid false negative."
-            echo "should_build=true" >> $GITHUB_OUTPUT
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "Manual dispatch detected; proceeding with build regardless of version guard."
-            echo "should_build=true" >> $GITHUB_OUTPUT
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           git fetch --force --tags
           latest_tag=$(git tag -l 'v*' --sort=-v:refname | head -n 1)
           latest_version=${latest_tag#v}
-
           current_version="${{ env.version }}"
 
           if [ -z "$latest_version" ]; then
             echo "No previous tagged release detected; proceeding with build."
-            echo "should_build=true" >> $GITHUB_OUTPUT
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -87,12 +100,12 @@ jobs:
 
             if git tag -l "$pre_release_tag" | grep -q .; then
               echo "Current .csproj version $current_version matches latest release and pre-release tag $pre_release_tag already exists; skipping build because the pre-release is already published."
-              echo "should_build=false" >> $GITHUB_OUTPUT
+              echo "should_build=false" >> "$GITHUB_OUTPUT"
               exit 0
             fi
 
             echo "Current .csproj version $current_version matches latest release but no pre-release tag $pre_release_tag is present; enabling build so the pre-release can be published automatically."
-            echo "should_build=true" >> $GITHUB_OUTPUT
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -100,33 +113,28 @@ jobs:
 
           if [ "$highest_version" = "$current_version" ]; then
             echo "Current .csproj version $current_version is ahead of latest release $latest_version; proceeding with build."
-            echo "should_build=true" >> $GITHUB_OUTPUT
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
           else
             echo "Current .csproj version $current_version is behind the latest release $latest_version; skipping build on push to main."
-            echo "should_build=false" >> $GITHUB_OUTPUT
+            echo "should_build=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 8.0.x
-
       - name: Restore dependencies
-        run: dotnet restore
+        run: dotnet restore "${{ steps.discover_csproj.outputs.csproj_file }}"
 
       - name: Build (Release)
         if: github.event_name == 'pull_request' || steps.version_guard.outputs.should_build == 'true' || github.event_name == 'workflow_dispatch'
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            dotnet build . --configuration Release -p:RunGenerateREADME=false
+            dotnet build "${{ steps.discover_csproj.outputs.csproj_file }}" --configuration Release --no-restore -p:RunGenerateREADME=false
           elif [ -n "${{ env.version }}" ]; then
-            dotnet build . --configuration Release -p:Version=${{ env.version }} -p:RunGenerateREADME=false
+            dotnet build "${{ steps.discover_csproj.outputs.csproj_file }}" --configuration Release --no-restore -p:Version=${{ env.version }} -p:RunGenerateREADME=false
           else
-            dotnet build . --configuration Release -p:RunGenerateREADME=false
+            dotnet build "${{ steps.discover_csproj.outputs.csproj_file }}" --configuration Release --no-restore -p:RunGenerateREADME=false
           fi
 
       - name: GH Release (pre-release)
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: github.event_name != 'pull_request' && (steps.version_guard.outputs.should_build == 'true' || github.event_name == 'workflow_dispatch') && env.version != ''
         with:
           body: |
@@ -138,7 +146,7 @@ jobs:
           prerelease: true
           tag_name: v${{ env.version }}-pre
           files: |
-            ./bin/Release/net6.0/${{ steps.get_dll_name.outputs.dll_name }}.dll
+            ./bin/Release/${{ env.TARGET_FRAMEWORK }}/${{ steps.get_dll_name.outputs.dll_name }}.dll
             CHANGELOG.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,41 +3,52 @@ name: Release
 on:
   workflow_dispatch:
 
+env:
+  DOTNET_SDK_VERSION: 8.0.x
+
 jobs:
   release_on_thunderstore:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '6.0.x'
-          dotnet-quality: 'preview'
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Extract Latest Tag
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_SDK_VERSION }}
+          cache: true
+          cache-dependency-path: Bloodcraft.csproj
+
+      - name: Extract latest tag
         id: extract_tag
-        run: |
-          latest_tag=$(git describe --tags `git rev-list --tags --max-count=1`)
-          echo "latest_tag=$latest_tag" >> $GITHUB_ENV
         shell: bash
-
-      - name: Set Release Tag
-        run: echo "RELEASE_TAG=${{ env.latest_tag }}" >> $GITHUB_ENV
-
-      - name: Download Release
         run: |
-          gh release download ${{ env.RELEASE_TAG }} -D ./dist
+          latest_tag=$(git tag -l 'v*' --sort=-v:refname | head -n 1)
+
+          if [ -z "$latest_tag" ]; then
+            echo "Unable to locate a release tag." >&2
+            exit 1
+          fi
+
+          echo "latest_tag=$latest_tag" >> "$GITHUB_OUTPUT"
+          echo "RELEASE_TAG=$latest_tag" >> "$GITHUB_ENV"
+
+      - name: Download release assets
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release download "${{ steps.extract_tag.outputs.latest_tag }}" --dir ./dist
 
       - name: Install Thunderstore CLI (tcli)
         run: dotnet tool install --global tcli
 
       - name: Publish build to Thunderstore
+        env:
+          RELEASE_TAG: ${{ env.RELEASE_TAG }}
         run: |
           sanitized_tag=${RELEASE_TAG#v}
           sanitized_tag=${sanitized_tag%%-*}
@@ -47,6 +58,4 @@ jobs:
             exit 1
           fi
 
-          tcli publish --token ${{ secrets.THUNDERSTORE_KEY }} --package-version "$sanitized_tag"
-        env:
-          RELEASE_TAG: ${{ env.RELEASE_TAG }}
+          tcli publish --token "${{ secrets.THUNDERSTORE_KEY }}" --package-version "$sanitized_tag"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,14 +24,14 @@ jobs:
           cache: true
           cache-dependency-path: Bloodcraft.csproj
 
-      - name: Extract latest tag
+      - name: Extract latest stable tag
         id: extract_tag
         shell: bash
         run: |
-          latest_tag=$(git tag -l 'v*' --sort=-v:refname | head -n 1)
+          latest_tag=$(git tag -l 'v*' --sort=-v:refname | grep -Ev '-' | head -n 1)
 
           if [ -z "$latest_tag" ]; then
-            echo "Unable to locate a release tag." >&2
+            echo "Unable to locate a stable release tag." >&2
             exit 1
           fi
 


### PR DESCRIPTION
### Motivation
- Unify the SDK policy so local setup and GitHub Actions use the same minimum .NET SDK major while the project continues targeting `net6.0` for BepInEx compatibility. 
- Ensure modern C# preview features compile reliably in CI by documenting and enforcing the SDK channel used for installs and CI. 
- Modernize CI workflows and harden discovery/validation so builds fail earlier on missing artifacts or malformed tags. 

### Description
- Update `.codex/install.sh` to declare `SDK_CHANNEL` (default `8.0`) and `TARGET_FRAMEWORK` (`net6.0`), print the SDK policy, derive `MINIMUM_SDK_MAJOR` from the channel, and use `TARGET_FRAMEWORK` for artifact checks. 
- Harden the install script: improved heredoc names, explicit messaging about DOTNET_ROOT/PATH, and ensured Python dependency handling remains robust (`PyYAML`). 
- Update `.github/workflows/build.yml` to set `DOTNET_SDK_VERSION: 8.0.x`, add `actions/setup-dotnet@v4` with caching, improve `.csproj` discovery and early failure on missing projects, restore/build the discovered project path, and bump `softprops/action-gh-release` to `v2`. 
- Update `.github/workflows/release.yml` to use the shared SDK env, add `actions/setup-dotnet@v4` with caching, tighten latest-tag extraction and release asset download, and sanitize the release tag prior to publishing with `tcli`. 

### Testing
- Ran `bash -n .codex/install.sh` to validate the script syntax (passed). 
- Parsed workflow YAML with `python3` + `yaml.safe_load` to validate both workflow files (passed). 
- Executed `bash .codex/install.sh` which installed the configured SDK channel and the `PyYAML` dependency (succeeded). 
- Built the project with `dotnet build Bloodcraft.csproj --configuration Release --no-restore -p:RunGenerateREADME=false` using the installed SDK and the build completed successfully (one `net6.0` end-of-support warning emitted).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd49788b88832d93dff6c02ff34512)