### PR TITLE
Clarify workflow YAML tooling warning

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -7,3 +7,16 @@
 - Pushes to `codex/feature-testing` publish disposable snapshot tags `v<canonical>-ft.<runNumber>`.
 - `pull_request` runs targeting `main` are validation-only; they verify the canonical version and build, but do not publish.
 - Branch-derived prerelease and feature-testing versions are workflow outputs only and must never be committed back into repo metadata files.
+
+## Review/testing note
+
+- Local YAML validation warnings against `.github/workflows/release.yml` should be interpreted carefully.
+- Command used during review/testing:
+
+  ```bash
+  python3 - <<'PY'
+  import yaml
+  PY
+  ```
+
+  Warning: `python3` is present, but this command currently fails because `import yaml` raises `ModuleNotFoundError: No module named 'yaml'` due to missing PyYAML. This is an environment/tooling dependency issue, not evidence that `.github/workflows/release.yml` is invalid YAML.


### PR DESCRIPTION
### Motivation
- Make the contributor-facing review/testing note accurately describe the local failure mode observed when validating `.github/workflows/release.yml`, and avoid wording that implies Python itself is unavailable or broken.

### Description
- Add a `## Review/testing note` to `.github/CONTRIBUTING.md` that preserves the `python3` check, documents the exact failure `ModuleNotFoundError: No module named 'yaml'`, and clarifies this is a missing PyYAML/tooling dependency rather than evidence that `.github/workflows/release.yml` is invalid YAML.

### Testing
- Verified the updated note and file content with `sed -n '1,120p' .github/CONTRIBUTING.md` and reproduced the failure using `python3 - <<'PY'\nimport yaml\nPY` which fails with `ModuleNotFoundError: No module named 'yaml'`, matching the documented behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf13746d50832da4517d33f3deedb4)