### PR TITLE
Add shellcheck bootstrapping to install script

### DIFF
--- a/.codex/install.sh
+++ b/.codex/install.sh
@@ -58,6 +58,37 @@ PY
     python3 -m pip install --user PyYAML
 }
 
+ensure_shellcheck() {
+    if command -v shellcheck >/dev/null 2>&1; then
+        echo "shellcheck already installed"
+        return
+    fi
+
+    echo "shellcheck not found; attempting to install shell lint tooling..."
+
+    if command -v apt-get >/dev/null 2>&1; then
+        apt-get update && apt-get install -y shellcheck
+        return
+    fi
+
+    if command -v brew >/dev/null 2>&1; then
+        brew install shellcheck
+        return
+    fi
+
+    if command -v dnf >/dev/null 2>&1; then
+        dnf install -y shellcheck
+        return
+    fi
+
+    if command -v yum >/dev/null 2>&1; then
+        yum install -y shellcheck
+        return
+    fi
+
+    echo "shellcheck could not be installed automatically because no supported package manager was found. Shell linting is unavailable in this environment." >&2
+}
+
 install_dotnet() {
     mkdir -p "$INSTALL_DIR"
     local install_script
@@ -106,6 +137,7 @@ else
 fi
 
 ensure_python_yaml
+ensure_shellcheck
 
 if [ ! -f "$PROJECT_PATH" ]; then
     echo "Project file not found at $PROJECT_PATH" >&2


### PR DESCRIPTION
### Motivation

- Ensure contributors get shell lint tooling automatically as part of the existing bootstrap flow so shell scripts in the repo can be linted out-of-the-box.
- Keep the install script readable and modular by adding an isolated helper similar to `ensure_python_yaml()`.

### Description

- Added a new `ensure_shellcheck()` helper to `.codex/install.sh` that exits early when `shellcheck` is already on `PATH`.
- The helper prefers OS-native package managers in this order and attempts to install `shellcheck` via `apt-get`, `brew`, `dnf`, then `yum`.
- When no supported package manager is present the helper prints a clear non-fatal message indicating shell linting is unavailable.
- Wired `ensure_shellcheck` into the bootstrap flow by invoking it right after `ensure_python_yaml()` and before the `dotnet restore` / `dotnet build` steps.

### Testing

- Ran `bash -n .codex/install.sh` to validate script syntax and it succeeded.
- Ran `bash .codex/install.sh` which completed the bootstrap: the script installed the repo-managed .NET SDK, installed PyYAML, installed `shellcheck` via `apt-get` in the test environment, restored and built the project, and reported a successful build.
- Ran `shellcheck .codex/install.sh` to lint the installer and it completed without error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bec67482cc832dbf2a120024709ce5)