### PR TITLE
Add concise release-process note to CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,8 +2,8 @@
 
 ## Release process
 
-- Treat the version in `Bloodcraft.csproj`, `thunderstore.toml`, and the current `CHANGELOG.md` entry as the canonical repo-owned version; update them together when preparing a new release.
-- Pushes to `main` publish the shared prerelease tag `v<canonical>-pre`.
+- Treat the version in `Bloodcraft.csproj`, `thunderstore.toml`, and the current `CHANGELOG.md` entry as the canonical repo-owned version, and keep it as plain `X.Y.Z` only; any `-pre` or `-ft.*` suffixes are derived by CI and are not committed to those files.
+- Pushes to `main` publish the shared prerelease tag `v<canonical>-pre` only when no existing GitHub Release already covers that canonical version.
 - Pushes to `codex/feature-testing` publish disposable snapshot tags `v<canonical>-ft.<runNumber>`.
 - `pull_request` runs targeting `main` are validation-only; they verify the canonical version and build, but do not publish.
 - Branch-derived prerelease and feature-testing versions are workflow outputs only and must never be committed back into repo metadata files.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing Notes
+
+## Release process
+
+- Treat the version in `Bloodcraft.csproj`, `thunderstore.toml`, and the current `CHANGELOG.md` entry as the canonical repo-owned version; update them together when preparing a new release.
+- Pushes to `main` publish the shared prerelease tag `v<canonical>-pre`.
+- Pushes to `codex/feature-testing` publish disposable snapshot tags `v<canonical>-ft.<runNumber>`.
+- `pull_request` runs targeting `main` are validation-only; they verify the canonical version and build, but do not publish.
+- Branch-derived prerelease and feature-testing versions are workflow outputs only and must never be committed back into repo metadata files.


### PR DESCRIPTION
### Motivation
- Provide a short, operational release-process note that clarifies canonical version ownership across `Bloodcraft.csproj`, `thunderstore.toml`, and `CHANGELOG.md`, and documents CI publishing behaviors and workflow-only branch-derived versions.

### Description
- Add `.github/CONTRIBUTING.md` containing a compact release-process checklist that: declares the canonical repo-owned version (coordinated across `Bloodcraft.csproj`, `thunderstore.toml`, and the current `CHANGELOG.md` entry); states that pushes to `main` publish the shared prerelease tag `v<canonical>-pre`; states that pushes to `codex/feature-testing` publish disposable snapshot tags `v<canonical>-ft.<runNumber>`; documents that `pull_request` runs to `main` are validation-only; and clarifies that branch-derived prerelease/feature-testing versions are workflow outputs only and must not be committed back into repository metadata.

### Testing
- Ran `git status --short` and `nl -ba .github/CONTRIBUTING.md` to verify the file was created and contains the expected content, and both commands succeeded; no build/test run was required for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69beff3442bc832da0d2a2d55658c976)