### PR TITLE
Add shared version metadata workflow helper

### DIFF
--- a/.codex/scripts/version-metadata.sh
+++ b/.codex/scripts/version-metadata.sh
@@ -35,7 +35,7 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
-mapfile -t version_lines < <(python3 - <<'PY' "$REPO_ROOT" "$CHECK_TAG"
+version_output="$(python3 - <<'PY' "$REPO_ROOT" "$CHECK_TAG"
 import pathlib
 import re
 import sys
@@ -129,7 +129,19 @@ if check_tag:
     print(f"tag={check_tag}")
     print(f"tag_version={normalized_tag}")
 PY
-)
+)"
+
+if [ -z "$version_output" ]; then
+  echo "Error: Version metadata helper produced no output." >&2
+  exit 1
+fi
+
+mapfile -t version_lines <<< "$version_output"
+
+if ! printf '%s\n' "${version_lines[@]}" | grep -q '^version='; then
+  echo "Error: Version metadata helper did not emit a version= entry." >&2
+  exit 1
+fi
 
 printf '%s\n' "${version_lines[@]}"
 

--- a/.codex/scripts/version-metadata.sh
+++ b/.codex/scripts/version-metadata.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+CHECK_TAG=""
+
+usage() {
+  cat <<'USAGE'
+Usage: .codex/scripts/version-metadata.sh [--check-tag <tag>]
+
+Extracts and validates the canonical repository version metadata.
+USAGE
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --check-tag)
+      if [ "$#" -lt 2 ]; then
+        echo "Error: --check-tag requires a tag value." >&2
+        exit 1
+      fi
+      CHECK_TAG="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Error: Unknown argument '$1'." >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+mapfile -t version_lines < <(python3 - <<'PY' "$REPO_ROOT" "$CHECK_TAG"
+import pathlib
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+repo_root = pathlib.Path(sys.argv[1])
+check_tag = sys.argv[2]
+
+csproj_path = repo_root / "Bloodcraft.csproj"
+toml_path = repo_root / "thunderstore.toml"
+changelog_path = repo_root / "CHANGELOG.md"
+
+
+def fail(message: str) -> None:
+    print(message, file=sys.stderr)
+    raise SystemExit(1)
+
+try:
+    csproj_root = ET.parse(csproj_path).getroot()
+except FileNotFoundError:
+    fail(f"Error: Missing project file: {csproj_path}")
+except ET.ParseError as exc:
+    fail(f"Error: Failed to parse {csproj_path.name}: {exc}")
+
+version_text = None
+for element in csproj_root.iter():
+    if element.tag.endswith("Version") and element.text and element.text.strip():
+        version_text = element.text.strip()
+        break
+
+if not version_text:
+    fail(f"Error: Unable to locate a <Version> value in {csproj_path.name}.")
+
+try:
+    thunderstore_text = toml_path.read_text(encoding="utf-8")
+except FileNotFoundError:
+    fail(f"Error: Missing Thunderstore metadata file: {toml_path}")
+
+package_match = re.search(r'^versionNumber\s*=\s*"([^"]+)"', thunderstore_text, re.MULTILINE)
+if not package_match:
+    fail(f"Error: Unable to locate package.versionNumber in {toml_path.name}.")
+
+package_version = package_match.group(1).strip()
+if not package_version:
+    fail(f"Error: package.versionNumber in {toml_path.name} is empty.")
+
+try:
+    changelog_text = changelog_path.read_text(encoding="utf-8-sig")
+except FileNotFoundError:
+    fail(f"Error: Missing changelog file: {changelog_path}")
+
+match = re.search(r"^`([^`]+)`", changelog_text, re.MULTILINE)
+if not match:
+    fail(f"Error: Unable to locate the first version heading in {changelog_path.name}.")
+
+changelog_version = match.group(1).strip()
+if not changelog_version:
+    fail(f"Error: The first version heading in {changelog_path.name} is empty.")
+
+if package_version != version_text:
+    fail(
+        f"Error: thunderstore.toml package.versionNumber '{package_version}' does not match "
+        f"Bloodcraft.csproj version '{version_text}'."
+    )
+
+if changelog_version != version_text:
+    fail(
+        f"Error: CHANGELOG.md first version heading '{changelog_version}' does not match "
+        f"Bloodcraft.csproj version '{version_text}'."
+    )
+
+normalized_tag = ""
+if check_tag:
+    normalized_tag = check_tag
+    if normalized_tag.startswith("refs/tags/"):
+        normalized_tag = normalized_tag[len("refs/tags/"):]
+    if normalized_tag.startswith("v"):
+        normalized_tag = normalized_tag[1:]
+    normalized_tag = normalized_tag.split("-", 1)[0]
+    if normalized_tag != version_text:
+        fail(
+            f"Error: Release tag '{check_tag}' resolves to version '{normalized_tag}', "
+            f"which does not match canonical version '{version_text}'."
+        )
+
+print(f"version={version_text}")
+print(f"csproj_version={version_text}")
+print(f"thunderstore_version={package_version}")
+print(f"changelog_version={changelog_version}")
+if check_tag:
+    print(f"tag={check_tag}")
+    print(f"tag_version={normalized_tag}")
+PY
+)
+
+printf '%s\n' "${version_lines[@]}"
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  printf '%s\n' "${version_lines[@]}" >> "$GITHUB_OUTPUT"
+fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
     permissions:
       contents: read
     outputs:
-      version: ${{ steps.extract_version.outputs.version }}
+      version: ${{ steps.version_metadata.outputs.version }}
       should_publish: ${{ steps.version_guard.outputs.should_publish }}
 
     steps:
@@ -107,27 +107,16 @@ jobs:
           echo "${{ env.DOTNET_SDK_POLICY_NOTE }}"
           echo "Pinned SDK version: ${{ env.DOTNET_SDK_VERSION }}"
 
-      - name: Install xmllint
-        run: sudo apt-get update && sudo apt-get install --yes libxml2-utils
-
-      - name: Extract version from .csproj
-        id: extract_version
-        run: |
-          version=$(xmllint --xpath "string(//Project/PropertyGroup/Version)" "${{ needs.build_validation.outputs.csproj_file }}")
-
-          if [ -z "$version" ]; then
-            echo "Unable to determine current version from ${{ needs.build_validation.outputs.csproj_file }}." >&2
-            exit 1
-          fi
-
-          echo "version=$version" >> "$GITHUB_OUTPUT"
+      - name: Extract and validate version metadata
+        id: version_metadata
+        run: ./.codex/scripts/version-metadata.sh
 
       - name: Determine publish eligibility
         id: version_guard
         run: |
           latest_tag=$(git tag -l 'v*' --sort=-v:refname | grep -Ev '-' | head -n 1)
           latest_version=${latest_tag#v}
-          current_version="${{ steps.extract_version.outputs.version }}"
+          current_version="${{ steps.version_metadata.outputs.version }}"
 
           if [ -z "$latest_version" ]; then
             echo "No previous tagged release detected; proceeding with prerelease publication."
@@ -169,7 +158,7 @@ jobs:
           dotnet build "${{ needs.build_validation.outputs.csproj_file }}" \
             --configuration Release \
             --no-restore \
-            -p:Version=${{ steps.extract_version.outputs.version }} \
+            -p:Version=${{ steps.version_metadata.outputs.version }} \
             -p:RunGenerateREADME=false
 
       - name: Stage pre-release assets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,10 @@ jobs:
           echo "latest_tag=$latest_tag" >> "$GITHUB_OUTPUT"
           echo "RELEASE_TAG=$latest_tag" >> "$GITHUB_ENV"
 
+      - name: Validate version metadata against release tag
+        id: version_metadata
+        run: ./.codex/scripts/version-metadata.sh --check-tag "${{ steps.extract_tag.outputs.latest_tag }}"
+
       - name: Download release assets
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Motivation
- Centralize extraction and validation of the canonical package version to avoid duplicated ad-hoc parsing in CI and to fail early when metadata disagree. 
- Ensure `Bloodcraft.csproj`, `thunderstore.toml`, `CHANGELOG.md`, and release tags remain in sync before building or publishing to Thunderstore.

### Description
- Add `.codex/scripts/version-metadata.sh`, a small helper that reads the canonical version from `Bloodcraft.csproj`, parses `thunderstore.toml` and the first version heading from `CHANGELOG.md`, compares them, optionally verifies a supplied tag with `--check-tag <tag>`, and emits machine-readable `key=value` outputs (and appends to `GITHUB_OUTPUT` when available). 
- The script prints `version=...`, `csproj_version=...`, `thunderstore_version=...`, `changelog_version=...`, and when used with `--check-tag` also prints `tag=...` and `tag_version=...` for use in GitHub Actions. 
- Update `.github/workflows/build.yml` to call the helper (`id: version_metadata`) instead of installing `xmllint` and running the inline XML extraction, and to use the helper’s `version` output for prerelease packaging and publish-eligibility checks. 
- Update `.github/workflows/release.yml` to run the helper with `--check-tag` immediately after resolving the latest stable tag so publishing to Thunderstore fails early if tag/meta mismatch.

### Testing
- Ran the helper locally: `./.codex/scripts/version-metadata.sh` and it printed the expected `key=value` lines and exited successfully. 
- Ran the helper with a tag: `./.codex/scripts/version-metadata.sh --check-tag v1.12.20` and it validated the tag and printed `tag`/`tag_version` successfully. 
- Performed a shell syntax check with `bash -n .codex/scripts/version-metadata.sh` which succeeded. 
- Verified both workflows reference the helper with a small `python3` check that confirmed `version-metadata.sh` appears in `.github/workflows/build.yml` and `.github/workflows/release.yml`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdff3bf1bc832db99d44195d08d60b)