### PR TITLE
Tighten SDK compatibility checks in .codex/install.sh

### DIFF
--- a/.codex/install.sh
+++ b/.codex/install.sh
@@ -10,32 +10,34 @@ SDK_CHANNEL="${DOTNET_INSTALL_CHANNEL:-8.0}"
 TARGET_FRAMEWORK="net6.0"
 BEPINEX_PLUGIN_DIR="${BEPINEX_PLUGIN_DIR:-}"
 DOTNET_INSTALLED=0
-MINIMUM_SDK_MAJOR="${SDK_CHANNEL%%.*}"
+PINNED_SDK_VERSION="8.0.100"
+SDK_ROLL_FORWARD_POLICY="latestFeature"
+REQUIRED_SDK_MAJOR="${PINNED_SDK_VERSION%%.*}"
 PYTHON_COMMANDS=(python3 python)
 PYTHON_DEPENDENCY="PyYAML"
 PYTHON_DEPENDENCY_IMPORT="yaml"
 
 print_sdk_policy() {
-    echo "Using .NET SDK channel $SDK_CHANNEL or newer to build target framework $TARGET_FRAMEWORK."
-    echo "This repository targets $TARGET_FRAMEWORK for BepInEx compatibility, but requires SDK major $MINIMUM_SDK_MAJOR+ because it uses modern preview C# features."
+    echo "Using .NET SDK compatibility policy $PINNED_SDK_VERSION with roll-forward $SDK_ROLL_FORWARD_POLICY to build target framework $TARGET_FRAMEWORK."
+    echo "This repository targets $TARGET_FRAMEWORK for BepInEx compatibility and requires a compatible $REQUIRED_SDK_MAJOR.0 feature band SDK because it uses modern preview C# features."
 }
 
-sdk_meets_minimum_version() {
+sdk_meets_required_version() {
     if ! command -v dotnet >/dev/null 2>&1; then
         return 1
     fi
 
-    local sdk_version
-    sdk_version="$(dotnet --version 2>/dev/null || true)"
+    local sdk_line sdk_version sdk_major
+    while IFS= read -r sdk_line; do
+        sdk_version="${sdk_line%% *}"
+        sdk_major="${sdk_version%%.*}"
 
-    if [ -z "$sdk_version" ]; then
-        return 1
-    fi
+        if [ "$sdk_major" = "$REQUIRED_SDK_MAJOR" ]; then
+            return 0
+        fi
+    done < <(dotnet --list-sdks 2>/dev/null || true)
 
-    local sdk_major
-    sdk_major="${sdk_version%%.*}"
-
-    [ "$sdk_major" -ge "$MINIMUM_SDK_MAJOR" ]
+    return 1
 }
 
 install_dotnet() {
@@ -129,10 +131,10 @@ print_sdk_policy
 
 if command -v dotnet >/dev/null 2>&1; then
     echo ".NET SDK already installed: $(dotnet --version)"
-    if sdk_meets_minimum_version; then
+    if sdk_meets_required_version; then
         DOTNET_INSTALLED=1
     else
-        echo ".NET SDK $(dotnet --version) is older than the required major version $MINIMUM_SDK_MAJOR; installing channel $SDK_CHANNEL into $INSTALL_DIR"
+        echo ".NET SDKs on PATH do not satisfy the repository compatibility policy ($PINNED_SDK_VERSION with $SDK_ROLL_FORWARD_POLICY); installing channel $SDK_CHANNEL into $INSTALL_DIR"
         install_dotnet
     fi
 else


### PR DESCRIPTION
### Motivation
- Make the repository install script enforce the repository's actual SDK compatibility policy (pinned `8.0.100` with `latestFeature` roll-forward) instead of only checking a parsed major version from `dotnet --version`.

### Description
- Added `PINNED_SDK_VERSION="8.0.100"`, `SDK_ROLL_FORWARD_POLICY="latestFeature"`, and `REQUIRED_SDK_MAJOR` to express the compatibility policy in `.codex/install.sh`.
- Replaced `sdk_meets_minimum_version` with `sdk_meets_required_version` which inspects `dotnet --list-sdks` and accepts only SDKs in the required feature band (e.g., `8.0.*`).
- Updated log text to report policy compatibility (the pinned version and roll-forward policy) instead of referring only to a major-version check.
- Kept the existing fallback/install behavior unchanged so the script still installs the configured `8.0` channel when the policy is not satisfied.

### Testing
- Ran `bash -n .codex/install.sh` to validate script syntax, which succeeded.
- Executed `bash .codex/install.sh`, which used the installer fallback and successfully installed `8.0.419`, restored, and built the project (build succeeded).
- Ran a small Python-driven harness to verify `sdk_meets_required_version` returns success when an `8.0.*` SDK is present and fails when only `9.x` SDKs are reported, and those checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdf53edb30832dbd2ebc654f1e3dd9)