### PR TITLE
Normalize feature-testing prerelease GitHub Release name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -399,7 +399,7 @@ jobs:
             - Branch: ${{ github.ref_name }}
             - Commit: ${{ github.sha }}
             - Run: ${{ github.run_id }}
-          name: Feature-testing branch prerelease v${{ needs.prepare_feature_testing_prerelease.outputs.feature_testing_version }}
+          name: feature-testing prerelease v${{ needs.prepare_feature_testing_prerelease.outputs.feature_testing_version }}
           fail_on_unmatched_files: true
           prerelease: true
           tag_name: v${{ needs.prepare_feature_testing_prerelease.outputs.feature_testing_version }}


### PR DESCRIPTION
### Motivation
- Ensure the feature-testing release title exactly matches the intended lower-case channel name and maintain consistent wording across the CI workflow while keeping tag format unchanged.

### Description
- Update the GitHub Release `name` in `publish_feature_testing_prerelease` within `.github/workflows/build.yml` from `Feature-testing branch prerelease v...` to `feature-testing prerelease v...` and leave the `tag_name` as `v${{ needs.prepare_feature_testing_prerelease.outputs.feature_testing_version }}`.

### Testing
- Ran `rg -n "Feature-testing branch prerelease|feature-testing prerelease" .github/workflows/build.yml` and `git diff --check`, both completed with no outstanding matches or warnings and the change was committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf103c9c18832d9af1d5c827b80379)