### PR TITLE
Align .NET SDK policy: pin SDK 8.0.100 and clarify tooling vs target framework

### DIFF
--- a/.codex/install.sh
+++ b/.codex/install.sh
@@ -5,21 +5,21 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 PROJECT_PATH="$REPO_ROOT/Bloodcraft.csproj"
 INSTALL_DIR="${DOTNET_INSTALL_DIR:-$HOME/.dotnet}"
-SDK_CHANNEL="${DOTNET_INSTALL_CHANNEL:-8.0}"
+SDK_VERSION="${DOTNET_SDK_VERSION:-8.0.100}"
 TARGET_FRAMEWORK="net6.0"
 BEPINEX_PLUGIN_DIR="${BEPINEX_PLUGIN_DIR:-}"
 DOTNET_INSTALLED=0
-MINIMUM_SDK_MAJOR="${SDK_CHANNEL%%.*}"
+REQUIRED_SDK_MAJOR="${SDK_VERSION%%.*}"
 PYTHON_COMMANDS=(python3 python)
 PYTHON_DEPENDENCY="PyYAML"
 PYTHON_DEPENDENCY_IMPORT="yaml"
 
 print_sdk_policy() {
-    echo "Using .NET SDK channel $SDK_CHANNEL or newer to build target framework $TARGET_FRAMEWORK."
-    echo "This repository targets $TARGET_FRAMEWORK for BepInEx compatibility, but requires SDK major $MINIMUM_SDK_MAJOR+ because it uses modern preview C# features."
+    echo "Using .NET SDK $SDK_VERSION (with 8.0 feature-band roll-forward) to build target framework $TARGET_FRAMEWORK."
+    echo "Target framework and SDK are different settings: the mod ships for $TARGET_FRAMEWORK, while the build tooling requires the .NET 8 SDK because the project enables preview C# features."
 }
 
-sdk_meets_minimum_version() {
+sdk_meets_required_version() {
     if ! command -v dotnet >/dev/null 2>&1; then
         return 1
     fi
@@ -34,7 +34,7 @@ sdk_meets_minimum_version() {
     local sdk_major
     sdk_major="${sdk_version%%.*}"
 
-    [ "$sdk_major" -ge "$MINIMUM_SDK_MAJOR" ]
+    [ "$sdk_major" -ge "$REQUIRED_SDK_MAJOR" ]
 }
 
 install_dotnet() {
@@ -43,7 +43,7 @@ install_dotnet() {
     install_script="$(mktemp)"
 
     curl -sSL https://dot.net/v1/dotnet-install.sh -o "$install_script"
-    bash "$install_script" --install-dir "$INSTALL_DIR" --channel "$SDK_CHANNEL"
+    bash "$install_script" --install-dir "$INSTALL_DIR" --version "$SDK_VERSION"
     rm -f "$install_script"
 
     export DOTNET_ROOT="$INSTALL_DIR"
@@ -128,10 +128,10 @@ print_sdk_policy
 
 if command -v dotnet >/dev/null 2>&1; then
     echo ".NET SDK already installed: $(dotnet --version)"
-    if sdk_meets_minimum_version; then
+    if sdk_meets_required_version; then
         DOTNET_INSTALLED=1
     else
-        echo ".NET SDK $(dotnet --version) is older than the required major version $MINIMUM_SDK_MAJOR; installing channel $SDK_CHANNEL into $INSTALL_DIR"
+        echo ".NET SDK $(dotnet --version) does not satisfy the required SDK policy ($SDK_VERSION with .NET 8 tooling); installing SDK $SDK_VERSION into $INSTALL_DIR"
         install_dotnet
     fi
 else

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,9 @@ concurrency:
   cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 env:
-  DOTNET_SDK_VERSION: 8.0.x
+  DOTNET_SDK_VERSION: 8.0.100
   TARGET_FRAMEWORK: net6.0
+  DOTNET_SDK_POLICY_NOTE: Build tooling uses the .NET 8 SDK while the project output still targets net6.0.
   RELEASE_ASSET_NAME: prerelease-package
 
 jobs:
@@ -65,6 +66,11 @@ jobs:
           dll_name=$(basename "$csproj" .csproj)
           echo "dll_name=$dll_name" >> "$GITHUB_OUTPUT"
 
+      - name: Log SDK policy
+        run: |
+          echo "${{ env.DOTNET_SDK_POLICY_NOTE }}"
+          echo "Pinned SDK version: ${{ env.DOTNET_SDK_VERSION }}"
+
       - name: Restore dependencies
         run: dotnet restore "${{ steps.discover_csproj.outputs.csproj_file }}"
 
@@ -95,6 +101,11 @@ jobs:
           dotnet-version: ${{ env.DOTNET_SDK_VERSION }}
           cache: true
           cache-dependency-path: Bloodcraft.csproj
+
+      - name: Log SDK policy
+        run: |
+          echo "${{ env.DOTNET_SDK_POLICY_NOTE }}"
+          echo "Pinned SDK version: ${{ env.DOTNET_SDK_VERSION }}"
 
       - name: Install xmllint
         run: sudo apt-get update && sudo apt-get install --yes libxml2-utils

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,9 @@ on:
   workflow_dispatch:
 
 env:
-  DOTNET_SDK_VERSION: 8.0.x
+  DOTNET_SDK_VERSION: 8.0.100
+  TARGET_FRAMEWORK: net6.0
+  DOTNET_SDK_POLICY_NOTE: Release tooling uses the .NET 8 SDK while packaged binaries continue to target net6.0.
 
 jobs:
   release_on_thunderstore:
@@ -23,6 +25,11 @@ jobs:
           dotnet-version: ${{ env.DOTNET_SDK_VERSION }}
           cache: true
           cache-dependency-path: Bloodcraft.csproj
+
+      - name: Log SDK policy
+        run: |
+          echo "${{ env.DOTNET_SDK_POLICY_NOTE }}"
+          echo "Pinned SDK version: ${{ env.DOTNET_SDK_VERSION }}"
 
       - name: Extract latest stable tag
         id: extract_tag

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "8.0.100",
+    "rollForward": "latestFeature",
+    "allowPrerelease": false
+  }
+}


### PR DESCRIPTION
### Motivation

- Remove mixed 6/7/8 messaging and make a single, explicit SDK policy for local and CI builds. 
- Keep the project output target framework as `net6.0` while documenting and enforcing the requirement to build with the .NET 8 SDK because preview C# features are enabled. 

### Description

- Add a root `global.json` that pins the repository SDK to `8.0.100` with `rollForward: latestFeature` and `allowPrerelease: false`.
- Update `.codex/install.sh` to use a single `SDK_VERSION` (`8.0.100`), install that exact SDK via `dotnet-install.sh --version`, and clarify log messages that distinguish the build tooling SDK from the project `TARGET_FRAMEWORK` (`net6.0`).
- Align GitHub Actions in `.github/workflows/build.yml` and `.github/workflows/release.yml` to set `DOTNET_SDK_VERSION: 8.0.100`, add `DOTNET_SDK_POLICY_NOTE` and an explicit `Log SDK policy` step, and preserve `TARGET_FRAMEWORK: net6.0` and `-p:RunGenerateREADME=false` for CI builds.
- Make small script renames/adjustments (e.g., `sdk_meets_required_version`) to reflect the pinned SDK policy without changing build outputs or release flows.

### Testing

- Ran `bash .codex/install.sh`, which installed the .NET 8 SDK and completed successfully (installed `8.0.100`).
- The install script performed `dotnet restore` and `dotnet build` and the build succeeded producing `bin/Release/net6.0/Bloodcraft.dll` with `0 Warning(s)` and `0 Error(s)`.
- No CI workflow changes to behavior were introduced beyond explicit SDK pinning and logging; local validation steps completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bde013eec8832d918c2ead1cf149fb)