### PR TITLE
Validate canonical version metadata before CI builds and Thunderstore release

### DIFF
--- a/.codex/scripts/version-metadata.sh
+++ b/.codex/scripts/version-metadata.sh
@@ -38,6 +38,8 @@ read_thunderstore_version() {
 
 read_latest_changelog_entry() {
     local entry
+    # shellcheck disable=SC2016
+    # sed needs literal backticks to match the repo's changelog header format.
     entry=$(sed -n '/^`[^`][^`]*`$/ { s/^`//; s/`$//; p; q; }' "$CHANGELOG_PATH" | tr -d '\r')
 
     if [ -z "$entry" ]; then

--- a/.codex/scripts/version-metadata.sh
+++ b/.codex/scripts/version-metadata.sh
@@ -6,14 +6,20 @@ REPO_ROOT="$(dirname "$(dirname "$SCRIPT_DIR")")"
 CSPROJ_PATH="$REPO_ROOT/Bloodcraft.csproj"
 THUNDERSTORE_PATH="$REPO_ROOT/thunderstore.toml"
 CHANGELOG_PATH="$REPO_ROOT/CHANGELOG.md"
+CANONICAL_VERSION_PATTERN='^[0-9]+\.[0-9]+\.[0-9]+$'
+
+fail() {
+    local message="$1"
+    echo "Error: $message" >&2
+    exit 1
+}
 
 read_csproj_version() {
     local version
     version=$(sed -n 's:.*<Version>\(.*\)</Version>.*:\1:p' "$CSPROJ_PATH" | head -n 1 | tr -d '[:space:]')
 
     if [ -z "$version" ]; then
-        echo "Unable to determine canonical version from $CSPROJ_PATH." >&2
-        exit 1
+        fail "Unable to determine canonical version from $CSPROJ_PATH."
     fi
 
     printf '%s\n' "$version"
@@ -24,38 +30,57 @@ read_thunderstore_version() {
     version=$(sed -n 's/^versionNumber = "\([^"]*\)"$/\1/p' "$THUNDERSTORE_PATH" | head -n 1 | tr -d '[:space:]')
 
     if [ -z "$version" ]; then
-        echo "Unable to determine thunderstore version from $THUNDERSTORE_PATH." >&2
-        exit 1
+        fail "Unable to determine Thunderstore version from $THUNDERSTORE_PATH."
     fi
 
     printf '%s\n' "$version"
 }
 
-validate_changelog_version() {
-    local expected_version="$1"
-    local first_line expected_line
+read_latest_changelog_entry() {
+    local entry
+    entry=$(sed -n '/^`[^`][^`]*`$/ { s/^`//; s/`$//; p; q; }' "$CHANGELOG_PATH" | tr -d '\r')
 
-    first_line=$(sed -n '1p' "$CHANGELOG_PATH" | tr -d '\r')
-    expected_line="\`$expected_version\`"
+    if [ -z "$entry" ]; then
+        fail "Unable to determine the latest CHANGELOG entry from $CHANGELOG_PATH."
+    fi
 
-    if [ "$first_line" != "$expected_line" ]; then
-        echo "CHANGELOG version mismatch: expected first line '$expected_line' in $CHANGELOG_PATH but found '$first_line'." >&2
-        exit 1
+    printf '%s\n' "$entry"
+}
+
+validate_canonical_version_format() {
+    local version="$1"
+    local source_name="$2"
+
+    if [[ ! "$version" =~ $CANONICAL_VERSION_PATTERN ]]; then
+        fail "$source_name version '$version' must match canonical format X.Y.Z."
     fi
 }
 
+emit_canonical_version() {
+    local canonical_version="$1"
+
+    if [ -n "${GITHUB_OUTPUT:-}" ]; then
+        echo "canonical_version=$canonical_version" >> "$GITHUB_OUTPUT"
+    fi
+
+    echo "canonical_version=$canonical_version"
+}
+
 canonical_version=$(read_csproj_version)
+validate_canonical_version_format "$canonical_version" "$CSPROJ_PATH"
+
 thunderstore_version=$(read_thunderstore_version)
+validate_canonical_version_format "$thunderstore_version" "$THUNDERSTORE_PATH"
 
 if [ "$thunderstore_version" != "$canonical_version" ]; then
-    echo "Version mismatch: $THUNDERSTORE_PATH has $thunderstore_version but $CSPROJ_PATH has canonical version $canonical_version." >&2
-    exit 1
+    fail "$THUNDERSTORE_PATH versionNumber '$thunderstore_version' does not match canonical version '$canonical_version' from $CSPROJ_PATH."
 fi
 
-validate_changelog_version "$canonical_version"
+changelog_version=$(read_latest_changelog_entry)
+validate_canonical_version_format "$changelog_version" "$CHANGELOG_PATH"
 
-if [ -n "${GITHUB_OUTPUT:-}" ]; then
-    echo "canonical_version=$canonical_version" >> "$GITHUB_OUTPUT"
+if [ "$changelog_version" != "$canonical_version" ]; then
+    fail "$CHANGELOG_PATH latest entry '$changelog_version' does not match canonical version '$canonical_version' from $CSPROJ_PATH."
 fi
 
-echo "canonical_version=$canonical_version"
+emit_canonical_version "$canonical_version"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,6 +151,10 @@ jobs:
         with:
           dotnet-version: 8.0.x
 
+      - name: Validate canonical version metadata
+        shell: bash
+        run: ./.codex/scripts/version-metadata.sh
+
       - name: Restore dependencies
         run: dotnet restore -p:CheckEolTargetFramework=false
 
@@ -242,6 +246,10 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.0.x
+
+      - name: Validate canonical version metadata
+        shell: bash
+        run: ./.codex/scripts/version-metadata.sh
 
       - name: Restore dependencies
         run: dotnet restore -p:CheckEolTargetFramework=false
@@ -343,6 +351,10 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.0.x
+
+      - name: Validate canonical version metadata
+        shell: bash
+        run: ./.codex/scripts/version-metadata.sh
 
       - name: Restore dependencies
         run: dotnet restore -p:CheckEolTargetFramework=false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,20 +7,27 @@ jobs:
   release_on_thunderstore:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate canonical version metadata
+        id: version_metadata
+        shell: bash
+        run: ./.codex/scripts/version-metadata.sh
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '6.0.x'
           dotnet-quality: 'preview'
 
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
       - name: Select eligible release tag
         id: select_tag
         run: |
+          canonical_version='${{ steps.version_metadata.outputs.canonical_version }}'
+
           # Feature-testing prereleases (v*-ft.*) are disposable CI artifacts and must never drive Thunderstore publication.
           tag_pattern='^v[0-9]+\.[0-9]+\.[0-9]+(-pre)?$'
           excluded_pattern='^v.*-ft\..*$'
@@ -38,6 +45,11 @@ jobs:
 
           selected_tag="${eligible_tags[0]}"
           package_version="${selected_tag#v}"
+
+          if [[ "$package_version" != "$canonical_version" && "$package_version" != "$canonical_version-pre" ]]; then
+            echo "Error: Selected release tag '$selected_tag' does not align with canonical version '$canonical_version'." >&2
+            exit 1
+          fi
 
           echo "Eligible Thunderstore tags: ${eligible_tags[*]}"
           echo "Selected Thunderstore tag: $selected_tag"


### PR DESCRIPTION
### Motivation
- Ensure the repository's canonical version is authoritative and prevent builds or publications when metadata files drift out of sync.
- Make build and release workflows fail fast with a clear message if `Bloodcraft.csproj`, `thunderstore.toml`, and the top of `CHANGELOG.md` disagree.
- Emit the validated canonical version for downstream workflow steps to consume so derived prerelease logic remains deterministic.

### Description
- Add `.codex/scripts/version-metadata.sh` which reads the canonical version from `Bloodcraft.csproj`, reads `versionNumber` from `thunderstore.toml`, verifies the latest `CHANGELOG.md` entry matches the canonical `X.Y.Z` format, and emits `canonical_version` to `GITHUB_OUTPUT` and stdout; the script exits non-zero with clear errors on mismatch.
- Harden the script to validate that all three sources conform to a canonical `X.Y.Z` pattern and provide informative failure messages.
- Wire the script into CI: call the script immediately before `dotnet restore`/`dotnet build` steps in the relevant jobs in `.github/workflows/build.yml` and run it at the start of the Thunderstore publish flow in `.github/workflows/release.yml`, and add a guard verifying the selected release tag aligns with the validated canonical version (or its `-pre` form).

### Testing
- Ran `bash -n .codex/scripts/version-metadata.sh` to validate script syntax, which succeeded.
- Executed `./.codex/scripts/version-metadata.sh` in-repo to verify it discovers and emits `canonical_version` (produced `canonical_version=1.12.17`), which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bee1a36d78832db20037f8ff52e6c3)