### PR TITLE
[codex] Add Bloodcraft release hygiene helpers

### DIFF
--- a/.codex/scripts/bump-version.ps1
+++ b/.codex/scripts/bump-version.ps1
@@ -1,0 +1,105 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern('^\d+\.\d+\.\d+$')]
+    [string]$Version,
+
+    [switch]$AllowEmptyChangelog
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$ScriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RepoRoot = Split-Path -Parent (Split-Path -Parent $ScriptRoot)
+
+$ProjectPath = Join-Path $RepoRoot "Bloodcraft.csproj"
+$ThunderstorePath = Join-Path $RepoRoot "thunderstore.toml"
+$ChangelogPath = Join-Path $RepoRoot "CHANGELOG.md"
+
+function Set-TextPreservingUtf8Bom {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+        [Parameter(Mandatory = $true)]
+        [string]$Value
+    )
+
+    $Bytes = [System.IO.File]::ReadAllBytes($Path)
+    $HasUtf8Bom = $Bytes.Length -ge 3 -and $Bytes[0] -eq 0xEF -and $Bytes[1] -eq 0xBB -and $Bytes[2] -eq 0xBF
+    $Encoding = [System.Text.UTF8Encoding]::new($HasUtf8Bom)
+    [System.IO.File]::WriteAllText($Path, $Value, $Encoding)
+}
+
+function Update-FirstMatch {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+        [Parameter(Mandatory = $true)]
+        [string]$Pattern,
+        [Parameter(Mandatory = $true)]
+        [string]$Replacement,
+        [Parameter(Mandatory = $true)]
+        [string]$Description
+    )
+
+    $Text = Get-Content -Raw -Path $Path
+    $Regex = [regex]::new($Pattern, [System.Text.RegularExpressions.RegexOptions]::Multiline)
+    $Match = $Regex.Match($Text)
+    if (-not $Match.Success) {
+        throw "Unable to update $Description in $Path."
+    }
+
+    $Updated = $Text.Substring(0, $Match.Index) + $Regex.Replace($Match.Value, $Replacement, 1) + $Text.Substring($Match.Index + $Match.Length)
+    Set-TextPreservingUtf8Bom -Path $Path -Value $Updated
+}
+
+function Update-Changelog {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+        [Parameter(Mandatory = $true)]
+        [string]$Version,
+        [Parameter(Mandatory = $true)]
+        [bool]$AllowEmpty
+    )
+
+    $Text = Get-Content -Raw -Path $Path
+
+    $VersionHeadingPattern = '(?m)^`' + [regex]::Escape($Version) + '`$'
+    if ($Text -match $VersionHeadingPattern) {
+        throw "CHANGELOG.md already contains a $Version entry."
+    }
+
+    $UnreleasedPattern = '(?ms)^## Unreleased\s*(?<body>.*?)(?=^`[^`]+`\s*$|^## |\z)'
+    $Match = [regex]::Match($Text, $UnreleasedPattern)
+    if (-not $Match.Success) {
+        throw "CHANGELOG.md must contain an '## Unreleased' section before bumping."
+    }
+
+    $Body = $Match.Groups["body"].Value.Trim()
+    if (-not $AllowEmpty -and [string]::IsNullOrWhiteSpace($Body)) {
+        throw "CHANGELOG.md '## Unreleased' is empty. Use -AllowEmptyChangelog to bump anyway."
+    }
+
+    $ReleasedBody = if ([string]::IsNullOrWhiteSpace($Body)) { "- No user-facing changes recorded." } else { $Body }
+    $VersionHeading = '`' + $Version + '`'
+    $Replacement = "## Unreleased`r`n`r`n$VersionHeading`r`n$ReleasedBody`r`n`r`n"
+    $Updated = $Text.Substring(0, $Match.Index) + $Replacement + $Text.Substring($Match.Index + $Match.Length)
+    Set-TextPreservingUtf8Bom -Path $Path -Value $Updated
+}
+
+Update-FirstMatch `
+    -Path $ProjectPath `
+    -Pattern '<Version>[^<]+</Version>' `
+    -Replacement "<Version>$Version</Version>" `
+    -Description "project version"
+
+Update-FirstMatch `
+    -Path $ThunderstorePath `
+    -Pattern '^versionNumber = "[^"]+"' `
+    -Replacement "versionNumber = `"$Version`"" `
+    -Description "Thunderstore version"
+
+Update-Changelog -Path $ChangelogPath -Version $Version -AllowEmpty:$AllowEmptyChangelog.IsPresent
+
+Write-Host "Updated Bloodcraft version metadata to $Version."

--- a/.codex/scripts/release-hygiene.tests.ps1
+++ b/.codex/scripts/release-hygiene.tests.ps1
@@ -151,8 +151,47 @@ function Test-ReleaseNudgeBlocksWithoutWarnOnly {
     }
 }
 
+function Test-ReleaseNudgeUsesPushBeforeShaWhenBaseRefIsEmpty {
+    $FixtureRoot = New-FixtureRepo
+    try {
+        $BeforeSha = (Invoke-Git -WorkingDirectory $FixtureRoot -Arguments @("rev-parse", "HEAD")).Trim()
+        Set-Content -Path (Join-Path $FixtureRoot "Systems/QuestTargetSystem.cs") -Value "class QuestTargetSystem { void ChangedOnPush() {} }" -NoNewline
+        Invoke-Git -WorkingDirectory $FixtureRoot -Arguments @("add", "Systems/QuestTargetSystem.cs") | Out-Null
+        Invoke-Git -WorkingDirectory $FixtureRoot -Arguments @("commit", "-m", "change system") | Out-Null
+        $HeadSha = (Invoke-Git -WorkingDirectory $FixtureRoot -Arguments @("rev-parse", "HEAD")).Trim()
+        Invoke-Git -WorkingDirectory $FixtureRoot -Arguments @("update-ref", "refs/remotes/origin/main", $HeadSha) | Out-Null
+
+        $EventPath = Join-Path $FixtureRoot "push-event.json"
+        Set-Content -Path $EventPath -Value (@{
+            before = $BeforeSha
+            after = $HeadSha
+        } | ConvertTo-Json -Compress) -NoNewline
+
+        $PreviousEventName = $env:GITHUB_EVENT_NAME
+        $PreviousEventPath = $env:GITHUB_EVENT_PATH
+        try {
+            $env:GITHUB_EVENT_NAME = "push"
+            $env:GITHUB_EVENT_PATH = $EventPath
+            $Output = & pwsh -NoProfile -File (Join-Path $FixtureRoot ".codex/scripts/release-nudge.ps1") -WarnOnly 2>&1 | Out-String
+            if ($LASTEXITCODE -ne 0) {
+                throw "release-nudge.ps1 push fallback exited with $LASTEXITCODE"
+            }
+        }
+        finally {
+            $env:GITHUB_EVENT_NAME = $PreviousEventName
+            $env:GITHUB_EVENT_PATH = $PreviousEventPath
+        }
+
+        Assert-Match -Text $Output -Pattern 'Bloodcraft CHANGELOG\.md has Unreleased notes' -Message "Release nudge did not use the push before SHA as its diff base."
+    }
+    finally {
+        Remove-Item -LiteralPath $FixtureRoot -Recurse -Force
+    }
+}
+
 Test-BumpVersionUpdatesBloodcraftMetadata
 Test-ReleaseNudgeWarnOnlyFlagsUnreleasedNotes
 Test-ReleaseNudgeBlocksWithoutWarnOnly
+Test-ReleaseNudgeUsesPushBeforeShaWhenBaseRefIsEmpty
 
 Write-Host "release-hygiene tests passed"

--- a/.codex/scripts/release-hygiene.tests.ps1
+++ b/.codex/scripts/release-hygiene.tests.ps1
@@ -1,0 +1,158 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$ScriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RepoRoot = Split-Path -Parent (Split-Path -Parent $ScriptRoot)
+$ReleaseNudgePath = Join-Path $ScriptRoot "release-nudge.ps1"
+$BumpVersionPath = Join-Path $ScriptRoot "bump-version.ps1"
+
+function Assert-Equal {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Actual,
+        [Parameter(Mandatory = $true)]
+        [string]$Expected,
+        [Parameter(Mandatory = $true)]
+        [string]$Message
+    )
+
+    if ($Actual -ne $Expected) {
+        throw "$Message Expected '$Expected', got '$Actual'."
+    }
+}
+
+function Assert-Match {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Text,
+        [Parameter(Mandatory = $true)]
+        [string]$Pattern,
+        [Parameter(Mandatory = $true)]
+        [string]$Message
+    )
+
+    if ($Text -notmatch $Pattern) {
+        throw "$Message Pattern '$Pattern' was not found."
+    }
+}
+
+function Invoke-Git {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments,
+        [Parameter(Mandatory = $true)]
+        [string]$WorkingDirectory
+    )
+
+    Push-Location $WorkingDirectory
+    try {
+        & git -c core.autocrlf=false @Arguments | Out-String
+        if ($LASTEXITCODE -ne 0) {
+            throw "git $($Arguments -join ' ') failed in $WorkingDirectory"
+        }
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+function New-FixtureRepo {
+    $FixtureRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("bloodcraft-release-hygiene-" + [guid]::NewGuid().ToString("N"))
+    New-Item -ItemType Directory -Path $FixtureRoot | Out-Null
+    New-Item -ItemType Directory -Path (Join-Path $FixtureRoot ".codex/scripts") -Force | Out-Null
+    New-Item -ItemType Directory -Path (Join-Path $FixtureRoot "Systems") -Force | Out-Null
+
+    Copy-Item -Path $ReleaseNudgePath -Destination (Join-Path $FixtureRoot ".codex/scripts/release-nudge.ps1")
+    Copy-Item -Path $BumpVersionPath -Destination (Join-Path $FixtureRoot ".codex/scripts/bump-version.ps1")
+
+    Set-Content -Path (Join-Path $FixtureRoot "Bloodcraft.csproj") -Value @"
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Version>1.2.3</Version>
+  </PropertyGroup>
+</Project>
+"@ -NoNewline
+
+    Set-Content -Path (Join-Path $FixtureRoot "thunderstore.toml") -Value @"
+[package]
+name = "Bloodcraft"
+versionNumber = "1.2.3"
+"@ -NoNewline
+
+    Set-Content -Path (Join-Path $FixtureRoot "CHANGELOG.md") -Value @"
+## Unreleased
+
+- planned fix
+
+`1.2.3`
+- previous release
+"@ -NoNewline
+
+    Set-Content -Path (Join-Path $FixtureRoot "Systems/QuestTargetSystem.cs") -Value "class QuestTargetSystem {}" -NoNewline
+
+    Invoke-Git -WorkingDirectory $FixtureRoot -Arguments @("init", "-b", "main") | Out-Null
+    Invoke-Git -WorkingDirectory $FixtureRoot -Arguments @("config", "user.email", "codex@example.invalid") | Out-Null
+    Invoke-Git -WorkingDirectory $FixtureRoot -Arguments @("config", "user.name", "Codex") | Out-Null
+    Invoke-Git -WorkingDirectory $FixtureRoot -Arguments @("add", ".") | Out-Null
+    Invoke-Git -WorkingDirectory $FixtureRoot -Arguments @("commit", "-m", "baseline") | Out-Null
+
+    return $FixtureRoot
+}
+
+function Test-BumpVersionUpdatesBloodcraftMetadata {
+    $FixtureRoot = New-FixtureRepo
+    try {
+        & pwsh -NoProfile -File (Join-Path $FixtureRoot ".codex/scripts/bump-version.ps1") -Version "1.2.4"
+        if ($LASTEXITCODE -ne 0) {
+            throw "bump-version.ps1 exited with $LASTEXITCODE"
+        }
+
+        $ProjectText = Get-Content -Raw -Path (Join-Path $FixtureRoot "Bloodcraft.csproj")
+        $ThunderstoreText = Get-Content -Raw -Path (Join-Path $FixtureRoot "thunderstore.toml")
+        $ChangelogText = Get-Content -Raw -Path (Join-Path $FixtureRoot "CHANGELOG.md")
+
+        Assert-Match -Text $ProjectText -Pattern '<Version>1\.2\.4</Version>' -Message "Project version was not updated."
+        Assert-Match -Text $ThunderstoreText -Pattern 'versionNumber = "1\.2\.4"' -Message "Thunderstore version was not updated."
+        Assert-Match -Text $ChangelogText -Pattern '(?m)^## Unreleased\s+`1\.2\.4`\s+- planned fix' -Message "Changelog release entry was not created."
+    }
+    finally {
+        Remove-Item -LiteralPath $FixtureRoot -Recurse -Force
+    }
+}
+
+function Test-ReleaseNudgeWarnOnlyFlagsUnreleasedNotes {
+    $FixtureRoot = New-FixtureRepo
+    try {
+        Set-Content -Path (Join-Path $FixtureRoot "Systems/QuestTargetSystem.cs") -Value "class QuestTargetSystem { void Changed() {} }" -NoNewline
+
+        $Output = & pwsh -NoProfile -File (Join-Path $FixtureRoot ".codex/scripts/release-nudge.ps1") -BaseRef "main" -WarnOnly 2>&1 | Out-String
+        if ($LASTEXITCODE -ne 0) {
+            throw "release-nudge.ps1 -WarnOnly exited with $LASTEXITCODE"
+        }
+
+        Assert-Match -Text $Output -Pattern 'CHANGELOG\.md has Unreleased notes' -Message "Release nudge did not flag unreleased notes."
+    }
+    finally {
+        Remove-Item -LiteralPath $FixtureRoot -Recurse -Force
+    }
+}
+
+function Test-ReleaseNudgeBlocksWithoutWarnOnly {
+    $FixtureRoot = New-FixtureRepo
+    try {
+        Set-Content -Path (Join-Path $FixtureRoot "Systems/QuestTargetSystem.cs") -Value "class QuestTargetSystem { void Changed() {} }" -NoNewline
+
+        $Output = & pwsh -NoProfile -File (Join-Path $FixtureRoot ".codex/scripts/release-nudge.ps1") -BaseRef "main" 2>&1 | Out-String
+        Assert-Equal -Actual "$LASTEXITCODE" -Expected "1" -Message "Release nudge should block when nudges exist."
+        Assert-Match -Text $Output -Pattern 'Bloodcraft' -Message "Release nudge output should name Bloodcraft."
+    }
+    finally {
+        Remove-Item -LiteralPath $FixtureRoot -Recurse -Force
+    }
+}
+
+Test-BumpVersionUpdatesBloodcraftMetadata
+Test-ReleaseNudgeWarnOnlyFlagsUnreleasedNotes
+Test-ReleaseNudgeBlocksWithoutWarnOnly
+
+Write-Host "release-hygiene tests passed"

--- a/.codex/scripts/release-nudge.ps1
+++ b/.codex/scripts/release-nudge.ps1
@@ -70,8 +70,40 @@ function Test-MeaningfulPath {
         -or $NormalizedPath -match '^[^/]+\.(cs|csproj)$'
 }
 
+function Get-PushBeforeSha {
+    if ($env:GITHUB_EVENT_NAME -ne "push") {
+        return $null
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_EVENT_BEFORE)) {
+        return $env:GITHUB_EVENT_BEFORE
+    }
+
+    if ([string]::IsNullOrWhiteSpace($env:GITHUB_EVENT_PATH) -or -not (Test-Path -LiteralPath $env:GITHUB_EVENT_PATH)) {
+        return $null
+    }
+
+    $Event = Get-Content -Raw -Path $env:GITHUB_EVENT_PATH | ConvertFrom-Json
+    return $Event.before
+}
+
+function Test-UsableCommitRef {
+    param(
+        [AllowNull()]
+        [string]$Ref
+    )
+
+    return -not [string]::IsNullOrWhiteSpace($Ref) `
+        -and $Ref -match '^[0-9a-fA-F]{40}$' `
+        -and $Ref -notmatch '^0{40}$'
+}
+
 if ([string]::IsNullOrWhiteSpace($BaseRef)) {
-    $BaseRef = if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_BASE_REF)) {
+    $PushBeforeSha = Get-PushBeforeSha
+    $BaseRef = if (Test-UsableCommitRef $PushBeforeSha) {
+        $PushBeforeSha
+    }
+    elseif (-not [string]::IsNullOrWhiteSpace($env:GITHUB_BASE_REF)) {
         "origin/$($env:GITHUB_BASE_REF)"
     }
     else {

--- a/.codex/scripts/release-nudge.ps1
+++ b/.codex/scripts/release-nudge.ps1
@@ -1,0 +1,135 @@
+param(
+    [string]$BaseRef,
+
+    [int]$LineThreshold = 120,
+
+    [switch]$WarnOnly
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$ScriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RepoRoot = Split-Path -Parent (Split-Path -Parent $ScriptRoot)
+$ChangelogPath = Join-Path $RepoRoot "CHANGELOG.md"
+
+function Invoke-Git {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments
+    )
+
+    Push-Location $RepoRoot
+    try {
+        & git -c core.autocrlf=false @Arguments
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+function Write-Nudge {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Message
+    )
+
+    if ($env:GITHUB_ACTIONS -eq "true") {
+        Write-Host "::warning title=Release hygiene nudge::$Message"
+    }
+    else {
+        Write-Warning $Message
+    }
+
+    $script:NudgeCount++
+}
+
+function Get-UnreleasedBody {
+    $Text = Get-Content -Raw -Path $ChangelogPath
+    $Match = [regex]::Match($Text, '(?ms)^## Unreleased\s*(?<body>.*?)(?=^`[^`]+`\s*$|^## |\z)')
+
+    if (-not $Match.Success) {
+        return $null
+    }
+
+    return $Match.Groups["body"].Value.Trim()
+}
+
+function Test-MeaningfulPath {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    $NormalizedPath = $Path -replace '\\', '/'
+
+    return $NormalizedPath -match '^(BloodcraftEclipseBridge|Commands|Factory|Interfaces|Patches|Services|Systems|Utilities)/' `
+        -or $NormalizedPath -match '^Resources/(Localization/)?[^/]+\.(cs|json)$' `
+        -or $NormalizedPath -match '^\.codex/scripts/' `
+        -or $NormalizedPath -match '^\.github/workflows/' `
+        -or $NormalizedPath -match '^[^/]+\.(cs|csproj)$'
+}
+
+if ([string]::IsNullOrWhiteSpace($BaseRef)) {
+    $BaseRef = if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_BASE_REF)) {
+        "origin/$($env:GITHUB_BASE_REF)"
+    }
+    else {
+        "origin/main"
+    }
+}
+
+$MergeBase = Invoke-Git -Arguments @("merge-base", "HEAD", $BaseRef) 2>$null
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($MergeBase)) {
+    Write-Host "release-nudge: unable to resolve merge-base for '$BaseRef'; skipping release hygiene gate."
+    exit 0
+}
+
+$ChangedFiles = @(Invoke-Git -Arguments @("diff", "--name-only", $MergeBase) 2>$null)
+$MeaningfulFiles = @($ChangedFiles | Where-Object { Test-MeaningfulPath $_ })
+
+if ($MeaningfulFiles.Count -eq 0) {
+    Write-Host "release-nudge: no meaningful source, script, or workflow changes detected."
+    exit 0
+}
+
+$NumstatArguments = @("diff", "--numstat", $MergeBase, "--") + $MeaningfulFiles
+$Numstat = @(Invoke-Git -Arguments $NumstatArguments 2>$null)
+$ChangedLines = 0
+foreach ($Line in $Numstat) {
+    $Parts = $Line -split "`t"
+    if ($Parts.Length -lt 2) {
+        continue
+    }
+
+    $AddedLines = 0
+    if ([int]::TryParse($Parts[0], [ref]$AddedLines)) {
+        $ChangedLines += $AddedLines
+    }
+
+    $DeletedLines = 0
+    if ([int]::TryParse($Parts[1], [ref]$DeletedLines)) {
+        $ChangedLines += $DeletedLines
+    }
+}
+
+$InterfaceTouched = @($MeaningfulFiles | Where-Object { ($_ -replace '\\', '/') -match '^(BloodcraftEclipseBridge|Commands|Interfaces|Services|Systems)/' }).Count -gt 0
+$ChangelogChanged = @($ChangedFiles | Where-Object { $_ -eq "CHANGELOG.md" }).Count -gt 0
+$UnreleasedBody = Get-UnreleasedBody
+$HasUnreleasedNotes = -not [string]::IsNullOrWhiteSpace($UnreleasedBody)
+$script:NudgeCount = 0
+
+if (($InterfaceTouched -or $ChangedLines -ge $LineThreshold) -and -not $ChangelogChanged -and -not $HasUnreleasedNotes) {
+    Write-Nudge "Meaningful Bloodcraft changes detected ($ChangedLines changed lines across $($MeaningfulFiles.Count) files). Consider adding CHANGELOG.md notes before release."
+}
+
+if ($HasUnreleasedNotes) {
+    Write-Nudge "Bloodcraft CHANGELOG.md has Unreleased notes. Before a release-bound merge, consider running .codex/scripts/bump-version.ps1 so version metadata and changelog stay aligned."
+}
+
+if ($script:NudgeCount -eq 0) {
+    Write-Host "release-nudge: no changelog or version-bump nudge needed."
+}
+elseif (-not $WarnOnly.IsPresent) {
+    exit 1
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,7 +144,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
           fetch-tags: false
           persist-credentials: false
 
@@ -156,6 +156,10 @@ jobs:
       - name: Validate canonical version metadata
         shell: bash
         run: ./.codex/scripts/version-metadata.sh
+
+      - name: Run release hygiene gate
+        shell: pwsh
+        run: ./.codex/scripts/release-nudge.ps1
 
       - name: Verify canonical version files remain unchanged
         shell: bash

--- a/Bloodcraft.csproj
+++ b/Bloodcraft.csproj
@@ -3,7 +3,7 @@
 		<TargetFramework>net6.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AssemblyName>Bloodcraft</AssemblyName>
-		<Version>1.13.22</Version>
+		<Version>1.13.23</Version>
 		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
 		<LocalNugetPackageFeed>$(MSBuildProjectDirectory)/../LocalNugetPackageFeed</LocalNugetPackageFeed>
 		<RestoreSources>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+`1.13.23`
+- added release hygiene helper scripts for changelog/version bump review and metadata updates
+- added CI coverage for the release hygiene nudge before build verification
+
 `1.13.22`
 - added opt-in Emberglass transport support for the Bloodcraft/Eclipse bridge while keeping the legacy ChatMessage bridge as the default fallback
 - added config and compatibility plumbing so Bloodcraft can start cleanly with or without Emberglass installed

--- a/thunderstore.toml
+++ b/thunderstore.toml
@@ -12,7 +12,7 @@ v-rising = ["oakveil-update", "mods", "server"]
 [package]
 namespace = "zfolmt"
 name = "Bloodcraft"
-versionNumber = "1.13.22"
+versionNumber = "1.13.23"
 description = "Leveling, expertise, legacies, professions, familiars, classes, quests!"
 websiteUrl = "https://github.com/mfoltz/Bloodcraft"
 containsNsfwContent = false


### PR DESCRIPTION
## Summary
- add Bloodcraft release-nudge and bump-version helpers
- add fixture-based helper regression coverage
- bump Bloodcraft metadata and changelog to 1.13.23
- run the release hygiene gate during build verification

## Validation
- pwsh .codex\\scripts\\release-hygiene.tests.ps1
- C:\\Program Files\\Git\\bin\\bash.exe .codex/scripts/version-metadata.sh
- git diff --check
- pwsh -NoProfile -File .codex\\scripts\\release-nudge.ps1 -WarnOnly