### PR TITLE
Make dotnet version probe non-fatal and fall back to install

### DIFF
--- a/.codex/install.sh
+++ b/.codex/install.sh
@@ -130,11 +130,23 @@ ensure_python_dependency() {
 print_sdk_policy
 
 if command -v dotnet >/dev/null 2>&1; then
-    echo ".NET SDK already installed: $(dotnet --version)"
+    existing_dotnet_version="$(dotnet --version 2>/dev/null || true)"
+
+    if [ -n "$existing_dotnet_version" ]; then
+        echo ".NET SDK already installed: $existing_dotnet_version"
+    else
+        echo ".NET SDK detected on PATH, but version probing failed; treating it as incompatible with repository SDK policy."
+    fi
+
     if sdk_meets_required_version; then
         DOTNET_INSTALLED=1
     else
-        echo ".NET SDKs on PATH do not satisfy the repository compatibility policy ($PINNED_SDK_VERSION with $SDK_ROLL_FORWARD_POLICY); installing channel $SDK_CHANNEL into $INSTALL_DIR"
+        if [ -n "$existing_dotnet_version" ]; then
+            echo ".NET SDKs on PATH do not satisfy the repository compatibility policy ($PINNED_SDK_VERSION with $SDK_ROLL_FORWARD_POLICY); detected version $existing_dotnet_version. Installing channel $SDK_CHANNEL into $INSTALL_DIR"
+        else
+            echo ".NET SDKs on PATH do not satisfy the repository compatibility policy ($PINNED_SDK_VERSION with $SDK_ROLL_FORWARD_POLICY); detected version could not be determined. Installing channel $SDK_CHANNEL into $INSTALL_DIR"
+        fi
+
         install_dotnet
     fi
 else


### PR DESCRIPTION
### Motivation

- Prevent a failing or empty `dotnet --version` probe from terminating the installer under `set -euo pipefail` so the script can treat such cases as incompatible SDKs and continue.
- Ensure the repo can reliably install a compatible SDK when a PATH `dotnet` exists but cannot satisfy the repository's pinned SDK policy.

### Description

- Update `.codex/install.sh` to capture the probe once in `existing_dotnet_version` using `dotnet --version 2>/dev/null || true` and avoid re-running the command.
- Treat an empty or failed `existing_dotnet_version` as an incompatible SDK and include an explicit log message for the unknown-version case.
- Use the captured `existing_dotnet_version` in log output when reporting an incompatible SDK, and call `install_dotnet` to install the `8.0` channel when the PATH SDK does not meet the repository policy.

### Testing

- Ran a syntax check with `bash -n .codex/install.sh`, which passed.
- Executed the install path with a simulated `dotnet` that fails `--version` and reports only an incompatible SDK via `--list-sdks`, using `PATH="$FAKE_BIN:$PATH" HOME="$HOME_DIR" DOTNET_INSTALL_DIR="$HOME_DIR/.dotnet" bash .codex/install.sh`, and observed that the script logged the probing failure, installed the `8.0` channel SDK, and completed the build successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdf83de654832dbb30a1b1fcd23c55)