### PR TITLE
Stop build workflow from mutating thunderstore metadata

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           fetch-depth: 1
           fetch-tags: false
+          persist-credentials: false
 
       - name: Install shellcheck
         run: sudo apt-get update && sudo apt-get install -y shellcheck
@@ -145,6 +146,7 @@ jobs:
         with:
           fetch-depth: 1
           fetch-tags: false
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -154,6 +156,12 @@ jobs:
       - name: Validate canonical version metadata
         shell: bash
         run: ./.codex/scripts/version-metadata.sh
+
+      - name: Verify canonical version files remain unchanged
+        shell: bash
+        run: |
+          csproj='${{ needs.validate_build_inputs.outputs.csproj_file }}'
+          git diff --exit-code -- "$csproj" thunderstore.toml
 
       - name: Restore dependencies
         run: dotnet restore -p:CheckEolTargetFramework=false
@@ -234,6 +242,7 @@ jobs:
         with:
           fetch-depth: 1
           fetch-tags: false
+          persist-credentials: false
 
       - name: Get DLL name
         id: get_dll_name
@@ -251,6 +260,12 @@ jobs:
         shell: bash
         run: ./.codex/scripts/version-metadata.sh
 
+      - name: Verify canonical version files remain unchanged
+        shell: bash
+        run: |
+          csproj='${{ needs.validate_build_inputs.outputs.csproj_file }}'
+          git diff --exit-code -- "$csproj" thunderstore.toml
+
       - name: Restore dependencies
         run: dotnet restore -p:CheckEolTargetFramework=false
 
@@ -259,6 +274,7 @@ jobs:
           version='${{ needs.prepare_prerelease.outputs.prerelease_version }}'
 
           if [ -n "$version" ]; then
+            # Canonical tracked version files must already be correct; CI-only versions flow through MSBuild properties.
             dotnet build . --configuration Release -p:Version=$version -p:RunGenerateREADME=false -p:CheckEolTargetFramework=false
           else
             dotnet build . --configuration Release -p:RunGenerateREADME=false -p:CheckEolTargetFramework=false
@@ -339,6 +355,7 @@ jobs:
         with:
           fetch-depth: 1
           fetch-tags: false
+          persist-credentials: false
 
       - name: Get DLL name
         id: get_dll_name
@@ -356,12 +373,19 @@ jobs:
         shell: bash
         run: ./.codex/scripts/version-metadata.sh
 
+      - name: Verify canonical version files remain unchanged
+        shell: bash
+        run: |
+          csproj='${{ needs.validate_build_inputs.outputs.csproj_file }}'
+          git diff --exit-code -- "$csproj" thunderstore.toml
+
       - name: Restore dependencies
         run: dotnet restore -p:CheckEolTargetFramework=false
 
       - name: Build feature-testing snapshot artifact
         run: |
           feature_testing_version='${{ needs.prepare_feature_testing_prerelease.outputs.feature_testing_version }}'
+          # Canonical tracked version files must already be correct; CI-only versions flow through MSBuild properties.
           dotnet build . --configuration Release -p:Version=$feature_testing_version -p:RunGenerateREADME=false -p:CheckEolTargetFramework=false
 
       - name: GH Release (feature-testing snapshot)


### PR DESCRIPTION
### Motivation

- Prevent the CI from editing and committing `thunderstore.toml` (or other tracked version files) and require canonical version files to be correct prior to publishing.
- Ensure derived/prerelease versions are conveyed only through build/release parameters (for example `-p:Version=...`) rather than by mutating repository files.
- Reduce accidental push capability from runner jobs by removing persistent checkout credentials so metadata changes cannot be pushed back from CI.

### Description

- Set `persist-credentials: false` on all `actions/checkout@v4` invocations in `.github/workflows/build.yml` to remove the runner's ability to push back changes.
- Added `git diff --exit-code -- "$csproj" thunderstore.toml` verification steps before restore/build/publish phases to require that `thunderstore.toml` and the canonical `.csproj` remain unchanged in CI.
- Clarified and enforced that derived prerelease and feature-testing versions are provided to the build using MSBuild properties (e.g. `dotnet build -p:Version=...`) and added comments in the relevant build steps to document this transient handling.

### Testing

- Verified the modified workflow parses as YAML using `ruby -e "require 'yaml'; data = YAML.load_file('.github/workflows/build.yml')..."`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bef28adfd0832dac6d45ca6c345c03)