### PR TITLE
Harden release tag selection to exclude feature-testing snapshots

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,18 +28,19 @@ jobs:
         run: |
           canonical_version='${{ steps.version_metadata.outputs.canonical_version }}'
 
-          # Feature-testing prereleases (v*-ft.*) are disposable CI artifacts and must never drive Thunderstore publication.
-          tag_pattern='^v[0-9]+\.[0-9]+\.[0-9]+(-pre)?$'
-          excluded_pattern='^v.*-ft\..*$'
+          # Thunderstore accepts canonical stable releases (vX.Y.Z) and shared prereleases (vX.Y.Z-pre).
+          # Feature-testing snapshots (v*-ft.*) are disposable CI artifacts and must never drive publication.
+          allowed_tag_pattern='^v[0-9]+\.[0-9]+\.[0-9]+(-pre)?$'
+          allowed_package_version_pattern='^[0-9]+\.[0-9]+\.[0-9]+(-pre)?$'
 
           mapfile -t eligible_tags < <(
             git tag --sort=-v:refname \
-              | grep -E "$tag_pattern" \
-              | grep -Ev "$excluded_pattern"
+              | grep -E "$allowed_tag_pattern"
           )
 
           if [[ ${#eligible_tags[@]} -eq 0 ]]; then
-            echo "Error: No eligible Thunderstore release tag found. Expected a stable tag (vX.Y.Z) or shared prerelease tag (vX.Y.Z-pre), excluding feature-testing tags (v*-ft.*)." >&2
+            echo "Error: No eligible Thunderstore release tag found." >&2
+            echo "Expected one of: vX.Y.Z or vX.Y.Z-pre. Feature-testing tags such as v*-ft.* are intentionally excluded." >&2
             exit 1
           fi
 
@@ -57,6 +58,8 @@ jobs:
 
           echo "RELEASE_TAG=$selected_tag" >> "$GITHUB_ENV"
           echo "PACKAGE_VERSION=$package_version" >> "$GITHUB_ENV"
+          echo "ALLOWED_TAG_PATTERN=$allowed_tag_pattern" >> "$GITHUB_ENV"
+          echo "ALLOWED_PACKAGE_VERSION_PATTERN=$allowed_package_version_pattern" >> "$GITHUB_ENV"
         shell: bash
 
       - name: Download Release
@@ -71,17 +74,12 @@ jobs:
 
       - name: Publish build to Thunderstore
         run: |
-          if [[ ! $RELEASE_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-pre)?$ ]]; then
+          if [[ ! $RELEASE_TAG =~ $ALLOWED_TAG_PATTERN ]]; then
             echo "Error: Release tag '$RELEASE_TAG' is not an allowed Thunderstore source tag." >&2
             exit 1
           fi
 
-          if [[ $RELEASE_TAG =~ ^v.*-ft\..*$ ]]; then
-            echo "Error: Feature-testing tag '$RELEASE_TAG' is excluded from Thunderstore publication." >&2
-            exit 1
-          fi
-
-          if [[ ! $PACKAGE_VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+(-pre)?$ ]]; then
+          if [[ ! $PACKAGE_VERSION =~ $ALLOWED_PACKAGE_VERSION_PATTERN ]]; then
             echo "Error: Package version '$PACKAGE_VERSION' derived from '$RELEASE_TAG' is not an allowed Thunderstore package version." >&2
             exit 1
           fi
@@ -91,3 +89,5 @@ jobs:
         env:
           RELEASE_TAG: ${{ env.RELEASE_TAG }}
           PACKAGE_VERSION: ${{ env.PACKAGE_VERSION }}
+          ALLOWED_TAG_PATTERN: ${{ env.ALLOWED_TAG_PATTERN }}
+          ALLOWED_PACKAGE_VERSION_PATTERN: ${{ env.ALLOWED_PACKAGE_VERSION_PATTERN }}


### PR DESCRIPTION
### Motivation
- Prevent disposable feature-testing snapshot tags (`v*-ft.*`) from driving Thunderstore publication and make allowed tags explicit. 
- Allow canonical stable releases (`vX.Y.Z`) and shared prerelease tags (`vX.Y.Z-pre`) as Thunderstore sources. 
- Ensure the tag-to-package sanitization step uses the same allowed patterns so a snapshot can never be mistaken for a canonical publishable version.

### Description
- Replace the previous tag selection with `allowed_tag_pattern` and `allowed_package_version_pattern` regexes that match `^vX.Y.Z(-pre)?$` and use them to filter Git tags. 
- Export the chosen tag, derived package version, and the two allowed-pattern variables to the environment (`GITHUB_ENV`) and log the eligible tags and selected tag. 
- Use the same allowed-pattern variables in the publish step to validate both `RELEASE_TAG` and `PACKAGE_VERSION` and fail with clear errors when mismatched. 
- Improve failure messages to clearly state the expected tag formats and remove the old special-case `-ft` check by excluding those via the allowed pattern.

### Testing
- Validated workflow YAML syntax by running `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "YAML OK"'`, which printed `YAML OK`.
- Attempted `bash -n .github/workflows/release.yml` which produced a shell syntax error because that command is not a YAML linter and is not applicable for validating workflow files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bef48a86dc832db6abade374b621bb)