### PR TITLE
Clarify release/versioning guidance in PR template and CONTRIBUTING

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,5 +1,13 @@
 # Contributing
 
+## Release versioning
+
+Treat version updates as an intentional release activity, not default PR housekeeping.
+
+- Process-only, docs-only, workflow-only, and other non-release-facing changes should not claim, imply, or advertise version bumps in commit messages, PR titles, PR summaries, or checklists.
+- Release-facing changes should update `Bloodcraft.csproj`, `CHANGELOG.md`, and `thunderstore.toml` together so shipped version metadata stays synchronized.
+- Keep release metadata churn minimal. If a PR does not intentionally ship a release-facing change, leave version numbers and changelog entries alone.
+
 ## `minor-feature` label
 
 Use the `minor-feature` label for pull requests that add or adjust a small, contributor-contained feature without widening into a broader release-sized change.
@@ -18,6 +26,6 @@ Expected scope:
 
 Workflow, configuration, and release churn should usually be deliberate rather than incidental. If a feature change needs workflow updates, config surface changes, migration steps, or release-note churn, include them only when they are directly required by the feature and call them out explicitly in **What changed** or **Why**.
 
-For workflow-only, process-only, and docs-only PRs, keep commit titles and PR descriptions aligned with what actually shipped. Do not claim a version bump unless `Bloodcraft.csproj`, `thunderstore.toml`, and `CHANGELOG.md` are all being updated together as part of a deliberate release-facing change.
+For workflow-only, process-only, and docs-only PRs, keep commit titles and PR descriptions aligned with what actually shipped. Do not claim or imply a version bump unless `Bloodcraft.csproj`, `CHANGELOG.md`, and `thunderstore.toml` are all being updated together as part of a deliberate release-facing change.
 
 Use `minor-feature` as the final label name in contributor docs, reviews, and PR discussions. Do not switch between `minor-feature` and earlier draft terms such as `small-feature`; keeping the terminology consistent helps reviewers match labels, automation, and the PR template guidance.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,7 @@
 ## Release/versioning note
 - If this PR is workflow-only, process-only, docs-only, or otherwise does not change shipped plugin behavior, do **not** claim, imply, or headline a version bump in the PR title, summary, or checklist.
 - Release-facing changes should update `Bloodcraft.csproj`, `CHANGELOG.md`, and `thunderstore.toml` together as one intentional versioning action.
-- Keep release metadata churn minimal: if no release-facing change is intended, leave version numbers and release notes untouched.
+- Keep release metadata churn minimal: if no release-facing change is intended, leave version numbers and release notes (`CHANGELOG.md`) untouched.
 
 ## `minor-feature` label guidance
 Use the `minor-feature` label for PRs that are intentionally narrow in scope. These PRs should usually:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,13 +5,14 @@
 - 
 
 ## Release/versioning note
-- If this PR is workflow-only, process-only, docs-only, or otherwise does not change shipped plugin behavior, do **not** describe it as a version bump in the PR title or summary.
-- Only describe a version bump when `Bloodcraft.csproj`, `thunderstore.toml`, and `CHANGELOG.md` are updated together for an intentional release-facing change.
+- If this PR is workflow-only, process-only, docs-only, or otherwise does not change shipped plugin behavior, do **not** claim, imply, or headline a version bump in the PR title, summary, or checklist.
+- Release-facing changes should update `Bloodcraft.csproj`, `CHANGELOG.md`, and `thunderstore.toml` together as one intentional versioning action.
+- Keep release metadata churn minimal: if no release-facing change is intended, leave version numbers and release notes untouched.
 
 ## `minor-feature` label guidance
 Use the `minor-feature` label for PRs that are intentionally narrow in scope. These PRs should usually:
 - Touch only a few focused files.
-- Avoid workflow, release, or config churn unless that churn is part of the intended feature.
+- Avoid workflow, release, or config churn unless that churn is directly required by the intended feature.
 - Include a short acceptance checklist.
 - Avoid unrelated refactors while the feature is in flight.
 


### PR DESCRIPTION
### Motivation
- The repository had clear version numbers in `Bloodcraft.csproj`, `CHANGELOG.md`, and `thunderstore.toml` but messaging around when to call a PR a version bump could lead to accidental metadata churn. 
- The intent is to prevent non-release-facing PRs from claiming or implying version bumps and to make version updates an explicit, synchronized action.

### Description
- Update ` .github/pull_request_template.md` to require that workflow/process/docs-only PRs must not claim, imply, or headline a version bump and to state that release-facing changes must update `Bloodcraft.csproj`, `CHANGELOG.md`, and `thunderstore.toml` together.  
- Add a `Release versioning` section to `.github/CONTRIBUTING.md` that instructs contributors to treat version updates as deliberate release activity and to keep release metadata churn minimal.  
- No changes to release metadata were made; `Bloodcraft.csproj`, `CHANGELOG.md`, and `thunderstore.toml` remain unchanged at `1.12.20` to keep versioning intentional.

### Testing
- Ran `git diff -- .github/pull_request_template.md .github/CONTRIBUTING.md` to verify the intended edits were produced and the diff matched expectations (passed).  
- Searched for version references with `rg -n '1\.12\.20|versionNumber|<Version>'` to confirm release files still reference `1.12.20` (passed).  
- Verified repository state with `git status --short` and committed the documentation changes with `git commit -m "Clarify release versioning guidance"` (commit succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdfa59387c832dbc32d8c763cd75be)