### PR TITLE
refactor: stop updating thunderstore metadata in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,15 +114,13 @@ jobs:
             core.setOutput('reason', reason);
             core.setOutput('matched_tag', '');
 
-  prepare_prerelease:
-    needs: validation
+  publish_prerelease:
+    needs:
+      - validation
     if: needs.validation.outputs.should_build == 'true' && github.ref == 'refs/heads/main'
     permissions:
       contents: write
     runs-on: ubuntu-latest
-    outputs:
-      canonical_version: ${{ needs.validation.outputs.canonical_version }}
-      csproj_file: ${{ needs.validation.outputs.csproj_file }}
 
     steps:
       - name: Log validation decision
@@ -132,44 +130,6 @@ jobs:
           echo "Canonical version: ${{ needs.validation.outputs.canonical_version }}"
           echo "Matched release tag: ${{ needs.validation.outputs.matched_tag || 'none' }}"
 
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-          fetch-tags: false
-
-      - name: Update thunderstore.toml
-        run: |
-          version='${{ needs.validation.outputs.canonical_version }}'
-
-          if [ -z "$version" ]; then
-            echo "Version is empty; skipping thunderstore.toml update."
-            exit 0
-          fi
-
-          sed -i "s/versionNumber = \".*\"/versionNumber = \"$version\"/" thunderstore.toml
-
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
-
-          if [ -n "$(git status --porcelain thunderstore.toml)" ]; then
-            git add thunderstore.toml
-            git commit -m "chore: Update thunderstore.toml version to $version"
-            git push origin HEAD:${{ github.ref }}
-          else
-            echo "No changes to commit in thunderstore.toml"
-          fi
-
-  publish_prerelease:
-    needs:
-      - validation
-      - prepare_prerelease
-    if: needs.validation.outputs.should_build == 'true' && github.ref == 'refs/heads/main'
-    permissions:
-      contents: write
-    runs-on: ubuntu-latest
-
-    steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
### Motivation
- Prevent prerelease CI jobs from mutating tracked repository files by removing the step that edited and pushed `thunderstore.toml` back to the repo. 
- Treat `thunderstore.toml` as canonical metadata that must already match the package `Version` before CI runs. 
- Ensure branch-specific prerelease versions are injected only into build/release metadata and not persisted to tracked files.

### Description
- Remove the `prepare_prerelease` job and the `Update thunderstore.toml` step that performed `sed`, `git commit` and `git push` in `.github/workflows/build.yml`. 
- Publish `main` prereleases directly from the canonical version validated by `./.codex/scripts/version-metadata.sh` and pass the version to MSBuild via `-p:Version=...` during `dotnet build`. 
- Keep `codex/feature-testing` behavior by deriving a `feature_testing_version` in workflow outputs and injecting it into build/release steps with `-p:Version=...` without modifying tracked files. 
- Retain `./.codex/scripts/version-metadata.sh` as the guard that ensures canonical files are synchronized before any publish step runs.

### Testing
- Ran `bash .codex/install.sh` and the toolchain installation completed successfully. 
- Ran `bash .codex/shellcheck.sh` and shell script linting passed. 
- Ran `dotnet build . --configuration Release -p:RunGenerateREADME=false` (after exporting `DOTNET_ROOT`/`PATH`) and the build succeeded with warnings about `net6.0` being out of support.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bed214ec20832dbb93377c07c6b12b)