### PR TITLE
Clarify workflow YAML review tooling

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -15,28 +15,28 @@
 - Direct parser check used during review/testing:
 
   ```bash
-  python3 - <<'PY'
-  import yaml
-  PY
+python3 - <<'PY'
+import yaml
+PY
   ```
 
   This check depends on PyYAML being installed. If `import yaml` raises `ModuleNotFoundError: No module named 'yaml'`, treat that as a missing parser dependency in the local environment, not as evidence that `.github/workflows/release.yml` is invalid YAML.
 - Guarded variant that separates dependency availability from YAML content validation:
 
   ```bash
-  if ! python3 -c 'import yaml' >/dev/null 2>&1; then
-    echo "Warning: PyYAML is not installed; skipping YAML parsing check."
-  else
-    python3 - <<'PY'
-  import pathlib
-  import yaml
+if ! python3 -c 'import yaml' >/dev/null 2>&1; then
+  echo "Warning: PyYAML is not installed; skipping YAML parsing check."
+else
+  python3 - <<'PY'
+import pathlib
+import yaml
 
-  workflowPath = pathlib.Path('.github/workflows/release.yml')
-  with workflowPath.open('r', encoding='utf-8') as workflowFile:
-      yaml.safe_load(workflowFile)
-  print(f'Parsed {workflowPath} successfully.')
-  PY
-  fi
+workflowPath = pathlib.Path('.github/workflows/release.yml')
+with workflowPath.open('r', encoding='utf-8') as workflowFile:
+    yaml.safe_load(workflowFile)
+print(f'Parsed {workflowPath} successfully.')
+PY
+fi
   ```
 
   A missing parser dependency is a tooling/setup warning that should be reported separately from workflow syntax or YAML content defects.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,8 +10,9 @@
 
 ## Review/testing note
 
+- When using the repo-managed environment for local workflow checks, run `bash .codex/install.sh` first so the expected tooling is available before running YAML parsing checks.
 - Local YAML validation warnings against `.github/workflows/release.yml` should be interpreted carefully.
-- Command used during review/testing:
+- Direct parser check used during review/testing:
 
   ```bash
   python3 - <<'PY'
@@ -19,4 +20,23 @@
   PY
   ```
 
-  Warning: `python3` is present, but this command currently fails because `import yaml` raises `ModuleNotFoundError: No module named 'yaml'` due to missing PyYAML. This is an environment/tooling dependency issue, not evidence that `.github/workflows/release.yml` is invalid YAML.
+  This check depends on PyYAML being installed. If `import yaml` raises `ModuleNotFoundError: No module named 'yaml'`, treat that as a missing parser dependency in the local environment, not as evidence that `.github/workflows/release.yml` is invalid YAML.
+- Guarded variant that separates dependency availability from YAML content validation:
+
+  ```bash
+  if ! python3 -c 'import yaml' >/dev/null 2>&1; then
+    echo "Warning: PyYAML is not installed; skipping YAML parsing check."
+  else
+    python3 - <<'PY'
+  import pathlib
+  import yaml
+
+  workflowPath = pathlib.Path('.github/workflows/release.yml')
+  with workflowPath.open('r', encoding='utf-8') as workflowFile:
+      yaml.safe_load(workflowFile)
+  print(f'Parsed {workflowPath} successfully.')
+  PY
+  fi
+  ```
+
+  A missing parser dependency is a tooling/setup warning that should be reported separately from workflow syntax or YAML content defects.

--- a/.github/instructions/workflows.instructions.md
+++ b/.github/instructions/workflows.instructions.md
@@ -10,3 +10,7 @@ When reviewing GitHub Actions workflows in this repository:
 - Prefer simple, explicit Bash over clever one-liners when reliability is at stake.
 - For new sanity or guard workflows, verify that initial branch pushes, pull_request events, and shallow clones are handled intentionally.
 - Suggest minimal fixes rather than broad workflow rewrites unless the current approach is likely to fail.
+- For local workflow-review parsing checks in the repo-managed environment, run `bash .codex/install.sh` first so the expected tooling is available.
+- If review notes include a Python YAML parse example such as `python3 - <<'PY'` with `import yaml`, call out that it depends on PyYAML being installed.
+- Prefer a guarded check like `python3 -c 'import yaml'` before YAML parsing when you want to separate dependency/setup issues from workflow content validation.
+- Be explicit in review comments that a missing YAML parser dependency is a local tooling problem, not a GitHub Actions workflow syntax defect.


### PR DESCRIPTION
### Motivation

- Make reviewer-facing workflow-review guidance explicit about using the repo-managed environment before running local YAML parsing checks. 
- Avoid false-positive workflow syntax defect reports when a local YAML parser dependency is missing. 
- Provide a simple guarded example for running Python-based YAML validation that separates dependency availability from YAML content validation.

### Description

- Updated `.github/CONTRIBUTING.md` to instruct contributors to run `bash .codex/install.sh` in the repo-managed environment before performing YAML parsing checks and to note that the inline `import yaml` example depends on PyYAML. 
- Added a guarded Python example that first checks `python3 -c 'import yaml'` and either warns about the missing PyYAML dependency or runs a `yaml.safe_load` parse of `.github/workflows/release.yml`. 
- Updated `.github/instructions/workflows.instructions.md` with the same guidance for reviewers and an explicit statement that a missing YAML parser dependency is a local tooling issue, not a GitHub Actions workflow syntax defect.

### Testing

- Ran `bash .codex/install.sh`, which provisioned the .NET SDK, installed PyYAML and `shellcheck`, and built the project successfully. 
- Ran `bash .codex/shellcheck.sh` to lint shell scripts and it completed without errors. 
- Ran the guarded Python YAML parse (`python3 -c 'import yaml'` guard + `yaml.safe_load` on `.github/workflows/release.yml`) and the workflow file parsed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf1a75dc98832da8a9263e204a2813)