### PR TITLE
Add staged Thunderstore release handoff

### DIFF
--- a/.codex/scripts/prerelease-notes.sh
+++ b/.codex/scripts/prerelease-notes.sh
@@ -143,21 +143,18 @@ cat > "$OUTPUT_PATH" <<EOF
 > [!NOTE]
 > This GitHub pre-release is the source artifact for the matching Thunderstore publish. Thunderstore receives package version \`${VERSION}\` from tag \`${TAG}\`.
 
-<details open>
-<summary>Good to know before Thunderstore</summary>
+### 📦 Thunderstore handoff
 
-| Item | Detail |
+| Signal | Detail |
 | --- | --- |
-| Changelog turnover | \`## Unreleased\` is empty; notes below come from \`${VERSION}\`. |
-| Source branch | \`${BRANCH}\` |
-| Source commit | \`${short_commit}\` |
-| Workflow run | ${run_detail} |
-| GitHub tag | \`${TAG}\` |
-| Thunderstore version | \`${VERSION}\` |
+| 📝 Changelog | \`## Unreleased\` is empty; notes below come from \`${VERSION}\`. |
+| 🌿 Branch | \`${BRANCH}\` |
+| 🔖 Commit | \`${short_commit}\` |
+| ▶️ Run | ${run_detail} |
+| 🏷️ Tag | \`${TAG}\` |
+| 📦 Package | \`${VERSION}\` |
 
-</details>
-
-### Changes
+### ✨ Changes
 
 ${version_body}
 EOF

--- a/.codex/scripts/prerelease-notes.sh
+++ b/.codex/scripts/prerelease-notes.sh
@@ -90,6 +90,10 @@ if [ ! -f "$CHANGELOG_PATH" ]; then
     fail "Unable to locate changelog at '$CHANGELOG_PATH'."
 fi
 
+if ! grep -Eq '^##[[:space:]]*Unreleased[[:space:]]*$' "$CHANGELOG_PATH"; then
+    fail "CHANGELOG.md must contain a ## Unreleased section before creating or publishing a prerelease."
+fi
+
 unreleased_body=$(
     awk '
         /^##[[:space:]]*Unreleased[[:space:]]*$/ { in_unreleased = 1; next }

--- a/.codex/scripts/prerelease-notes.sh
+++ b/.codex/scripts/prerelease-notes.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$(dirname "$SCRIPT_DIR")")"
+
+CHANGELOG_PATH="$REPO_ROOT/CHANGELOG.md"
+VERSION=""
+TAG=""
+BRANCH=""
+COMMIT=""
+RUN_ID=""
+OUTPUT_PATH=""
+CHECK_ONLY="false"
+
+fail() {
+    echo "Error: $1" >&2
+    exit 1
+}
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: prerelease-notes.sh --version X.Y.Z [options]
+
+Options:
+  --changelog PATH   CHANGELOG.md path to read.
+  --tag TAG          GitHub Release tag. Defaults to vX.Y.Z-pre.
+  --branch NAME      Source branch name for the notes card.
+  --commit SHA       Source commit SHA for the notes card.
+  --run-id ID        GitHub Actions run id for the notes card.
+  --output PATH      Markdown file to write.
+  --check-only       Validate changelog turnover without writing notes.
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --changelog)
+            CHANGELOG_PATH="${2:-}"
+            shift 2
+            ;;
+        --version)
+            VERSION="${2:-}"
+            shift 2
+            ;;
+        --tag)
+            TAG="${2:-}"
+            shift 2
+            ;;
+        --branch)
+            BRANCH="${2:-}"
+            shift 2
+            ;;
+        --commit)
+            COMMIT="${2:-}"
+            shift 2
+            ;;
+        --run-id)
+            RUN_ID="${2:-}"
+            shift 2
+            ;;
+        --output)
+            OUTPUT_PATH="${2:-}"
+            shift 2
+            ;;
+        --check-only)
+            CHECK_ONLY="true"
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            usage
+            fail "Unknown argument '$1'."
+            ;;
+    esac
+done
+
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    fail "--version must use canonical X.Y.Z format."
+fi
+
+if [ -z "$TAG" ]; then
+    TAG="v${VERSION}-pre"
+fi
+
+if [ ! -f "$CHANGELOG_PATH" ]; then
+    fail "Unable to locate changelog at '$CHANGELOG_PATH'."
+fi
+
+unreleased_body=$(
+    awk '
+        /^##[[:space:]]*Unreleased[[:space:]]*$/ { in_unreleased = 1; next }
+        in_unreleased && (/^`[^`]+`[[:space:]]*$/ || /^## /) { exit }
+        in_unreleased { print }
+    ' "$CHANGELOG_PATH"
+)
+
+if printf '%s' "$unreleased_body" | grep -q '[^[:space:]]'; then
+    fail "CHANGELOG.md ## Unreleased must be empty before creating or publishing a prerelease."
+fi
+
+version_body=$(
+    awk -v version="$VERSION" '
+        $0 == "`" version "`" { in_version = 1; next }
+        in_version && (/^`[^`]+`[[:space:]]*$/ || /^## /) { exit }
+        in_version { print }
+    ' "$CHANGELOG_PATH"
+)
+
+if ! printf '%s' "$version_body" | grep -q '[^[:space:]]'; then
+    fail "CHANGELOG.md does not contain notes for '$VERSION'."
+fi
+
+if [ "$CHECK_ONLY" = "true" ]; then
+    echo "prerelease-notes: changelog turnover validated for $VERSION."
+    exit 0
+fi
+
+if [ -z "$OUTPUT_PATH" ]; then
+    fail "--output is required unless --check-only is used."
+fi
+
+BRANCH="${BRANCH:-unknown}"
+COMMIT="${COMMIT:-unknown}"
+RUN_ID="${RUN_ID:-unknown}"
+short_commit="$COMMIT"
+if [ ${#short_commit} -gt 12 ]; then
+    short_commit="${short_commit:0:12}"
+fi
+
+run_detail="\`$RUN_ID\`"
+if [ -n "${GITHUB_REPOSITORY:-}" ] && [ "$RUN_ID" != "unknown" ]; then
+    run_detail="[${RUN_ID}](https://github.com/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID})"
+fi
+
+mkdir -p "$(dirname "$OUTPUT_PATH")"
+cat > "$OUTPUT_PATH" <<EOF
+## Bloodcraft ${VERSION} pre-release
+
+> [!NOTE]
+> This GitHub pre-release is the source artifact for the matching Thunderstore publish. Thunderstore receives package version \`${VERSION}\` from tag \`${TAG}\`.
+
+<details open>
+<summary>Good to know before Thunderstore</summary>
+
+| Item | Detail |
+| --- | --- |
+| Changelog turnover | \`## Unreleased\` is empty; notes below come from \`${VERSION}\`. |
+| Source branch | \`${BRANCH}\` |
+| Source commit | \`${short_commit}\` |
+| Workflow run | ${run_detail} |
+| GitHub tag | \`${TAG}\` |
+| Thunderstore version | \`${VERSION}\` |
+
+</details>
+
+### Changes
+
+${version_body}
+EOF
+
+echo "prerelease-notes: wrote $OUTPUT_PATH"

--- a/.codex/scripts/prerelease-notes.tests.ps1
+++ b/.codex/scripts/prerelease-notes.tests.ps1
@@ -116,6 +116,30 @@ function Test-PrereleaseNotesRejectsUnreleasedContent {
     }
 }
 
+function Test-PrereleaseNotesRejectsMissingUnreleasedHeader {
+    $FixtureRoot = New-Fixture
+    try {
+        $ChangelogPath = Join-Path $FixtureRoot "CHANGELOG.md"
+        Set-Content -Path $ChangelogPath -Value @"
+`1.2.3`
+- added staged Thunderstore packaging
+"@
+
+        $Output = Invoke-PrereleaseNotes -Arguments @(
+            "--changelog", $ChangelogPath,
+            "--version", "1.2.3",
+            "--check-only")
+        if ($LASTEXITCODE -eq 0) {
+            throw "prerelease-notes.sh unexpectedly accepted a missing Unreleased header."
+        }
+
+        Assert-Match -Text $Output -Pattern 'must contain a ## Unreleased section' -Message "Missing Unreleased rejection message was not specific."
+    }
+    finally {
+        Remove-Item -Recurse -Force -LiteralPath $FixtureRoot
+    }
+}
+
 function Test-PrereleaseNotesRejectsMissingVersionEntry {
     $FixtureRoot = New-Fixture
     try {
@@ -195,6 +219,7 @@ function Test-ReleaseWorkflowStagesAndChecksReleaseChangelog {
 
 Test-PrereleaseNotesIncludesChangelogAndDetailsCard
 Test-PrereleaseNotesRejectsUnreleasedContent
+Test-PrereleaseNotesRejectsMissingUnreleasedHeader
 Test-PrereleaseNotesRejectsMissingVersionEntry
 Test-ReleaseWorkflowStagesAndChecksReleaseChangelog
 

--- a/.codex/scripts/prerelease-notes.tests.ps1
+++ b/.codex/scripts/prerelease-notes.tests.ps1
@@ -146,13 +146,19 @@ function Test-ReleaseWorkflowStagesAndChecksReleaseChangelog {
     $WorkflowPath = Join-Path (Split-Path -Parent (Split-Path -Parent $ScriptRoot)) ".github/workflows/release.yml"
     $WorkflowText = Get-Content -Raw -Path $WorkflowPath
 
+    $PreserveMarker = "      - name: Preserve release helper scripts"
     $CheckoutMarker = "      - name: Checkout selected release tag"
     $StageMarker = "      - name: Stage selected release contents"
     $ChangelogMarker = "      - name: Validate staged release changelog"
 
+    $PreserveIndex = $WorkflowText.IndexOf($PreserveMarker, [StringComparison]::Ordinal)
     $CheckoutIndex = $WorkflowText.IndexOf($CheckoutMarker, [StringComparison]::Ordinal)
     $StageIndex = $WorkflowText.IndexOf($StageMarker, [StringComparison]::Ordinal)
     $ChangelogIndex = $WorkflowText.IndexOf($ChangelogMarker, [StringComparison]::Ordinal)
+
+    if ($PreserveIndex -lt 0) {
+        throw "release.yml is missing the Preserve release helper scripts step."
+    }
 
     if ($CheckoutIndex -lt 0) {
         throw "release.yml is missing selected tag checkout."
@@ -166,6 +172,10 @@ function Test-ReleaseWorkflowStagesAndChecksReleaseChangelog {
         throw "release.yml is missing staged release changelog validation."
     }
 
+    if ($CheckoutIndex -lt $PreserveIndex) {
+        throw "Release helper scripts must be preserved before checking out the selected tag."
+    }
+
     if ($StageIndex -lt $CheckoutIndex) {
         throw "Release contents must be staged after checking out the selected tag."
     }
@@ -176,6 +186,10 @@ function Test-ReleaseWorkflowStagesAndChecksReleaseChangelog {
 
     if ($WorkflowText -notmatch 'cd \./dist/thunderstore-publish') {
         throw "Thunderstore publish should run from the staged publish root."
+    }
+
+    if ($WorkflowText -notmatch '\$RUNNER_TEMP/prerelease-notes\.sh') {
+        throw "release.yml should run changelog validation from the preserved helper script."
     }
 }
 

--- a/.codex/scripts/prerelease-notes.tests.ps1
+++ b/.codex/scripts/prerelease-notes.tests.ps1
@@ -68,10 +68,19 @@ function Test-PrereleaseNotesIncludesChangelogAndDetailsCard {
         }
 
         $Notes = Get-Content -Raw -Path $OutputPath
-        Assert-Match -Text $Notes -Pattern '<details open>' -Message "Release notes did not include the details card."
-        Assert-Match -Text $Notes -Pattern 'Good to know before Thunderstore' -Message "Release notes did not include the card summary."
+        if ($Notes -match '<details') {
+            throw "Release notes should keep the Thunderstore handoff card visible without a dropdown."
+        }
+
+        Assert-Match -Text $Notes -Pattern '### 📦 Thunderstore handoff' -Message "Release notes did not include the handoff card heading."
+        Assert-Match -Text $Notes -Pattern '📝 Changelog' -Message "Release notes did not include the changelog cue."
+        Assert-Match -Text $Notes -Pattern '🌿 Branch' -Message "Release notes did not include the branch cue."
+        Assert-Match -Text $Notes -Pattern '🔖 Commit' -Message "Release notes did not include the commit cue."
+        Assert-Match -Text $Notes -Pattern '▶️ Run' -Message "Release notes did not include the workflow run cue."
+        Assert-Match -Text $Notes -Pattern '🏷️ Tag' -Message "Release notes did not include the tag cue."
+        Assert-Match -Text $Notes -Pattern '📦 Package' -Message "Release notes did not include the package cue."
         Assert-Match -Text $Notes -Pattern '## Unreleased.*empty' -Message "Release notes did not describe changelog turnover."
-        Assert-Match -Text $Notes -Pattern 'Thunderstore version.*1\.2\.3' -Message "Release notes did not include the Thunderstore package version."
+        Assert-Match -Text $Notes -Pattern 'Package.*1\.2\.3' -Message "Release notes did not include the Thunderstore package version."
         Assert-Match -Text $Notes -Pattern 'staged Thunderstore packaging' -Message "Release notes did not include current version changelog notes."
         Assert-Match -Text $Notes -Pattern '1234567890ab' -Message "Release notes did not include the short commit."
     }

--- a/.codex/scripts/prerelease-notes.tests.ps1
+++ b/.codex/scripts/prerelease-notes.tests.ps1
@@ -1,0 +1,178 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$ScriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$PrereleaseNotesPath = Join-Path $ScriptRoot "prerelease-notes.sh"
+$BashPath = "C:\Program Files\Git\bin\bash.exe"
+
+if (-not (Test-Path -LiteralPath $BashPath)) {
+    throw "Git Bash was not found at $BashPath."
+}
+
+function Assert-Match {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Text,
+        [Parameter(Mandatory = $true)]
+        [string]$Pattern,
+        [Parameter(Mandatory = $true)]
+        [string]$Message
+    )
+
+    if ($Text -notmatch $Pattern) {
+        throw $Message
+    }
+}
+
+function New-Fixture {
+    $FixtureRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("bloodcraft-prerelease-notes-" + [guid]::NewGuid().ToString("N"))
+    New-Item -ItemType Directory -Path $FixtureRoot | Out-Null
+    return $FixtureRoot
+}
+
+function Invoke-PrereleaseNotes {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments
+    )
+
+    & $BashPath $PrereleaseNotesPath @Arguments 2>&1 | Out-String
+}
+
+function Test-PrereleaseNotesIncludesChangelogAndDetailsCard {
+    $FixtureRoot = New-Fixture
+    try {
+        $ChangelogPath = Join-Path $FixtureRoot "CHANGELOG.md"
+        $OutputPath = Join-Path $FixtureRoot "prerelease-notes.md"
+        Set-Content -Path $ChangelogPath -Value @'
+## Unreleased
+
+`1.2.3`
+- added staged Thunderstore packaging
+- tightened prerelease receipts
+
+`1.2.2`
+- previous release
+'@
+
+        $Output = Invoke-PrereleaseNotes -Arguments @(
+            "--changelog", $ChangelogPath,
+            "--version", "1.2.3",
+            "--tag", "v1.2.3-pre",
+            "--branch", "main",
+            "--commit", "1234567890abcdef",
+            "--run-id", "42",
+            "--output", $OutputPath)
+        if ($LASTEXITCODE -ne 0) {
+            throw "prerelease-notes.sh exited with $LASTEXITCODE`n$Output"
+        }
+
+        $Notes = Get-Content -Raw -Path $OutputPath
+        Assert-Match -Text $Notes -Pattern '<details open>' -Message "Release notes did not include the details card."
+        Assert-Match -Text $Notes -Pattern 'Good to know before Thunderstore' -Message "Release notes did not include the card summary."
+        Assert-Match -Text $Notes -Pattern '## Unreleased.*empty' -Message "Release notes did not describe changelog turnover."
+        Assert-Match -Text $Notes -Pattern 'Thunderstore version.*1\.2\.3' -Message "Release notes did not include the Thunderstore package version."
+        Assert-Match -Text $Notes -Pattern 'staged Thunderstore packaging' -Message "Release notes did not include current version changelog notes."
+        Assert-Match -Text $Notes -Pattern '1234567890ab' -Message "Release notes did not include the short commit."
+    }
+    finally {
+        Remove-Item -Recurse -Force -LiteralPath $FixtureRoot
+    }
+}
+
+function Test-PrereleaseNotesRejectsUnreleasedContent {
+    $FixtureRoot = New-Fixture
+    try {
+        $ChangelogPath = Join-Path $FixtureRoot "CHANGELOG.md"
+        Set-Content -Path $ChangelogPath -Value @'
+## Unreleased
+- still parked for the next release
+
+`1.2.3`
+- added staged Thunderstore packaging
+'@
+
+        $Output = Invoke-PrereleaseNotes -Arguments @(
+            "--changelog", $ChangelogPath,
+            "--version", "1.2.3",
+            "--check-only")
+        if ($LASTEXITCODE -eq 0) {
+            throw "prerelease-notes.sh unexpectedly accepted non-empty Unreleased notes."
+        }
+
+        Assert-Match -Text $Output -Pattern 'CHANGELOG\.md ## Unreleased must be empty' -Message "Unreleased rejection message was not specific."
+    }
+    finally {
+        Remove-Item -Recurse -Force -LiteralPath $FixtureRoot
+    }
+}
+
+function Test-PrereleaseNotesRejectsMissingVersionEntry {
+    $FixtureRoot = New-Fixture
+    try {
+        $ChangelogPath = Join-Path $FixtureRoot "CHANGELOG.md"
+        Set-Content -Path $ChangelogPath -Value @'
+## Unreleased
+
+`1.2.2`
+- previous release
+'@
+
+        $Output = Invoke-PrereleaseNotes -Arguments @(
+            "--changelog", $ChangelogPath,
+            "--version", "1.2.3",
+            "--check-only")
+        if ($LASTEXITCODE -eq 0) {
+            throw "prerelease-notes.sh unexpectedly accepted a missing version entry."
+        }
+
+        Assert-Match -Text $Output -Pattern "does not contain notes for '1\.2\.3'" -Message "Missing version rejection message was not specific."
+    }
+    finally {
+        Remove-Item -Recurse -Force -LiteralPath $FixtureRoot
+    }
+}
+
+function Test-ReleaseWorkflowStagesAndChecksReleaseChangelog {
+    $WorkflowPath = Join-Path (Split-Path -Parent (Split-Path -Parent $ScriptRoot)) ".github/workflows/release.yml"
+    $WorkflowText = Get-Content -Raw -Path $WorkflowPath
+
+    $CheckoutMarker = "      - name: Checkout selected release tag"
+    $StageMarker = "      - name: Stage selected release contents"
+    $ChangelogMarker = "      - name: Validate staged release changelog"
+
+    $CheckoutIndex = $WorkflowText.IndexOf($CheckoutMarker, [StringComparison]::Ordinal)
+    $StageIndex = $WorkflowText.IndexOf($StageMarker, [StringComparison]::Ordinal)
+    $ChangelogIndex = $WorkflowText.IndexOf($ChangelogMarker, [StringComparison]::Ordinal)
+
+    if ($CheckoutIndex -lt 0) {
+        throw "release.yml is missing selected tag checkout."
+    }
+
+    if ($StageIndex -lt 0) {
+        throw "release.yml is missing the Stage selected release contents step."
+    }
+
+    if ($ChangelogIndex -lt 0) {
+        throw "release.yml is missing staged release changelog validation."
+    }
+
+    if ($StageIndex -lt $CheckoutIndex) {
+        throw "Release contents must be staged after checking out the selected tag."
+    }
+
+    if ($ChangelogIndex -lt $StageIndex) {
+        throw "Staged release changelog validation must run after staging release contents."
+    }
+
+    if ($WorkflowText -notmatch 'cd \./dist/thunderstore-publish') {
+        throw "Thunderstore publish should run from the staged publish root."
+    }
+}
+
+Test-PrereleaseNotesIncludesChangelogAndDetailsCard
+Test-PrereleaseNotesRejectsUnreleasedContent
+Test-PrereleaseNotesRejectsMissingVersionEntry
+Test-ReleaseWorkflowStagesAndChecksReleaseChangelog
+
+Write-Host "prerelease-notes tests passed"

--- a/.codex/shellcheck.sh
+++ b/.codex/shellcheck.sh
@@ -6,6 +6,7 @@ REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 
 SHELL_SCRIPTS=(
     "$REPO_ROOT/.codex/install.sh"
+    "$REPO_ROOT/.codex/scripts/prerelease-notes.sh"
     "$REPO_ROOT/.codex/scripts/version-metadata.sh"
     "$REPO_ROOT/.codex/shellcheck.sh"
 )

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -286,15 +286,22 @@ jobs:
             dotnet build . --configuration Release -p:RunGenerateREADME=false -p:CheckEolTargetFramework=false
           fi
 
+      - name: Prepare prerelease notes
+        shell: bash
+        run: |
+          bash .codex/scripts/prerelease-notes.sh \
+            --version '${{ needs.prepare_prerelease.outputs.prerelease_version }}' \
+            --tag '${{ needs.prepare_prerelease.outputs.prerelease_tag }}' \
+            --branch '${{ github.ref_name }}' \
+            --commit '${{ github.sha }}' \
+            --run-id '${{ github.run_id }}' \
+            --output ./dist/prerelease-notes.md
+
       - name: GH Release (pre-release)
         uses: softprops/action-gh-release@v2.6.2
         if: needs.prepare_prerelease.outputs.prerelease_version != ''
         with:
-          body: |
-            Automated pre-release for version ${{ needs.prepare_prerelease.outputs.prerelease_version }} generated from the main branch.
-            - Branch: ${{ github.ref_name }}
-            - Commit: ${{ github.sha }}
-            - Run: ${{ github.run_id }}
+          body_path: ./dist/prerelease-notes.md
           name: ${{ needs.prepare_prerelease.outputs.prerelease_name }}
           fail_on_unmatched_files: true
           prerelease: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,12 @@ jobs:
           echo "ALLOWED_PACKAGE_VERSION_PATTERN=$allowed_package_version_pattern" >> "$GITHUB_ENV"
         shell: bash
 
+      - name: Preserve release helper scripts
+        shell: bash
+        run: |
+          cp .codex/scripts/prerelease-notes.sh "$RUNNER_TEMP/prerelease-notes.sh"
+          chmod +x "$RUNNER_TEMP/prerelease-notes.sh"
+
       - name: Checkout selected release tag
         shell: bash
         run: git checkout --detach "refs/tags/$RELEASE_TAG"
@@ -133,7 +139,7 @@ jobs:
       - name: Validate staged release changelog
         shell: bash
         run: |
-          bash .codex/scripts/prerelease-notes.sh \
+          bash "$RUNNER_TEMP/prerelease-notes.sh" \
             --changelog ./dist/thunderstore-publish/CHANGELOG.md \
             --version "$PACKAGE_VERSION" \
             --tag "$RELEASE_TAG" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,11 +20,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Validate canonical version metadata
-        id: version_metadata
-        shell: bash
-        run: ./.codex/scripts/version-metadata.sh
-
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
@@ -35,7 +30,6 @@ jobs:
       - name: Select eligible release tag
         id: select_tag
         run: |
-          canonical_version='${{ steps.version_metadata.outputs.canonical_version }}'
           requested_tag='${{ inputs.release_tag }}'
 
           # GitHub prerelease tags (vX.Y.Z-pre) can publish canonical Thunderstore package versions (X.Y.Z).
@@ -62,11 +56,6 @@ jobs:
           release_version="${requested_tag#v}"
           package_version="${release_version%-pre}"
 
-          if [[ "$release_version" != "$canonical_version" && "$release_version" != "$canonical_version-pre" ]]; then
-            echo "Error: Release tag '$requested_tag' does not align with canonical version '$canonical_version'." >&2
-            exit 1
-          fi
-
           echo "Selected Thunderstore tag: $requested_tag"
           echo "GitHub release version: $release_version"
           echo "Thunderstore package version: $package_version"
@@ -78,17 +67,86 @@ jobs:
           echo "ALLOWED_PACKAGE_VERSION_PATTERN=$allowed_package_version_pattern" >> "$GITHUB_ENV"
         shell: bash
 
-      - name: Download Release
+      - name: Checkout selected release tag
+        shell: bash
+        run: git checkout --detach "refs/tags/$RELEASE_TAG"
+
+      - name: Validate selected release metadata
+        id: version_metadata
+        shell: bash
+        run: ./.codex/scripts/version-metadata.sh
+
+      - name: Confirm selected release version
+        shell: bash
         run: |
+          canonical_version='${{ steps.version_metadata.outputs.canonical_version }}'
+
+          if [[ "$RELEASE_VERSION" != "$canonical_version" && "$RELEASE_VERSION" != "$canonical_version-pre" ]]; then
+            echo "Error: Release tag '$RELEASE_TAG' does not align with canonical version '$canonical_version'." >&2
+            exit 1
+          fi
+
+      - name: Download Release
+        shell: bash
+        run: |
+          rm -rf ./dist
           gh release download "$RELEASE_TAG" -D ./dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ env.RELEASE_TAG }}
 
+      - name: Stage selected release contents
+        shell: bash
+        run: |
+          publish_root="./dist/thunderstore-publish"
+          required_release_assets=(
+            "Bloodcraft.dll"
+            "CHANGELOG.md"
+          )
+          required_checkout_assets=(
+            "README.md"
+            "icon.png"
+            "thunderstore.toml"
+          )
+
+          rm -rf "$publish_root"
+          mkdir -p "$publish_root"
+
+          for asset in "${required_release_assets[@]}"; do
+            if [[ ! -f "./dist/$asset" ]]; then
+              echo "Error: GitHub Release asset './dist/$asset' is missing." >&2
+              exit 1
+            fi
+
+            cp "./dist/$asset" "$publish_root/$asset"
+          done
+
+          for asset in "${required_checkout_assets[@]}"; do
+            if [[ ! -f "$asset" ]]; then
+              echo "Error: selected release checkout asset '$asset' is missing." >&2
+              exit 1
+            fi
+
+            cp "$asset" "$publish_root/$asset"
+          done
+
+      - name: Validate staged release changelog
+        shell: bash
+        run: |
+          bash .codex/scripts/prerelease-notes.sh \
+            --changelog ./dist/thunderstore-publish/CHANGELOG.md \
+            --version "$PACKAGE_VERSION" \
+            --tag "$RELEASE_TAG" \
+            --check-only
+        env:
+          RELEASE_TAG: ${{ env.RELEASE_TAG }}
+          PACKAGE_VERSION: ${{ env.PACKAGE_VERSION }}
+
       - name: Install Thunderstore CLI (tcli)
         run: dotnet tool install --global tcli
 
       - name: Publish build to Thunderstore
+        shell: bash
         run: |
           if [[ ! $RELEASE_TAG =~ $ALLOWED_TAG_PATTERN ]]; then
             echo "Error: Release tag '$RELEASE_TAG' is not an allowed Thunderstore source tag." >&2
@@ -101,6 +159,7 @@ jobs:
           fi
 
           echo "Publishing Thunderstore package version: $PACKAGE_VERSION"
+          cd ./dist/thunderstore-publish
           tcli publish --token "$THUNDERSTORE_KEY" --package-version "$PACKAGE_VERSION"
         env:
           RELEASE_TAG: ${{ env.RELEASE_TAG }}

--- a/.gitignore
+++ b/.gitignore
@@ -299,4 +299,6 @@ DevCommands.cs
 /.codex/persistent-data
 /.codex/runs
 /.codex/state
+/.codex/tmp
+/.codex/*.harness.settings.json
 /.codex/emberglass-bridge-proof.harness.settings.json

--- a/Bloodcraft.csproj
+++ b/Bloodcraft.csproj
@@ -3,7 +3,7 @@
 		<TargetFramework>net6.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AssemblyName>Bloodcraft</AssemblyName>
-		<Version>1.13.23</Version>
+		<Version>1.13.24</Version>
 		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
 		<LocalNugetPackageFeed>$(MSBuildProjectDirectory)/../LocalNugetPackageFeed</LocalNugetPackageFeed>
 		<RestoreSources>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+`1.13.24`
+- added generated GitHub prerelease notes, staged Thunderstore changelog validation, and staged publish-root release handoff
+
 `1.13.23`
 - added release hygiene helper scripts for changelog/version bump review and metadata updates
 - added CI coverage for the release hygiene nudge before build verification

--- a/thunderstore.toml
+++ b/thunderstore.toml
@@ -12,7 +12,7 @@ v-rising = ["oakveil-update", "mods", "server"]
 [package]
 namespace = "zfolmt"
 name = "Bloodcraft"
-versionNumber = "1.13.23"
+versionNumber = "1.13.24"
 description = "Leveling, expertise, legacies, professions, familiars, classes, quests!"
 websiteUrl = "https://github.com/mfoltz/Bloodcraft"
 containsNsfwContent = false


### PR DESCRIPTION
## Summary

- add a repo-local prerelease notes generator for GitHub prereleases, including the Thunderstore detail card
- use the generated notes as the GitHub prerelease body
- checkout the selected release tag before release metadata validation
- stage the downloaded release payload into `./dist/thunderstore-publish` before Thunderstore publication
- validate the staged changelog before `tcli publish`, then publish from the staged root
- bump Bloodcraft to `1.13.24`

## Verification

- `pwsh -NoProfile -File .codex/scripts/prerelease-notes.tests.ps1`
- `pwsh -NoProfile -File .codex/scripts/release-hygiene.tests.ps1`
- `git diff --check`
- `actionlint .github/workflows/build.yml .github/workflows/release.yml`
- `C:\Program Files\Git\bin\bash.exe .codex/install.sh`
- `C:\Program Files\Git\bin\bash.exe .codex/scripts/version-metadata.sh` -> `canonical_version=1.13.24`
- `C:\Program Files\Git\bin\bash.exe -n .codex/scripts/prerelease-notes.sh`

Note: local verification emitted existing Windows/.NET informational warnings only: Git autocrlf notices and the net6.0 EOL warning. Local Git Bash could not install shellcheck because no supported package manager was available; the CI workflow installs shellcheck on Ubuntu before running `.codex/shellcheck.sh`.