### PR TITLE
Enhance release metadata scope checks

### DIFF
--- a/.codex/scripts/pr-scope-check.sh
+++ b/.codex/scripts/pr-scope-check.sh
@@ -48,6 +48,13 @@ emit_group() {
     done
 }
 
+emit_notice() {
+    local title="$1"
+    local message="$2"
+
+    echo "::notice title=$title::$message"
+}
+
 matches_prefixes() {
     local path="$1"
     shift
@@ -137,6 +144,18 @@ is_production_code_file() {
     return 1
 }
 
+extract_csproj_version() {
+    sed -nE 's|.*<Version>([^<]+)</Version>.*|\1|p' Bloodcraft.csproj | head -n 1
+}
+
+extract_thunderstore_version() {
+    sed -nE 's|^versionNumber[[:space:]]*=[[:space:]]*"([^"]+)".*|\1|p' thunderstore.toml | head -n 1
+}
+
+extract_changelog_version() {
+    awk 'match($0, /[0-9]+(\.[0-9]+){1,3}([-+][^] ]+)?/) { print substr($0, RSTART, RLENGTH); exit }' CHANGELOG.md
+}
+
 RANGE="${1:-}"
 if [[ -z "$RANGE" ]]; then
     echo "Usage: $0 <git-diff-range>" >&2
@@ -202,6 +221,10 @@ done
 TOTAL_CHANGED=${#CHANGED_PATHS[@]}
 TEST_SIGNAL="No obvious test files were touched."
 RELEASE_METADATA_SIGNAL="No production C# files were touched, so no release-metadata expectation is implied."
+RELEASE_SYNC_SIGNAL="No release metadata update detected."
+RELEASE_SYNC_NOTICE_TITLE="Release metadata unchanged"
+RELEASE_SYNC_NOTICE_MESSAGE="No release metadata update detected in Bloodcraft.csproj, CHANGELOG.md, or thunderstore.toml."
+
 if [[ ${#TEST_FILES[@]} -gt 0 ]]; then
     TEST_SIGNAL="Yes — test-related files appear to be touched (${#TEST_FILES[@]})."
 fi
@@ -214,15 +237,43 @@ if [[ ${#PRODUCTION_CODE_FILES[@]} -gt 0 ]]; then
     fi
 fi
 
+if [[ ${#RELEASE_CHANGED[@]} -eq 0 ]]; then
+    RELEASE_SYNC_SIGNAL="No release metadata update detected."
+elif [[ ${#RELEASE_CHANGED[@]} -ne ${#RELEASE_FILES[@]} ]]; then
+    RELEASE_SYNC_SIGNAL="Release metadata updated in only ${#RELEASE_CHANGED[@]} of ${#RELEASE_FILES[@]} expected files. Version-facing updates should keep Bloodcraft.csproj, CHANGELOG.md, and thunderstore.toml synchronized."
+    RELEASE_SYNC_NOTICE_TITLE="Release metadata partially updated"
+    RELEASE_SYNC_NOTICE_MESSAGE="Release-facing version updates are expected to update Bloodcraft.csproj, CHANGELOG.md, and thunderstore.toml together."
+else
+    csproj_version="$(extract_csproj_version)"
+    thunderstore_version="$(extract_thunderstore_version)"
+    changelog_version="$(extract_changelog_version)"
+
+    if [[ -z "$csproj_version" || -z "$thunderstore_version" || -z "$changelog_version" ]]; then
+        RELEASE_SYNC_SIGNAL="Release metadata files changed together, but at least one version value could not be parsed. Parsed values — csproj: '${csproj_version:-missing}', thunderstore: '${thunderstore_version:-missing}', changelog: '${changelog_version:-missing}'."
+        RELEASE_SYNC_NOTICE_TITLE="Release metadata parse warning"
+        RELEASE_SYNC_NOTICE_MESSAGE="Release metadata files changed together, but one or more version values could not be parsed for synchronization review."
+    elif [[ "$csproj_version" == "$thunderstore_version" && "$csproj_version" == "$changelog_version" ]]; then
+        RELEASE_SYNC_SIGNAL="Release metadata is synchronized at version $csproj_version across Bloodcraft.csproj, CHANGELOG.md, and thunderstore.toml."
+        RELEASE_SYNC_NOTICE_TITLE="Release metadata synchronized"
+        RELEASE_SYNC_NOTICE_MESSAGE="Release metadata is synchronized at version $csproj_version across Bloodcraft.csproj, CHANGELOG.md, and thunderstore.toml."
+    else
+        RELEASE_SYNC_SIGNAL="Release metadata versions do not match — Bloodcraft.csproj: $csproj_version; thunderstore.toml: $thunderstore_version; CHANGELOG.md: $changelog_version."
+        RELEASE_SYNC_NOTICE_TITLE="Release metadata version mismatch"
+        RELEASE_SYNC_NOTICE_MESSAGE="Release metadata versions do not match across Bloodcraft.csproj, CHANGELOG.md, and thunderstore.toml."
+    fi
+fi
+
 append_summary "## PR changed-files summary"
 append_summary "Changed files inspected: **$TOTAL_CHANGED**"
 append_summary "Tests touched: **$TEST_SIGNAL**"
 append_summary "Release metadata updated alongside production C# changes: **$RELEASE_METADATA_SIGNAL**"
+append_summary "Release metadata synchronization review: **$RELEASE_SYNC_SIGNAL**"
 append_summary ""
 
 echo "Changed files inspected: $TOTAL_CHANGED"
 echo "Tests touched: $TEST_SIGNAL"
 echo "Release metadata updated alongside production C# changes: $RELEASE_METADATA_SIGNAL"
+echo "Release metadata synchronization review: $RELEASE_SYNC_SIGNAL"
 emit_group "### Workflow changes" "${WORKFLOW_FILES[@]}"
 emit_group "### Config changes" "${CONFIG_FILES[@]}"
 emit_group "### Release/versioning changes" "${RELEASE_CHANGED[@]}"
@@ -232,39 +283,42 @@ emit_group "### Production C# changes" "${PRODUCTION_CODE_FILES[@]}"
 emit_group "### Other changed files" "${OTHER_FILES[@]}"
 
 if [[ ${#WORKFLOW_FILES[@]} -gt 0 ]]; then
-    echo "::notice title=Workflow files changed::Workflow definitions changed in this PR."
+    emit_notice "Workflow files changed" "Workflow definitions changed in this PR."
 fi
 
 if [[ ${#CONFIG_FILES[@]} -gt 0 ]]; then
-    echo "::notice title=Config files changed::Configuration-oriented files changed in this PR."
+    emit_notice "Config files changed" "Configuration-oriented files changed in this PR."
 fi
 
 if [[ ${#LOCALIZATION_FILES[@]} -gt 0 ]]; then
-    echo "::notice title=Localization files changed::Localization resources changed in this PR."
+    emit_notice "Localization files changed" "Localization resources changed in this PR."
 fi
 
 if [[ ${#RELEASE_CHANGED[@]} -gt 0 ]]; then
-    echo "::notice title=Release/versioning files changed::Release metadata changed in this PR."
+    emit_notice "Release/versioning files changed" "Release metadata changed in this PR."
 fi
 
 if [[ ${#PRODUCTION_CODE_FILES[@]} -gt 0 ]]; then
     if [[ ${#RELEASE_CHANGED[@]} -gt 0 ]]; then
-        echo "::notice title=Production C# changes include release metadata::Production C# files changed and release-facing metadata files were updated in the same PR."
+        emit_notice "Production C# changes include release metadata" "Production C# files changed and release-facing metadata files were updated in the same PR."
     else
-        echo "::notice title=Production C# changes without release metadata::Production C# files changed without updates to CHANGELOG.md, Bloodcraft.csproj, or thunderstore.toml. Reviewers should confirm whether release metadata is intentionally deferred."
+        emit_notice "Production C# changes without release metadata" "Production C# files changed without updates to CHANGELOG.md, Bloodcraft.csproj, or thunderstore.toml. Reviewers should confirm whether release metadata is intentionally deferred."
     fi
 fi
 
 if [[ ${#TEST_FILES[@]} -eq 0 ]]; then
-    echo "::notice title=Tests not obviously touched::No obvious test files were detected in the PR diff."
+    emit_notice "Tests not obviously touched" "No obvious test files were detected in the PR diff."
 else
-    echo "::notice title=Tests appear touched::Detected ${#TEST_FILES[@]} test-related file(s) in the PR diff."
+    emit_notice "Tests appear touched" "Detected ${#TEST_FILES[@]} test-related file(s) in the PR diff."
 fi
+
+emit_notice "$RELEASE_SYNC_NOTICE_TITLE" "$RELEASE_SYNC_NOTICE_MESSAGE"
 
 append_summary ""
 append_summary "### Release metadata review cue"
 append_summary "- Production C# files changed: **${#PRODUCTION_CODE_FILES[@]}**"
 append_summary "- Release-facing metadata files changed: **${#RELEASE_CHANGED[@]}**"
+append_summary "- Release metadata status: **$RELEASE_SYNC_SIGNAL**"
 append_summary "- Reviewer prompt: confirm whether release metadata updates are intentionally included or intentionally deferred."
 append_summary "- Messaging prompt: workflow-only, process-only, or docs-only PR titles/descriptions should not claim a version bump unless all release metadata files changed together."
 append_summary ""

--- a/.codex/scripts/pr-scope-check.sh
+++ b/.codex/scripts/pr-scope-check.sh
@@ -55,6 +55,16 @@ emit_notice() {
     echo "::notice title=$title::$message"
 }
 
+resolve_repo_root() {
+    git rev-parse --show-toplevel 2>/dev/null || pwd
+}
+
+release_file_path() {
+    local relative_path="$1"
+
+    printf '%s/%s\n' "$REPO_ROOT" "$relative_path"
+}
+
 matches_prefixes() {
     local path="$1"
     shift
@@ -145,24 +155,46 @@ is_production_code_file() {
 }
 
 extract_csproj_version() {
-    sed -nE 's|.*<Version>([^<]+)</Version>.*|\1|p' Bloodcraft.csproj | head -n 1
+    local file_path
+    file_path="$(release_file_path 'Bloodcraft.csproj')"
+
+    if [[ ! -f "$file_path" ]]; then
+        return 0
+    fi
+
+    sed -nE 's|.*<Version>([^<]+)</Version>.*|\1|p' "$file_path" | head -n 1 || true
 }
 
 extract_thunderstore_version() {
-    sed -nE 's|^versionNumber[[:space:]]*=[[:space:]]*"([^"]+)".*|\1|p' thunderstore.toml | head -n 1
+    local file_path
+    file_path="$(release_file_path 'thunderstore.toml')"
+
+    if [[ ! -f "$file_path" ]]; then
+        return 0
+    fi
+
+    sed -nE 's|^versionNumber[[:space:]]*=[[:space:]]*"([^"]+)".*|\1|p' "$file_path" | head -n 1 || true
 }
 
 extract_changelog_version() {
-    awk 'match($0, /[0-9]+(\.[0-9]+){1,3}([-+][^] ]+)?/) { print substr($0, RSTART, RLENGTH); exit }' CHANGELOG.md
+    local file_path
+    file_path="$(release_file_path 'CHANGELOG.md')"
+
+    if [[ ! -f "$file_path" ]]; then
+        return 0
+    fi
+
+    awk 'match($0, /[0-9]+(\.[0-9]+){1,3}([-+][^] ]+)?/) { print substr($0, RSTART, RLENGTH); exit }' "$file_path" || true
 }
 
+REPO_ROOT="$(resolve_repo_root)"
 RANGE="${1:-}"
 if [[ -z "$RANGE" ]]; then
     echo "Usage: $0 <git-diff-range>" >&2
     exit 1
 fi
 
-if ! changed_output="$(git diff --name-only --diff-filter=ACMRDT "$RANGE")"; then
+if ! changed_output="$(git -C "$REPO_ROOT" diff --name-only --diff-filter=ACMRDT "$RANGE")"; then
     echo "Unable to inspect changed files for range: $RANGE" >&2
     exit 1
 fi


### PR DESCRIPTION
### Motivation
- Make release-metadata analysis more specific so reviewers can see whether `Bloodcraft.csproj`, `CHANGELOG.md`, and `thunderstore.toml` were updated together. 
- Surface synchronization results in the workflow summary and notices without blocking PRs so this remains informational during rollout.

### Description
- Added a reusable `emit_notice` helper to centralize workflow notice emission. 
- Implemented three extractors: `extract_csproj_version` (reads `<Version>` from `Bloodcraft.csproj`), `extract_thunderstore_version` (reads `versionNumber` from `thunderstore.toml`), and `extract_changelog_version` (scans the top of `CHANGELOG.md` for the first version token). 
- Introduced synchronization logic that distinguishes: no release files changed, partial updates (some but not all expected files), all three changed with parse errors, matched versions across the three files, and mismatched versions. 
- Surface the result in `GITHUB_STEP_SUMMARY` and emit workflow notices so reviewers immediately see the status while keeping the check informational.

### Testing
- Ran repository provisioning and build with `bash .codex/install.sh` successfully. 
- Verified script syntax with `bash -n .codex/scripts/pr-scope-check.sh`. 
- Exercised the script against an actual range with `.codex/scripts/pr-scope-check.sh HEAD~1..HEAD` and inspected summary output. 
- Created synthetic git scenarios (partial update and fully synchronized update) and confirmed the script reports partial vs synchronized status as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be0295f4b4832d846fbced56f60e9f)