### PR TITLE
Align release workflow .NET SDK with repository (use 8.0.x)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,9 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '6.0.x'
-          dotnet-quality: 'preview'
+          # Keep release publishing on the same repo-managed SDK line as global.json,
+          # .codex/install.sh, and the main build workflow.
+          dotnet-version: '8.0.x'
 
       - name: Select eligible release tag
         id: select_tag


### PR DESCRIPTION
### Motivation
- Ensure the release publishing workflow uses the same repo-managed .NET SDK line as `global.json`, `.codex/install.sh`, and the main build workflow so published artifacts are built against the same toolchain and avoid accidental divergence.

### Description
- Update `.github/workflows/release.yml` to set `dotnet-version: '8.0.x'`, remove the `dotnet-quality: 'preview'` override, and add a short inline comment explaining the intentional alignment with the main build toolchain.

### Testing
- Ran `git diff --check` which completed with no issues; attempted a YAML parse check using Python (`yaml.safe_load`) but it could not run because `PyYAML` is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf121ce6ac832db3ccaeb3e800591c)