### PR TITLE
[codex] Add opt-in Emberglass Eclipse bridge

### DIFF
--- a/.codex/harness.settings.json
+++ b/.codex/harness.settings.json
@@ -82,7 +82,7 @@
         "generic and can't be used in il2cpp"
       ],
       "expectedPluginVersions": {
-        "Bloodcraft": "1.13.21"
+        "Bloodcraft": "1.13.22"
       },
       "expectedVraVersion": "1.1.12-r99041-b2",
       "buildEnvironment": {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: Existing GitHub Release tag to publish to Thunderstore, such as v1.13.21 or v1.13.21-pre.
+        description: Existing GitHub Release tag to publish to Thunderstore, such as v1.13.22 or v1.13.22-pre.
         required: true
         type: string
 

--- a/.gitignore
+++ b/.gitignore
@@ -298,3 +298,5 @@ secrets.json
 DevCommands.cs
 /.codex/persistent-data
 /.codex/runs
+/.codex/state
+/.codex/emberglass-bridge-proof.harness.settings.json

--- a/Bloodcraft.csproj
+++ b/Bloodcraft.csproj
@@ -3,7 +3,7 @@
 		<TargetFramework>net6.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AssemblyName>Bloodcraft</AssemblyName>
-		<Version>1.13.21</Version>
+		<Version>1.13.22</Version>
 		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
 		<LocalNugetPackageFeed>$(MSBuildProjectDirectory)/../LocalNugetPackageFeed</LocalNugetPackageFeed>
 		<RestoreSources>

--- a/Bloodcraft.csproj
+++ b/Bloodcraft.csproj
@@ -5,11 +5,16 @@
 		<AssemblyName>Bloodcraft</AssemblyName>
 		<Version>1.13.21</Version>
 		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-        <RestoreSources>
-			$(MSBuildProjectDirectory)\..\LocalNugetPackageFeed;
+		<LocalNugetPackageFeed>$(MSBuildProjectDirectory)/../LocalNugetPackageFeed</LocalNugetPackageFeed>
+		<RestoreSources>
 			$(RestoreSources);
 			https://api.nuget.org/v3/index.json;
 			https://nuget.bepinex.dev/v3/index.json;
+		</RestoreSources>
+		<UseLocalNugetPackageFeed Condition="'$(UseLocalNugetPackageFeed)' == ''">false</UseLocalNugetPackageFeed>
+		<RestoreSources Condition="'$(UseLocalNugetPackageFeed)' == 'true' and Exists('$(LocalNugetPackageFeed)')">
+			$(RestoreSources);
+			$(LocalNugetPackageFeed);
 		</RestoreSources>
 		<EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
 		<BepInExPluginGuid>io.zfolmt.Bloodcraft</BepInExPluginGuid>

--- a/BloodcraftEclipseBridge/Messages/EclipseRegistrationPacket.cs
+++ b/BloodcraftEclipseBridge/Messages/EclipseRegistrationPacket.cs
@@ -1,0 +1,15 @@
+namespace BloodcraftEclipseBridge.Messages;
+
+internal sealed class EclipseRegistrationPacket
+{
+    public string Message { get; set; } = string.Empty;
+
+    public EclipseRegistrationPacket()
+    {
+    }
+
+    public EclipseRegistrationPacket(string message)
+    {
+        Message = message;
+    }
+}

--- a/BloodcraftEclipseBridge/Messages/EclipseServerMessagePacket.cs
+++ b/BloodcraftEclipseBridge/Messages/EclipseServerMessagePacket.cs
@@ -1,0 +1,15 @@
+namespace BloodcraftEclipseBridge.Messages;
+
+internal sealed class EclipseServerMessagePacket
+{
+    public string Message { get; set; } = string.Empty;
+
+    public EclipseServerMessagePacket()
+    {
+    }
+
+    public EclipseServerMessagePacket(string message)
+    {
+        Message = message;
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+`1.13.22`
+- added opt-in Emberglass transport support for the Bloodcraft/Eclipse bridge while keeping the legacy ChatMessage bridge as the default fallback
+- added config and compatibility plumbing so Bloodcraft can start cleanly with or without Emberglass installed
+- hardened build/release workflow checks and release-tag selection for smoother prerelease validation
+
 `1.13.21`
 - added Primal Arsenal experimental weapon support for Shadow Matter weapons, including replacement ability loadouts and cooldown tuning
 - updated V Rising references for `1.1.12-r99041-b2` and hardened startup readiness around server-world availability

--- a/Core.cs
+++ b/Core.cs
@@ -163,7 +163,10 @@ internal static class Core
         _ = new LocalizationService();
 
         if (Eclipsed)
+        {
+            EmberglassEclipseBridge.Initialize();
             _ = new EclipseService();
+        }
 
         if (ConfigService.ExtraRecipes)
             Recipes.ModifyRecipes();

--- a/Interfaces/EclipseInterface.cs
+++ b/Interfaces/EclipseInterface.cs
@@ -63,7 +63,7 @@ internal class VersionHandler_1_3 : IVersionHandler<ProgressDataV1_3>
         string message = BuildConfigMessage();
         string messageWithMAC = $"{message};mac{ChatMessageSystemPatch.GenerateMAC(message)}";
 
-        LocalizationService.HandleServerReply(Core.EntityManager, user, messageWithMAC);
+        EmberglassEclipseBridge.SendToClientOrFallback(user, messageWithMAC, "configs");
     }
     public void SendClientProgress(Entity playerCharacter, ulong steamId)
     {
@@ -85,7 +85,7 @@ internal class VersionHandler_1_3 : IVersionHandler<ProgressDataV1_3>
         string message = BuildProgressMessage(data);
         string messageWithMAC = $"{message};mac{ChatMessageSystemPatch.GenerateMAC(message)}";
 
-        LocalizationService.HandleServerReply(Core.EntityManager, user, messageWithMAC);
+        EmberglassEclipseBridge.SendToClientOrFallback(user, messageWithMAC, "progress");
     }
     public string BuildConfigMessage()
     {

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -14,6 +14,7 @@ namespace Bloodcraft;
 [BepInPlugin(MyPluginInfo.PLUGIN_GUID, MyPluginInfo.PLUGIN_NAME, MyPluginInfo.PLUGIN_VERSION)]
 [BepInDependency("gg.deca.VampireCommandFramework")]
 [BepInDependency("markvaaz.ScarletRCON", BepInDependency.DependencyFlags.SoftDependency)]
+[BepInDependency("io.zfolmt.Emberglass", BepInDependency.DependencyFlags.SoftDependency)]
 internal class Plugin : BasePlugin
 {
     internal static Harmony Harmony { get; set; }

--- a/Services/ConfigService.cs
+++ b/Services/ConfigService.cs
@@ -16,6 +16,9 @@ internal static class ConfigService
     static readonly Lazy<bool> _eclipsed = new(() => GetConfigValue<bool>("Eclipsed"));
     public static bool Eclipsed => _eclipsed.Value;
 
+    static readonly Lazy<bool> _useEmberglassEclipseBridge = new(() => GetConfigValue<bool>("UseEmberglassEclipseBridge"));
+    public static bool UseEmberglassEclipseBridge => _useEmberglassEclipseBridge.Value;
+
     static readonly Lazy<bool> _elitePrimalRifts = new(() => GetConfigValue<bool>("ElitePrimalRifts"));
     public static bool ElitePrimalRifts => _elitePrimalRifts.Value;
 
@@ -527,6 +530,7 @@ internal static class ConfigService
         [
             new ConfigEntryDefinition("General", "LanguageLocalization", "English", "The language localization for prefabs displayed to users. English by default. Options: Brazilian, English, French, German, Hungarian, Italian, Japanese, Koreana, Latam, Polish, Russian, SimplifiedChinese, Spanish, TraditionalChinese, Thai, Turkish, Vietnamese"),
             new ConfigEntryDefinition("General", "Eclipsed", false, "Eclipse will be active if any features that sync with the client are enabled. Instead, this now controls the frequency; true for faster (0.1s), false for slower (2.5s)."),
+            new ConfigEntryDefinition("General", "UseEmberglassEclipseBridge", false, "Use Emberglass for the Bloodcraft/Eclipse bridge when Emberglass is installed. Falls back to the legacy chat bridge when disabled or unavailable."),
             new ConfigEntryDefinition("General", "ElitePrimalRifts", false, "Enable or disable elite primal rifts."),
             new ConfigEntryDefinition("General", "RiftFrequency", 0, "Number of primal rifts to start per day when they are enabled (24 max)."),
             new ConfigEntryDefinition("General", "NightmareMode", false, "Enable or disable PvE-only health, power, and movement tuning for enemy units."),

--- a/Services/EmberglassEclipseBridge.cs
+++ b/Services/EmberglassEclipseBridge.cs
@@ -18,6 +18,7 @@ internal static class EmberglassEclipseBridge
     static PropertyInfo _isReady;
     static EventInfo _onReady;
     static EventInfo _onClientReady;
+    static readonly HashSet<string> _loggedSendFailures = [];
 
     public static void Initialize()
     {
@@ -89,7 +90,7 @@ internal static class EmberglassEclipseBridge
         }
         catch (Exception ex)
         {
-            DisableForSession($"failed to send {messageKind} ({FormatExceptionForLog(ex)})");
+            LogSendFailure(messageKind, ex);
             return false;
         }
     }
@@ -153,6 +154,19 @@ internal static class EmberglassEclipseBridge
         _available = false;
         _disabledForSession = true;
         Core.Log.LogWarning($"[EclipseBridge:Emberglass] disabled for this session; using ChatMessage bridge ({reason})");
+    }
+
+    static void LogSendFailure(string messageKind, Exception exception)
+    {
+        string formattedException = FormatExceptionForLog(exception);
+        string failureKey = $"{messageKind}:{formattedException}";
+
+        if (!_loggedSendFailures.Add(failureKey))
+        {
+            return;
+        }
+
+        Core.Log.LogWarning($"[EclipseBridge:Emberglass] failed to send {messageKind}; using ChatMessage fallback for this message ({formattedException})");
     }
 
     static string FormatExceptionForLog(Exception exception)

--- a/Services/EmberglassEclipseBridge.cs
+++ b/Services/EmberglassEclipseBridge.cs
@@ -1,0 +1,170 @@
+using Bloodcraft.Patches;
+using BloodcraftEclipseBridge.Messages;
+using ProjectM.Network;
+using System.Reflection;
+
+namespace Bloodcraft.Services;
+
+internal static class EmberglassEclipseBridge
+{
+    const string EMBERGLASS_ASSEMBLY_NAME = "Emberglass";
+    const string VNETWORK_TYPE_NAME = "Emberglass.API.Shared.VNetwork";
+
+    static bool _initialized;
+    static bool _available;
+    static bool _disabledForSession;
+    static bool _unavailableLogged;
+    static MethodInfo _sendToClient;
+    static PropertyInfo _isReady;
+    static EventInfo _onReady;
+    static EventInfo _onClientReady;
+
+    public static void Initialize()
+    {
+        if (_initialized || !ConfigService.UseEmberglassEclipseBridge || _disabledForSession)
+        {
+            return;
+        }
+
+        _initialized = true;
+
+        if (!TryResolveVNetwork(out Type vNetworkType))
+        {
+            LogUnavailable("Emberglass is not loaded");
+            return;
+        }
+
+        try
+        {
+            MethodInfo registerServerbound = GetGenericMethod(vNetworkType, "RegisterServerbound", 1);
+            _sendToClient = GetGenericMethod(vNetworkType, "SendToClient", 2);
+            _isReady = vNetworkType.GetProperty("IsReady", BindingFlags.Public | BindingFlags.Static);
+            _onReady = vNetworkType.GetEvent("OnReady", BindingFlags.Public | BindingFlags.Static);
+            _onClientReady = vNetworkType.GetEvent("OnClientReady", BindingFlags.Public | BindingFlags.Static);
+
+            registerServerbound
+                .MakeGenericMethod(typeof(EclipseRegistrationPacket))
+                .Invoke(null, [new Action<User, EclipseRegistrationPacket>(OnRegistrationPacket)]);
+
+            _available = true;
+            Core.Log.LogInfo("[EclipseBridge:Emberglass] registered");
+        }
+        catch (Exception ex)
+        {
+            DisableForSession($"failed to register bridge ({ex.GetType().Name}: {ex.Message})");
+        }
+    }
+
+    public static void SendToClientOrFallback(User user, string message, string messageKind)
+    {
+        if (TrySendToClient(user, message, messageKind))
+        {
+            return;
+        }
+
+        LocalizationService.HandleServerReply(Core.EntityManager, user, message);
+    }
+
+    static bool TrySendToClient(User user, string message, string messageKind)
+    {
+        if (!ConfigService.UseEmberglassEclipseBridge || _disabledForSession)
+        {
+            return false;
+        }
+
+        Initialize();
+
+        if (!_available || !IsReady())
+        {
+            return false;
+        }
+
+        try
+        {
+            Core.Log.LogInfo($"[EclipseBridge:Emberglass] sending {messageKind}");
+
+            _sendToClient
+                .MakeGenericMethod(typeof(EclipseServerMessagePacket))
+                .Invoke(null, [user, new EclipseServerMessagePacket(message)]);
+
+            Core.Log.LogInfo($"[EclipseBridge:Emberglass] {messageKind} sent");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            DisableForSession($"failed to send {messageKind} ({FormatExceptionForLog(ex)})");
+            return false;
+        }
+    }
+
+    static void OnRegistrationPacket(User sender, EclipseRegistrationPacket packet)
+    {
+        if (string.IsNullOrWhiteSpace(packet.Message))
+        {
+            Core.Log.LogWarning("[EclipseBridge:Emberglass] empty registration packet received");
+            return;
+        }
+
+        if (!ChatMessageSystemPatch.CheckMAC(packet.Message, out string originalMessage))
+        {
+            Core.Log.LogWarning("[EclipseBridge:Emberglass] failed to verify registration MAC");
+            return;
+        }
+
+        Core.Log.LogInfo("[EclipseBridge:Emberglass] registration received");
+        EclipseService.HandleClientMessage(originalMessage);
+    }
+
+    static bool TryResolveVNetwork(out Type vNetworkType)
+    {
+        Assembly assembly = AppDomain.CurrentDomain
+            .GetAssemblies()
+            .FirstOrDefault(loadedAssembly => loadedAssembly.GetName().Name == EMBERGLASS_ASSEMBLY_NAME);
+
+        vNetworkType = assembly?.GetType(VNETWORK_TYPE_NAME, throwOnError: false);
+        return vNetworkType != null;
+    }
+
+    static MethodInfo GetGenericMethod(Type declaringType, string name, int parameterCount)
+    {
+        return declaringType
+            .GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Single(method =>
+                method.Name == name
+                && method.IsGenericMethodDefinition
+                && method.GetParameters().Length == parameterCount);
+    }
+
+    static bool IsReady()
+    {
+        return _isReady?.GetValue(null) is true;
+    }
+
+    static void LogUnavailable(string reason)
+    {
+        if (_unavailableLogged)
+        {
+            return;
+        }
+
+        _unavailableLogged = true;
+        Core.Log.LogInfo($"[EclipseBridge:Emberglass] unavailable; using ChatMessage bridge ({reason})");
+    }
+
+    static void DisableForSession(string reason)
+    {
+        _available = false;
+        _disabledForSession = true;
+        Core.Log.LogWarning($"[EclipseBridge:Emberglass] disabled for this session; using ChatMessage bridge ({reason})");
+    }
+
+    static string FormatExceptionForLog(Exception exception)
+    {
+        if (exception is TargetInvocationException { InnerException: not null } targetInvocationException)
+        {
+            return $"{exception.GetType().Name}: {exception.Message}; inner={FormatExceptionForLog(targetInvocationException.InnerException)}";
+        }
+
+        return $"{exception.GetType().Name}: {exception.Message}";
+    }
+}

--- a/Services/EmberglassEclipseBridge.cs
+++ b/Services/EmberglassEclipseBridge.cs
@@ -81,13 +81,10 @@ internal static class EmberglassEclipseBridge
 
         try
         {
-            Core.Log.LogInfo($"[EclipseBridge:Emberglass] sending {messageKind}");
-
             _sendToClient
                 .MakeGenericMethod(typeof(EclipseServerMessagePacket))
                 .Invoke(null, [user, new EclipseServerMessagePacket(message)]);
 
-            Core.Log.LogInfo($"[EclipseBridge:Emberglass] {messageKind} sent");
             return true;
         }
         catch (Exception ex)

--- a/packages.lock.json
+++ b/packages.lock.json
@@ -35,7 +35,7 @@
         "type": "Direct",
         "requested": "[1.1.12-r99041-b2, 1.1.12-r99041-b2]",
         "resolved": "1.1.12-r99041-b2",
-        "contentHash": "oGF6Yohq6sqEe0AnfL9FAcB7YJt0fdHEZhCusxfT7Doncs5fIuvXv08g6ZIqPtZ3PcqTz+g2RGQL5z6wIrutWA==",
+        "contentHash": "BPWzE4nVwvWkA8k3C58NkAOdlmZGW6VBcQhZwx8Y0FKY/aoPy61jcYCUUP+QC5GegAZYLnNLp2DHDLd45wlAXQ==",
         "dependencies": {
           "Il2CppInterop.Common": "[1.4.6-ci.426]",
           "Il2CppInterop.Runtime": "[1.4.6-ci.426]"

--- a/thunderstore.toml
+++ b/thunderstore.toml
@@ -12,7 +12,7 @@ v-rising = ["oakveil-update", "mods", "server"]
 [package]
 namespace = "zfolmt"
 name = "Bloodcraft"
-versionNumber = "1.13.21"
+versionNumber = "1.13.22"
 description = "Leveling, expertise, legacies, professions, familiars, classes, quests!"
 websiteUrl = "https://github.com/mfoltz/Bloodcraft"
 containsNsfwContent = false


### PR DESCRIPTION
## Summary

- Adds a Bloodcraft-side reflection-backed Emberglass bridge for the existing Bloodcraft/Eclipse signed payload flow.
- Keeps `General.UseEmberglassEclipseBridge` disabled by default and falls back to the legacy ChatMessage bridge when Emberglass is disabled, unavailable, not ready, or fails during setup/send.
- Adds consumer-owned bridge packet DTOs under `BloodcraftEclipseBridge.Messages` and preserves existing MAC verification before handing registration payloads to `EclipseService`.

## Base Branch

This PR is intentionally stacked on `codex/bloodcraft-ci-restore-source` so the diff stays focused on the bridge work. After the prerequisite PR lands, this PR can be retargeted to `main` if appropriate.

## Validation

- `git diff --check` for the bridge diff
- `bash .codex/install.sh` via Git Bash: build succeeded with the existing net6 EOL warning only

## Runtime Proof

The combined Bloodcraft/Eclipse enabled bridge proof was run with the committed Emberglass networking beta DLL and classified green.

- Emberglass proof commit: `bb5a122`
- Emberglass DLL SHA256: `FE4364C463DD8F42508C93441E66060361CC51E4C698883BB8D167CF6D772AB7`
- Consumer proof run id: `20260513-203324`
- Server markers: trust ready, handshake start received, key exchange offer sent, key exchange accepted, bridge registration received, configs sent, progress sent, no MAC/trust/truncation/startup failure markers.
- Client markers: pinned server key accepted, session key established, Eclipse bridge ready, registration sent, configs received, progress received, no MAC/trust/truncation/authentication failure markers.

## Notes

Eclipse client-side bridge changes live on a separate follow-up branch/PR. Emberglass public API/release work lives in the separate Emberglass PR.