### PR TITLE
Add canonical version validation script and use it in CI

### DIFF
--- a/.codex/scripts/version-metadata.sh
+++ b/.codex/scripts/version-metadata.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$(dirname "$SCRIPT_DIR")")"
+CSPROJ_PATH="$REPO_ROOT/Bloodcraft.csproj"
+THUNDERSTORE_PATH="$REPO_ROOT/thunderstore.toml"
+CHANGELOG_PATH="$REPO_ROOT/CHANGELOG.md"
+
+read_csproj_version() {
+    local version
+    version=$(sed -n 's:.*<Version>\(.*\)</Version>.*:\1:p' "$CSPROJ_PATH" | head -n 1 | tr -d '[:space:]')
+
+    if [ -z "$version" ]; then
+        echo "Unable to determine canonical version from $CSPROJ_PATH." >&2
+        exit 1
+    fi
+
+    printf '%s\n' "$version"
+}
+
+read_thunderstore_version() {
+    local version
+    version=$(sed -n 's/^versionNumber = "\([^"]*\)"$/\1/p' "$THUNDERSTORE_PATH" | head -n 1 | tr -d '[:space:]')
+
+    if [ -z "$version" ]; then
+        echo "Unable to determine thunderstore version from $THUNDERSTORE_PATH." >&2
+        exit 1
+    fi
+
+    printf '%s\n' "$version"
+}
+
+validate_changelog_version() {
+    local expected_version="$1"
+    local first_line expected_line
+
+    first_line=$(sed -n '1p' "$CHANGELOG_PATH" | tr -d '\r')
+    expected_line="\`$expected_version\`"
+
+    if [ "$first_line" != "$expected_line" ]; then
+        echo "CHANGELOG version mismatch: expected first line '$expected_line' in $CHANGELOG_PATH but found '$first_line'." >&2
+        exit 1
+    fi
+}
+
+canonical_version=$(read_csproj_version)
+thunderstore_version=$(read_thunderstore_version)
+
+if [ "$thunderstore_version" != "$canonical_version" ]; then
+    echo "Version mismatch: $THUNDERSTORE_PATH has $thunderstore_version but $CSPROJ_PATH has canonical version $canonical_version." >&2
+    exit 1
+fi
+
+validate_changelog_version "$canonical_version"
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    echo "canonical_version=$canonical_version" >> "$GITHUB_OUTPUT"
+fi
+
+echo "canonical_version=$canonical_version"

--- a/.codex/shellcheck.sh
+++ b/.codex/shellcheck.sh
@@ -6,6 +6,7 @@ REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 
 SHELL_SCRIPTS=(
     "$REPO_ROOT/.codex/install.sh"
+    "$REPO_ROOT/.codex/scripts/version-metadata.sh"
     "$REPO_ROOT/.codex/shellcheck.sh"
 )
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     outputs:
       should_build: ${{ steps.check_release.outputs.should_build }}
       reason: ${{ steps.check_release.outputs.reason }}
-      canonical_version: ${{ steps.read_version.outputs.version }}
+      canonical_version: ${{ steps.version_metadata.outputs.canonical_version }}
       matched_tag: ${{ steps.check_release.outputs.matched_tag }}
       csproj_file: ${{ steps.discover_csproj.outputs.csproj_file }}
 
@@ -51,26 +51,19 @@ jobs:
 
           echo "csproj_file=$csproj_file" >> "$GITHUB_OUTPUT"
 
-      - name: Read canonical version from .csproj
-        id: read_version
+      - name: Validate canonical version metadata
+        id: version_metadata
         shell: bash
         run: |
-          csproj='${{ steps.discover_csproj.outputs.csproj_file }}'
-          version=$(sed -n 's:.*<Version>\(.*\)</Version>.*:\1:p' "$csproj" | head -n 1 | tr -d '[:space:]')
-
-          if [ -z "$version" ]; then
-            echo "Unable to determine current version from $csproj." >&2
-            exit 1
-          fi
-
-          echo "Current .csproj version: $version"
-          echo "version=$version" >> "$GITHUB_OUTPUT"
+          # Branch-specific prerelease versions are derived after canonical validation
+          # and are not stored in repository metadata files.
+          ./.codex/scripts/version-metadata.sh
 
       - name: Check release tags for current version
         id: check_release
         uses: actions/github-script@v7
         env:
-          CURRENT_VERSION: ${{ steps.read_version.outputs.version }}
+          CURRENT_VERSION: ${{ steps.version_metadata.outputs.canonical_version }}
         with:
           script: |
             const currentVersion = process.env.CURRENT_VERSION;
@@ -83,7 +76,7 @@ jobs:
             if (context.eventName === 'workflow_dispatch' || context.ref === 'refs/heads/codex/feature-testing') {
               const reason = context.eventName === 'workflow_dispatch'
                 ? `Manual dispatch for version ${currentVersion}; allowing build.`
-                : `Feature-testing branch snapshot for canonical version ${currentVersion}; allowing build.`;
+                : `Feature-testing branch snapshot derived from canonical version ${currentVersion}; allowing build.`;
               core.info(reason);
               core.setOutput('should_build', 'true');
               core.setOutput('reason', reason);


### PR DESCRIPTION
### Motivation
- Provide a single source of truth for the canonical package version so CI validation and prerelease flows derive branch-specific snapshots only after canonical metadata has been validated.

### Description
- Add `.codex/scripts/version-metadata.sh` which reads the canonical version from `Bloodcraft.csproj`, verifies `versionNumber` in `thunderstore.toml` matches, validates the first line of `CHANGELOG.md` matches the backticked canonical version, and emits `canonical_version=...` to `$GITHUB_OUTPUT` and stdout.
- Update `.github/workflows/build.yml` to replace inline `.csproj` parsing with a `Validate canonical version metadata` step that runs `./.codex/scripts/version-metadata.sh` and wire its `canonical_version` output into downstream steps for both the `main` prerelease and `codex/feature-testing` derived-version paths.
- Include a short comment in the workflow step to clarify that branch-specific prerelease versions are derived after canonical validation and are not stored in repository metadata files.
- Extend `.codex/shellcheck.sh` to include the new script in CI shell linting.

### Testing
- Installed `shellcheck` and ran `bash .codex/shellcheck.sh`, which linted the repo scripts successfully (passed).
- Ran the new script directly with `./.codex/scripts/version-metadata.sh`, which printed `canonical_version=1.12.17` and exited successfully (passed).
- Captured workflow-style output with `tmp_output=$(mktemp) && GITHUB_OUTPUT="$tmp_output" ./.codex/scripts/version-metadata.sh && cat "$tmp_output"`, which produced `canonical_version=1.12.17` (passed).
- Ran `bash .codex/install.sh` in this environment but the external dotnet installer failed here (`/tmp/...: line 1: upstream: command not found`), so full SDK install/build steps were not validated in this environment (failed due to environment installer behavior).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bec866a43c832d9b54586a49407eed)