### PR TITLE
Simplify workflow review instructions

### DIFF
--- a/.github/instructions/workflows.instructions.md
+++ b/.github/instructions/workflows.instructions.md
@@ -10,9 +10,8 @@ When reviewing GitHub Actions workflows in this repository:
 - Prefer simple, explicit Bash over clever one-liners when reliability is at stake.
 - For new sanity or guard workflows, verify that initial branch pushes, pull_request events, and shallow clones are handled intentionally.
 - Suggest minimal fixes rather than broad workflow rewrites unless the current approach is likely to fail.
-- For local workflow-review parsing checks in the repo-managed environment, run `bash .codex/install.sh` first so the expected tooling is available.
+- Before local workflow or tooling checks in the repo-managed environment, run `bash .codex/install.sh` so the expected tooling is available.
 - Do not recommend `bash -n` against `.github/workflows/*.yml`; Bash syntax checking is not applicable to YAML workflow files.
 - If shell validation is still needed, limit `bash -n` or `shellcheck` to real `.sh` files or extracted shell snippets.
-- If review notes include a Python YAML parse example such as `python3 - <<'PY'` with `import yaml`, call out that it depends on PyYAML being installed.
-- Prefer a guarded check like `python3 -c 'import yaml'` before YAML parsing when you want to separate dependency/setup issues from workflow content validation.
-- Be explicit in review comments that a missing YAML parser dependency is a local tooling problem, not a GitHub Actions workflow syntax defect.
+- Use an appropriate YAML-aware validator for workflow files.
+- If a local YAML validator dependency is missing, report it as an environment or tooling limitation rather than a workflow syntax failure.


### PR DESCRIPTION
### Motivation

- Make the workflow-review guidance more concise and durable so reviewers focus on trigger correctness, brittle logic, and diagnosability rather than one-off remediation details.  
- Remove PyYAML-specific remediation notes and replace them with a short, general rule about YAML validation to reduce maintenance and false negatives in reviews.

### Description

- Update ` .github/instructions/workflows.instructions.md` to keep core reviewer priorities (trigger correctness, path filters, checkout depth/history assumptions, merge-base logic, matrix behavior, and diagnosability) and the rule to avoid style-only comments.  
- Reword the bootstrap guidance to advise running `bash .codex/install.sh` before local workflow or tooling checks.  
- Remove the PyYAML example and replace it with a concise rule to `Use an appropriate YAML-aware validator for workflow files` and to treat missing local validator dependencies as an environment/tooling limitation rather than a workflow syntax failure.

### Testing

- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfd7143508832d807b785a800913f3)