### PR TITLE
Tighten workflow version file checks to include CHANGELOG.md

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,7 +161,8 @@ jobs:
         shell: bash
         run: |
           csproj='${{ needs.validate_build_inputs.outputs.csproj_file }}'
-          git diff --exit-code -- "$csproj" thunderstore.toml
+          # Canonical repo-owned version files must remain unchanged throughout CI.
+          git diff --exit-code -- "$csproj" thunderstore.toml CHANGELOG.md
 
       - name: Restore dependencies
         run: dotnet restore -p:CheckEolTargetFramework=false
@@ -264,7 +265,8 @@ jobs:
         shell: bash
         run: |
           csproj='${{ needs.validate_build_inputs.outputs.csproj_file }}'
-          git diff --exit-code -- "$csproj" thunderstore.toml
+          # Canonical repo-owned version files must remain unchanged throughout CI.
+          git diff --exit-code -- "$csproj" thunderstore.toml CHANGELOG.md
 
       - name: Restore dependencies
         run: dotnet restore -p:CheckEolTargetFramework=false
@@ -377,7 +379,8 @@ jobs:
         shell: bash
         run: |
           csproj='${{ needs.validate_build_inputs.outputs.csproj_file }}'
-          git diff --exit-code -- "$csproj" thunderstore.toml
+          # Canonical repo-owned version files must remain unchanged throughout CI.
+          git diff --exit-code -- "$csproj" thunderstore.toml CHANGELOG.md
 
       - name: Restore dependencies
         run: dotnet restore -p:CheckEolTargetFramework=false


### PR DESCRIPTION
### Motivation
- Enforce immutability for every canonical repo-owned version metadata file so CI cannot accidentally modify tracked version information during the build/publish flows.

### Description
- Update `.github/workflows/build.yml` to add a short explanatory comment and include `CHANGELOG.md` in the `git diff --exit-code -- ...` guard (replacing `git diff --exit-code -- "$csproj" thunderstore.toml`) in the `build_verification`, `publish_prerelease`, and `publish_feature_testing_prerelease` steps so the same canonical file set is checked consistently.

### Testing
- Ran `rg -n "Verify canonical version files remain unchanged|git diff --exit-code --|Canonical repo-owned version files" .github/workflows/build.yml`, `git diff -- .github/workflows/build.yml`, and `git show --stat --oneline --decorate=short HEAD`; all commands returned the expected results and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf11526c44832db37a5f160d0af851)