### PR TITLE
Restore GitHub Actions concurrency control

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.ref }}
   cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,10 @@ on:
       - codex/feature-testing
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+
 env:
   DOTNET_SDK_VERSION: 8.0.x
   TARGET_FRAMEWORK: net6.0


### PR DESCRIPTION
### Motivation
- Restore workflow-level `concurrency` protection so repeated pushes or PR updates for the same ref collapse into a single active run while avoiding unexpected cancellation of manual dispatch runs.

### Description
- Add a top-level `concurrency` block to `.github/workflows/build.yml` with `group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref }}` and `cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}` to group runs by workflow+ref and only cancel non-manual (validation) runs.

### Testing
- Validated the workflow file by parsing it with Ruby YAML via `ruby -e "require 'yaml'; data = YAML.load_file('.github/workflows/build.yml'); puts data['concurrency']"`, which confirmed the `concurrency` block, `group`, and `cancel-in-progress` values were present and correct.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdddc32008832da3659b767261076b)