### PR TITLE
docs: condense contributing review notes

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,35 +10,5 @@
 
 ## Review/testing note
 
-- When using the repo-managed environment for local workflow checks, run `bash .codex/install.sh` first so the expected tooling is available before running YAML parsing checks.
-- Bash syntax checks such as `bash -n` are not applicable to `.github/workflows/*.yml` files because GitHub Actions workflows are YAML, not shell scripts.
-- If shell validation is needed, run `bash .codex/shellcheck.sh` or `bash -n` only against actual `.sh` files or extracted shell snippets, not the workflow YAML itself.
-- Local YAML validation warnings against `.github/workflows/release.yml` should be interpreted carefully.
-- Direct parser check used during review/testing:
-
-  ```bash
-python3 - <<'PY'
-import yaml
-PY
-  ```
-
-  This check depends on PyYAML being installed. If `import yaml` raises `ModuleNotFoundError: No module named 'yaml'`, treat that as a missing parser dependency in the local environment, not as evidence that `.github/workflows/release.yml` is invalid YAML.
-- Guarded variant that separates dependency availability from YAML content validation:
-
-  ```bash
-if ! python3 -c 'import yaml' >/dev/null 2>&1; then
-  echo "Warning: PyYAML is not installed; skipping YAML parsing check."
-else
-  python3 - <<'PY'
-import pathlib
-import yaml
-
-workflowPath = pathlib.Path('.github/workflows/release.yml')
-with workflowPath.open('r', encoding='utf-8') as workflowFile:
-    yaml.safe_load(workflowFile)
-print(f'Parsed {workflowPath} successfully.')
-PY
-fi
-  ```
-
-  A missing parser dependency is a tooling/setup warning that should be reported separately from workflow syntax or YAML content defects.
+- Run `bash .codex/install.sh` before local workflow or tooling checks so the expected repo-managed environment is available.
+- Do not run `bash -n` against `.github/workflows/*.yml`; if shell validation is needed, use it only for actual `.sh` files or extracted shell snippets.


### PR DESCRIPTION
### Motivation
- Keep the release-process rules and branch/channel policy intact while removing reviewer-only troubleshooting details to keep contributor-facing docs concise and focused.

### Description
- Edit `.github/CONTRIBUTING.md` to preserve the `## Release process` section unchanged and replace the `## Review/testing note` with two short bullets: run `bash .codex/install.sh` before local checks and do not run `bash -n` on `.github/workflows/*.yml`, removing the inline Python/PyYAML examples and the `ModuleNotFoundError` troubleshooting guidance.

### Testing
- Ran `git diff --check`, which completed with no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfd168cfb8832d8e8b68488aa83b3d)