### PR TITLE
chore: add canonical shellcheck lint command

### DIFF
--- a/.codex/shellcheck.sh
+++ b/.codex/shellcheck.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+SHELL_SCRIPTS=(
+    "$REPO_ROOT/.codex/install.sh"
+    "$REPO_ROOT/.codex/shellcheck.sh"
+)
+
+if ! command -v shellcheck >/dev/null 2>&1; then
+    echo "shellcheck is required but was not found on PATH. Run 'bash .codex/install.sh' first to install repository tooling." >&2
+    exit 1
+fi
+
+echo "Linting shell scripts with shellcheck:"
+printf ' - %s\n' "${SHELL_SCRIPTS[@]#$REPO_ROOT/}"
+
+shellcheck "${SHELL_SCRIPTS[@]}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,12 @@ jobs:
           fetch-depth: 1
           fetch-tags: false
 
+      - name: Install shellcheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+
+      - name: Shell lint
+        run: bash .codex/shellcheck.sh
+
       - name: Discover .csproj
         id: discover_csproj
         run: |

--- a/README.md
+++ b/README.md
@@ -9,6 +9,19 @@
 - [Configuration](#configuration)
 - [Recommended Mods](#recommended-mods)
 
+## Development
+
+### Tooling bootstrap
+- Run `bash .codex/install.sh` from the repository root before any `dotnet` command. This provisions the expected .NET SDK, builds the project once, and installs `shellcheck` when a supported package manager is available.
+
+### Shell linting
+- Canonical shell lint command: `bash .codex/shellcheck.sh`
+- Current explicit lint scope:
+  - `.codex/install.sh`
+  - `.codex/shellcheck.sh`
+- This command fails fast when `shellcheck` is unavailable and tells contributors to bootstrap the repository with `bash .codex/install.sh` first.
+- Keep `.codex/` as the default lint target for repository tooling. Expand the explicit file list in `.codex/shellcheck.sh` as new tracked shell scripts are added.
+
 ## Support Development
 
 [![patreon](https://i.imgur.com/u6aAqeL.png)](https://www.patreon.com/join/4865914)  [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/zfolmt)


### PR DESCRIPTION
### Motivation
- Provide a single, documented way for contributors and CI to lint repository shell scripts so `shellcheck` is not only installed but actually used and failures are reproducible. 
- Keep the lint scope explicit and predictable by listing tracked tooling scripts under `.codex/` rather than using a recursive discovery by default.

### Description
- Add a new executable lint entrypoint ` .codex/shellcheck.sh` that lists explicit shell scripts to lint (initially `.codex/install.sh` and the lint script itself) and fails fast with guidance to run `bash .codex/install.sh` if `shellcheck` is missing. 
- Document the canonical local lint command and bootstrap instructions in `README.md` under a new "Development" section. 
- Add a CI step in `.github/workflows/build.yml` to install `shellcheck` and run `bash .codex/shellcheck.sh` so the repository enforces the same linting step in CI.

### Testing
- Ran `sudo apt-get update && sudo apt-get install -y shellcheck` to install `shellcheck` in the environment and it completed successfully. 
- Ran `bash .codex/shellcheck.sh` locally and it executed `shellcheck` against the explicit script list and exited successfully. 
- The workflow change to run `bash .codex/shellcheck.sh` in CI was added so linting will be enforced on GitHub Actions (CI step added but not executed in this change set).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bec7aeb034832da031514e3b218237)