### PR TITLE
Run `dotnet` commands from repository root in `.codex/install.sh`

### DIFF
--- a/.codex/install.sh
+++ b/.codex/install.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$REPO_ROOT"
 PROJECT_PATH="$REPO_ROOT/Bloodcraft.csproj"
 INSTALL_DIR="${DOTNET_INSTALL_DIR:-$HOME/.dotnet}"
 SDK_CHANNEL="${DOTNET_INSTALL_CHANNEL:-8.0}"


### PR DESCRIPTION
### Motivation
- Ensure SDK detection and all subsequent `dotnet` invocations resolve relative to the repository root so the script works whether invoked from the repo root or any other directory.

### Description
- After computing `REPO_ROOT` the script now runs `cd "$REPO_ROOT"` so the initial SDK detection (`dotnet --version`) and later `dotnet restore` / `dotnet build` run with the repo root as the working directory, while preserving `TARGET_FRAMEWORK="net6.0"` and the existing build flags (including `-p:RunGenerateREADME=false`).

### Testing
- Ran `bash .codex/install.sh` from the repository root and `bash /workspace/Bloodcraft/.codex/install.sh` from another directory, and both runs completed `dotnet restore` and `dotnet build` successfully and produced the expected `bin/Release/net6.0/Bloodcraft.dll`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdeeb67c34832d9c4c893aefac0eaa)