### PR TITLE
Guard Nightmare and Primal scaling across restarts

### DIFF
--- a/.codex/harness.settings.json
+++ b/.codex/harness.settings.json
@@ -82,7 +82,7 @@
         "generic and can't be used in il2cpp"
       ],
       "expectedPluginVersions": {
-        "Bloodcraft": "1.13.25"
+        "Bloodcraft": "1.13.26"
       },
       "expectedVraVersion": "1.1.12-r99041-b2",
       "buildEnvironment": {
@@ -175,7 +175,7 @@
         "generic and can't be used in il2cpp"
       ],
       "expectedPluginVersions": {
-        "Bloodcraft": "1.13.25"
+        "Bloodcraft": "1.13.26"
       },
       "expectedVraVersion": "1.1.12-r99041-b2",
       "buildEnvironment": {
@@ -290,7 +290,7 @@
         "generic and can't be used in il2cpp"
       ],
       "expectedPluginVersions": {
-        "Bloodcraft": "1.13.25"
+        "Bloodcraft": "1.13.26"
       },
       "expectedVraVersion": "1.1.12-r99041-b2",
       "buildEnvironment": {

--- a/.codex/harness.settings.json
+++ b/.codex/harness.settings.json
@@ -88,6 +88,247 @@
       "buildEnvironment": {
         "BEPINEX_PLUGIN_DIR": ""
       }
+    },
+    "bloodcraft-rcon-smoke": {
+      "modId": "bloodcraft",
+      "pluginName": "Bloodcraft",
+      "buildScript": ".codex\\install.sh",
+      "builtDllPath": "bin\\Release\\net6.0\\Bloodcraft.dll",
+      "preBuildScripts": [
+        ".codex\\scripts\\Install-ScarletRconHarnessDependency.ps1",
+        ".codex\\scripts\\Configure-BloodcraftScenario.ps1"
+      ],
+      "requiredPlugins": [
+        {
+          "source": "{PrimaryInstallPath}\\BepInEx\\plugins\\VampireCommandFramework.dll"
+        },
+        {
+          "source": "{PrimaryInstallPath}\\BepInEx\\plugins\\NetTopologySuite.dll"
+        },
+        {
+          "source": "{CodexRoot}\\tmp\\scarlet-rcon\\plugins\\ScarletCore.dll"
+        },
+        {
+          "source": "{CodexRoot}\\tmp\\scarlet-rcon\\plugins\\ScarletRCON.dll"
+        }
+      ],
+      "cleanupPlugins": [
+        "Bloodcraft.dll",
+        "Bloodstone.dll",
+        "Emberglass.dll",
+        "FinishZone.dll",
+        "HookDOTS.API.dll",
+        "KindredCommands.dll",
+        "KindredExtract.dll",
+        "KindredInnkeeper.dll",
+        "KindredLogistics.dll",
+        "KindredPortals.dll",
+        "KinImmortal.dll",
+        "KinLootBGone.dll",
+        "KinPonds.dll",
+        "KinPoolParty.dll",
+        "KinThrone.dll",
+        "Penumbra.dll",
+        "ScarletCore.dll",
+        "ScarletRCON.dll",
+        "VRising.DataExtractor.dll",
+        "VRoles.dll"
+      ],
+      "snapshotPaths": [
+        "{PersistentDataPath}\\Settings",
+        "{ServerInstallPath}\\BepInEx\\config\\Bloodcraft"
+      ],
+      "arguments": [
+        "-persistentDataPath",
+        "{PersistentDataPath}",
+        "-saveName",
+        "{SaveName}",
+        "-serverName",
+        "Codex Bloodcraft RCON Smoke",
+        "-gamePort",
+        "28015",
+        "-queryPort",
+        "28016",
+        "-rconEnabled",
+        "true",
+        "-rconPort",
+        "25575",
+        "-rconPassword",
+        "codex-rcon",
+        "-listOnSteam",
+        "false",
+        "-listOnEOS",
+        "false",
+        "-lanMode",
+        "true",
+        "-logFile",
+        "{ServerLogPath}"
+      ],
+      "successMarkers": [
+        "(Bloodcraft\\[[^\\]]+\\] loaded!|\\[Info\\s+:Bloodcraft\\]\\s+Loaded \\[[^\\]]+\\])",
+        "(Bloodcraft\\[[^\\]]+\\] initialized!|\\[Info\\s+:Bloodcraft\\]\\s+Initialized \\[[^\\]]+\\])"
+      ],
+      "failureMarkers": [
+        "Bloodcraft\\[[^\\]]+\\] fatal init failure",
+        "There is no Server world!",
+        "Server world is not ready yet",
+        "generic and can't be used in il2cpp"
+      ],
+      "expectedPluginVersions": {
+        "Bloodcraft": "1.13.24"
+      },
+      "expectedVraVersion": "1.1.12-r99041-b2",
+      "buildEnvironment": {
+        "BEPINEX_PLUGIN_DIR": "",
+        "VRISING_HARNESS_SERVER_INSTALL": "{ServerInstallPath}",
+        "VRISING_HARNESS_PERSISTENT_DATA": "{PersistentDataPath}",
+        "VRISING_HARNESS_ADMIN_STEAM_IDS": "76561198004949073",
+        "VRISING_HARNESS_RCON_PORT": "25575",
+        "VRISING_HARNESS_RCON_PASSWORD": "codex-rcon"
+      },
+      "scenario": {
+        "settleSecondsAfterReady": 2,
+        "timeoutSeconds": 30,
+        "rcon": {
+          "host": "127.0.0.1",
+          "port": 25575,
+          "password": "codex-rcon"
+        },
+        "commands": [
+          {
+            "name": "health",
+            "type": "rcon",
+            "command": "bloodcraft.status.health",
+            "expectRegex": "\\\"Ready\\\"\\s*:\\s*true"
+          }
+        ]
+      }
+    },
+    "bloodcraft-nightmare-primal-idempotency": {
+      "modId": "bloodcraft",
+      "pluginName": "Bloodcraft",
+      "buildScript": ".codex\\install.sh",
+      "builtDllPath": "bin\\Release\\net6.0\\Bloodcraft.dll",
+      "preBuildScripts": [
+        ".codex\\scripts\\Install-ScarletRconHarnessDependency.ps1",
+        ".codex\\scripts\\Configure-BloodcraftScenario.ps1"
+      ],
+      "requiredPlugins": [
+        {
+          "source": "{PrimaryInstallPath}\\BepInEx\\plugins\\VampireCommandFramework.dll"
+        },
+        {
+          "source": "{PrimaryInstallPath}\\BepInEx\\plugins\\NetTopologySuite.dll"
+        },
+        {
+          "source": "{CodexRoot}\\tmp\\scarlet-rcon\\plugins\\ScarletCore.dll"
+        },
+        {
+          "source": "{CodexRoot}\\tmp\\scarlet-rcon\\plugins\\ScarletRCON.dll"
+        }
+      ],
+      "cleanupPlugins": [
+        "Bloodcraft.dll",
+        "Bloodstone.dll",
+        "Emberglass.dll",
+        "FinishZone.dll",
+        "HookDOTS.API.dll",
+        "KindredCommands.dll",
+        "KindredExtract.dll",
+        "KindredInnkeeper.dll",
+        "KindredLogistics.dll",
+        "KindredPortals.dll",
+        "KinImmortal.dll",
+        "KinLootBGone.dll",
+        "KinPonds.dll",
+        "KinPoolParty.dll",
+        "KinThrone.dll",
+        "Penumbra.dll",
+        "ScarletCore.dll",
+        "ScarletRCON.dll",
+        "VRising.DataExtractor.dll",
+        "VRoles.dll"
+      ],
+      "snapshotPaths": [
+        "{PersistentDataPath}\\Settings",
+        "{ServerInstallPath}\\BepInEx\\config\\Bloodcraft"
+      ],
+      "arguments": [
+        "-persistentDataPath",
+        "{PersistentDataPath}",
+        "-saveName",
+        "{SaveName}",
+        "-serverName",
+        "Codex Bloodcraft Idempotency",
+        "-gamePort",
+        "28025",
+        "-queryPort",
+        "28026",
+        "-rconEnabled",
+        "true",
+        "-rconPort",
+        "25576",
+        "-rconPassword",
+        "codex-rcon",
+        "-listOnSteam",
+        "false",
+        "-listOnEOS",
+        "false",
+        "-lanMode",
+        "true",
+        "-logFile",
+        "{ServerLogPath}"
+      ],
+      "successMarkers": [
+        "(Bloodcraft\\[[^\\]]+\\] loaded!|\\[Info\\s+:Bloodcraft\\]\\s+Loaded \\[[^\\]]+\\])",
+        "(Bloodcraft\\[[^\\]]+\\] initialized!|\\[Info\\s+:Bloodcraft\\]\\s+Initialized \\[[^\\]]+\\])"
+      ],
+      "failureMarkers": [
+        "Bloodcraft\\[[^\\]]+\\] fatal init failure",
+        "There is no Server world!",
+        "Server world is not ready yet",
+        "generic and can't be used in il2cpp"
+      ],
+      "expectedPluginVersions": {
+        "Bloodcraft": "1.13.24"
+      },
+      "expectedVraVersion": "1.1.12-r99041-b2",
+      "buildEnvironment": {
+        "BEPINEX_PLUGIN_DIR": "",
+        "VRISING_HARNESS_SERVER_INSTALL": "{ServerInstallPath}",
+        "VRISING_HARNESS_PERSISTENT_DATA": "{PersistentDataPath}",
+        "VRISING_HARNESS_ADMIN_STEAM_IDS": "76561198004949073",
+        "VRISING_HARNESS_RCON_PORT": "25576",
+        "VRISING_HARNESS_RCON_PASSWORD": "codex-rcon"
+      },
+      "scenario": {
+        "settleSecondsAfterReady": 5,
+        "timeoutSeconds": 180,
+        "restartCycles": 2,
+        "rcon": {
+          "host": "127.0.0.1",
+          "port": 25576,
+          "password": "codex-rcon"
+        },
+        "commands": [
+          {
+            "name": "health",
+            "type": "rcon",
+            "command": "bloodcraft.status.health",
+            "expectRegex": "\\\"Ready\\\"\\s*:\\s*true"
+          },
+          {
+            "name": "primal-start",
+            "type": "rcon",
+            "command": "bloodcraft.diagnostics.primal.start",
+            "expectRegex": "^(true:queued|false:no-online-player)$"
+          }
+        ],
+        "waitLogMarkers": [
+          "\\[NightmareMode\\] Applied scaling to [0-9]+ prefab\\(s\\) and [0-9]+ unit\\(s\\); skipped [0-9]+ nonstandard unit\\(s\\); skipped [0-9]+ missing-baseline unit\\(s\\)\\."
+        ],
+        "waitSaveGlob": "{PersistentDataPath}\\Saves\\v4\\{SaveName}\\AutoSave_*.save.gz"
+      }
     }
   }
 }

--- a/.codex/scripts/Configure-BloodcraftScenario.ps1
+++ b/.codex/scripts/Configure-BloodcraftScenario.ps1
@@ -1,0 +1,81 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$ServerInstallPath = $env:VRISING_HARNESS_SERVER_INSTALL
+if ([string]::IsNullOrWhiteSpace($ServerInstallPath)) {
+    throw "VRISING_HARNESS_SERVER_INSTALL is required."
+}
+
+$RconPort = $env:VRISING_HARNESS_RCON_PORT
+$RconPassword = $env:VRISING_HARNESS_RCON_PASSWORD
+if (-not [string]::IsNullOrWhiteSpace($RconPort)) {
+    $HostSettingsPath = Join-Path $ServerInstallPath "VRisingServer_Data\StreamingAssets\Settings\ServerHostSettings.json"
+    if (-not (Test-Path -LiteralPath $HostSettingsPath)) {
+        throw "Server host settings not found: $HostSettingsPath"
+    }
+
+    $HostSettings = Get-Content -Raw -Path $HostSettingsPath | ConvertFrom-Json
+    if ($null -eq $HostSettings.Rcon) {
+        $HostSettings | Add-Member -MemberType NoteProperty -Name Rcon -Value ([pscustomobject]@{})
+    }
+
+    $HostSettings.Rcon.Enabled = $true
+    $HostSettings.Rcon.Port = [int]$RconPort
+    $HostSettings.Rcon.Password = if ($null -eq $RconPassword) { "" } else { $RconPassword }
+
+    $HostSettings | ConvertTo-Json -Depth 8 | Set-Content -Path $HostSettingsPath -Encoding UTF8
+    Write-Host "[bloodcraft-scenario] Enabled V Rising RCON on port $RconPort in $HostSettingsPath"
+}
+
+$PersistentDataPath = $env:VRISING_HARNESS_PERSISTENT_DATA
+$AdminSteamIds = $env:VRISING_HARNESS_ADMIN_STEAM_IDS
+if (-not [string]::IsNullOrWhiteSpace($PersistentDataPath) -and -not [string]::IsNullOrWhiteSpace($AdminSteamIds)) {
+    $SettingsPath = Join-Path $PersistentDataPath "Settings"
+    $AdminListPath = Join-Path $SettingsPath "adminlist.txt"
+
+    New-Item -ItemType Directory -Path $SettingsPath -Force | Out-Null
+
+    $ExistingAdminIds = @()
+    if (Test-Path -LiteralPath $AdminListPath) {
+        $ExistingAdminIds = @(Get-Content -Path $AdminListPath | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+    }
+
+    $ConfiguredAdminIds = @($AdminSteamIds -split "[,;\s]+" | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+    foreach ($AdminSteamId in $ConfiguredAdminIds) {
+        if ($AdminSteamId -notmatch "^\d{17}$") {
+            throw "Invalid admin SteamID '$AdminSteamId'. Expected a 17-digit SteamID64."
+        }
+    }
+
+    $MergedAdminIds = @($ExistingAdminIds + $ConfiguredAdminIds | Select-Object -Unique)
+    Set-Content -Path $AdminListPath -Value $MergedAdminIds -Encoding UTF8
+    Write-Host "[bloodcraft-scenario] Seeded $($ConfiguredAdminIds.Count) admin SteamID(s) in $AdminListPath"
+}
+
+$ConfigPath = Join-Path $ServerInstallPath "BepInEx\config\io.zfolmt.Bloodcraft.cfg"
+if (-not (Test-Path -LiteralPath $ConfigPath)) {
+    New-Item -ItemType Directory -Path (Split-Path -Path $ConfigPath -Parent) -Force | Out-Null
+    Set-Content -Path $ConfigPath -Value "[General]`r`n" -Encoding UTF8
+}
+
+$ConfigText = Get-Content -Raw -Path $ConfigPath
+$Replacements = [ordered]@{
+    "ElitePrimalRifts" = "true"
+    "RiftFrequency" = "6"
+    "NightmareMode" = "true"
+}
+
+foreach ($Entry in $Replacements.GetEnumerator()) {
+    $Pattern = "(?m)^$([regex]::Escape($Entry.Key))\s*=.*$"
+    $Replacement = "$($Entry.Key) = $($Entry.Value)"
+
+    if ([regex]::IsMatch($ConfigText, $Pattern)) {
+        $ConfigText = [regex]::Replace($ConfigText, $Pattern, $Replacement)
+    }
+    else {
+        $ConfigText = $ConfigText.TrimEnd() + [Environment]::NewLine + $Replacement + [Environment]::NewLine
+    }
+}
+
+Set-Content -Path $ConfigPath -Value $ConfigText -Encoding UTF8
+Write-Host "[bloodcraft-scenario] Enabled Nightmare Mode and Primal Rifts in $ConfigPath"

--- a/.codex/scripts/Install-ScarletRconHarnessDependency.ps1
+++ b/.codex/scripts/Install-ScarletRconHarnessDependency.ps1
@@ -1,0 +1,77 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$CodexRoot = Split-Path -Path $PSScriptRoot -Parent
+$CacheRoot = Join-Path $CodexRoot "tmp\scarlet-rcon"
+$DownloadRoot = Join-Path $CacheRoot "downloads"
+$ExtractRoot = Join-Path $CacheRoot "extracted"
+$PluginRoot = Join-Path $CacheRoot "plugins"
+
+$Packages = @(
+    [ordered]@{
+        Name = "ScarletCore"
+        Version = "1.3.11"
+        Url = "https://thunderstore.io/package/download/ScarletMods/ScarletCore/1.3.11/"
+        Sha256 = "1A879411B8258F9C28B8D6804720563E825FA1788ECA87F7B89BAB081CA6569F"
+        Dll = "ScarletCore.dll"
+    },
+    [ordered]@{
+        Name = "ScarletRCON"
+        Version = "1.2.9"
+        Url = "https://thunderstore.io/package/download/ScarletMods/ScarletRCON/1.2.9/"
+        Sha256 = "05F481108569830428B3BD1E57332280B445F30885D8F048D7735355160504BF"
+        Dll = "ScarletRCON.dll"
+    }
+)
+
+function Test-ZipHash {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+        [Parameter(Mandatory = $true)]
+        [string]$ExpectedHash
+    )
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return $false
+    }
+
+    $ActualHash = (Get-FileHash -Path $Path -Algorithm SHA256).Hash
+    return [string]::Equals($ActualHash, $ExpectedHash, [System.StringComparison]::OrdinalIgnoreCase)
+}
+
+New-Item -ItemType Directory -Path $DownloadRoot -Force | Out-Null
+New-Item -ItemType Directory -Path $ExtractRoot -Force | Out-Null
+New-Item -ItemType Directory -Path $PluginRoot -Force | Out-Null
+
+foreach ($Package in $Packages) {
+    $ZipPath = Join-Path $DownloadRoot "$($Package.Name)-$($Package.Version).zip"
+    if (-not (Test-ZipHash -Path $ZipPath -ExpectedHash $Package.Sha256)) {
+        Write-Host "[scarlet-rcon] Downloading $($Package.Name) $($Package.Version)"
+        Invoke-WebRequest -Uri $Package.Url -OutFile $ZipPath
+    }
+
+    if (-not (Test-ZipHash -Path $ZipPath -ExpectedHash $Package.Sha256)) {
+        $ActualHash = if (Test-Path -LiteralPath $ZipPath) { (Get-FileHash -Path $ZipPath -Algorithm SHA256).Hash } else { "<missing>" }
+        throw "Downloaded $($Package.Name) $($Package.Version) hash mismatch. Expected $($Package.Sha256), got $ActualHash."
+    }
+
+    $PackageExtractRoot = Join-Path $ExtractRoot "$($Package.Name)-$($Package.Version)"
+    $ExtractedDllPath = Join-Path $PackageExtractRoot $Package.Dll
+    if (-not (Test-Path -LiteralPath $ExtractedDllPath)) {
+        if (Test-Path -LiteralPath $PackageExtractRoot) {
+            Remove-Item -LiteralPath $PackageExtractRoot -Recurse -Force
+        }
+
+        New-Item -ItemType Directory -Path $PackageExtractRoot -Force | Out-Null
+        Expand-Archive -LiteralPath $ZipPath -DestinationPath $PackageExtractRoot -Force
+    }
+
+    if (-not (Test-Path -LiteralPath $ExtractedDllPath)) {
+        throw "$($Package.Dll) was not found in $ZipPath."
+    }
+
+    Copy-Item -LiteralPath $ExtractedDllPath -Destination (Join-Path $PluginRoot $Package.Dll) -Force
+}
+
+Write-Host "[scarlet-rcon] Prepared ScarletRCON harness dependencies in $PluginRoot"

--- a/.codex/scripts/Invoke-SourceRconCommand.ps1
+++ b/.codex/scripts/Invoke-SourceRconCommand.ps1
@@ -1,0 +1,111 @@
+param(
+    [string]$HostName = "127.0.0.1",
+    [int]$Port,
+    [string]$Password = "",
+    [Parameter(Mandatory = $true)]
+    [string]$Command
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function New-RconPacketBytes {
+    param(
+        [int]$RequestId,
+        [int]$Type,
+        [string]$Body
+    )
+
+    $BodyBytes = [System.Text.Encoding]::UTF8.GetBytes($Body)
+    $Size = 4 + 4 + $BodyBytes.Length + 2
+    $Buffer = New-Object byte[] (4 + $Size)
+    [System.BitConverter]::GetBytes($Size).CopyTo($Buffer, 0)
+    [System.BitConverter]::GetBytes($RequestId).CopyTo($Buffer, 4)
+    [System.BitConverter]::GetBytes($Type).CopyTo($Buffer, 8)
+    [Array]::Copy($BodyBytes, 0, $Buffer, 12, $BodyBytes.Length)
+    return $Buffer
+}
+
+function Read-ExactBytes {
+    param(
+        [System.IO.Stream]$Stream,
+        [int]$Count
+    )
+
+    $Buffer = New-Object byte[] $Count
+    $Offset = 0
+    while ($Offset -lt $Count) {
+        $Read = $Stream.Read($Buffer, $Offset, $Count - $Offset)
+        if ($Read -le 0) {
+            throw "RCON connection closed while reading packet."
+        }
+
+        $Offset += $Read
+    }
+
+    return $Buffer
+}
+
+function Read-RconPacket {
+    param([System.IO.Stream]$Stream)
+
+    $SizeBytes = Read-ExactBytes -Stream $Stream -Count 4
+    $Size = [System.BitConverter]::ToInt32($SizeBytes, 0)
+    $Payload = Read-ExactBytes -Stream $Stream -Count $Size
+    $RequestId = [System.BitConverter]::ToInt32($Payload, 0)
+    $Type = [System.BitConverter]::ToInt32($Payload, 4)
+    $BodyLength = [Math]::Max(0, $Size - 10)
+    $Body = [System.Text.Encoding]::UTF8.GetString($Payload, 8, $BodyLength)
+
+    return [pscustomobject]@{
+        RequestId = $RequestId
+        Type = $Type
+        Body = $Body
+    }
+}
+
+function Write-RconPacket {
+    param(
+        [System.IO.Stream]$Stream,
+        [int]$RequestId,
+        [int]$Type,
+        [string]$Body
+    )
+
+    $Bytes = New-RconPacketBytes -RequestId $RequestId -Type $Type -Body $Body
+    $Stream.Write($Bytes, 0, $Bytes.Length)
+    $Stream.Flush()
+}
+
+$Client = [System.Net.Sockets.TcpClient]::new()
+$Client.Connect($HostName, $Port)
+try {
+    $Stream = $Client.GetStream()
+
+    Write-RconPacket -Stream $Stream -RequestId 1 -Type 3 -Body $Password
+    $Authenticated = $false
+    $AuthDeadline = (Get-Date).AddSeconds(10)
+    while ((Get-Date) -lt $AuthDeadline -and -not $Authenticated) {
+        $Packet = Read-RconPacket -Stream $Stream
+        if ($Packet.RequestId -eq 1 -and $Packet.Type -eq 2) {
+            $Authenticated = $true
+        }
+    }
+
+    if (-not $Authenticated) {
+        throw "RCON authentication failed."
+    }
+
+    Write-RconPacket -Stream $Stream -RequestId 2 -Type 2 -Body $Command
+    $Response = Read-RconPacket -Stream $Stream
+
+    [pscustomobject]@{
+        Command = $Command
+        Response = $Response.Body
+        RequestId = $Response.RequestId
+        Type = $Response.Type
+    } | ConvertTo-Json -Compress
+}
+finally {
+    $Client.Dispose()
+}

--- a/Bloodcraft.csproj
+++ b/Bloodcraft.csproj
@@ -3,7 +3,7 @@
 		<TargetFramework>net6.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AssemblyName>Bloodcraft</AssemblyName>
-		<Version>1.13.25</Version>
+		<Version>1.13.26</Version>
 		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
 		<LocalNugetPackageFeed>$(MSBuildProjectDirectory)/../LocalNugetPackageFeed</LocalNugetPackageFeed>
 		<RestoreSources>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- fixed Nightmare Mode and Primal Rift scaling so persisted units are guarded against duplicate stat scaling across server restarts
+- added reusable V Rising harness scenario/RCON support for restart diagnostics, including ScarletRCON setup and local admin-list seeding
+
 ## v1.13.24
 
 - added generated GitHub prerelease notes, staged Thunderstore changelog validation, and staged publish-root release handoff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v1.13.26
+
 - fixed Nightmare Mode and Primal Rift scaling so persisted units are guarded against duplicate stat scaling across server restarts
 - added reusable V Rising harness scenario/RCON support for restart diagnostics, including ScarletRCON setup and local admin-list seeding
 

--- a/Commands/RconCommands.cs
+++ b/Commands/RconCommands.cs
@@ -1,4 +1,5 @@
 using Bloodcraft.Services;
+using Bloodcraft.Systems;
 using Bloodcraft.Utilities;
 using ScarletRCON.Shared;
 using Stunlock.Core;
@@ -117,5 +118,23 @@ public static class RconCommands
     public static string HealthStatus()
     {
         return StartupStateService.BuildJsonSummary();
+    }
+
+    [RconCommand("diagnostics.primal.start", "Attempts to queue a Primal Rift start event for harness diagnostics.", "Returns true:queued or a false:<reason> diagnostic result.")]
+    public static string StartPrimalRifts()
+    {
+        if (!StartupStateService.IsReady())
+        {
+            return "false:server-not-ready";
+        }
+
+        if (!ConfigService.ElitePrimalRifts)
+        {
+            return "false:elite-primal-rifts-disabled";
+        }
+
+        return PrimalWarEventSystem.TryStartPrimalRiftsForDiagnostics(out string reason)
+            ? $"true:{reason}"
+            : $"false:{reason}";
     }
 }

--- a/Core.cs
+++ b/Core.cs
@@ -450,6 +450,7 @@ internal static class Core
                         int appliedUnits = 0;
                         int skippedNonStandard = 0;
                         int missingBaseline = 0;
+                        HashSet<Entity> prefabsToScale = [];
 
                         foreach (QueryResult result in stream.GetResults())
                         {
@@ -458,10 +459,9 @@ internal static class Core
 
                             if (ShouldSkipNightmareTarget(prefabGuid, prefabName)) continue;
 
-                            switch (TryApplyNightmareStats(result.Entity, prefabGuid))
+                            switch (TryApplyNightmareStats(result.Entity, prefabGuid, prefabsToScale))
                             {
-                                case NightmareScalingResult.AppliedPrefab:
-                                    appliedPrefabs++;
+                                case NightmareScalingResult.QueuedPrefab:
                                     break;
                                 case NightmareScalingResult.AppliedUnit:
                                     appliedUnits++;
@@ -473,6 +473,12 @@ internal static class Core
                                     missingBaseline++;
                                     break;
                             }
+                        }
+
+                        foreach (Entity prefabEntity in prefabsToScale)
+                        {
+                            ApplyNightmareStatMultipliers(prefabEntity);
+                            appliedPrefabs++;
                         }
 
                         if (appliedPrefabs > 0 || appliedUnits > 0 || skippedNonStandard > 0 || missingBaseline > 0)
@@ -501,24 +507,26 @@ internal static class Core
 
     enum NightmareScalingResult
     {
-        AppliedPrefab,
+        QueuedPrefab,
         AppliedUnit,
         AlreadyNonStandard,
         MissingBaseline
     }
 
-    static NightmareScalingResult TryApplyNightmareStats(Entity entity, PrefabGUID prefabGuid)
+    static NightmareScalingResult TryApplyNightmareStats(Entity entity, PrefabGUID prefabGuid, HashSet<Entity> prefabsToScale)
     {
         if (!SystemService.PrefabCollectionSystem._PrefabGuidToEntityMap.TryGetValue(prefabGuid, out Entity prefabEntity)
-            || !TryReadNightmareStats(prefabEntity, out Health baselineHealth, out UnitStats baselineUnitStats, out AiMoveSpeeds baselineAiMoveSpeeds)
             || !TryReadNightmareStats(entity, out Health health, out UnitStats unitStats, out AiMoveSpeeds aiMoveSpeeds))
             return NightmareScalingResult.MissingBaseline;
 
         if (IsNightmarePrefabEntity(entity, prefabEntity))
         {
-            ApplyNightmareStatMultipliers(entity);
-            return NightmareScalingResult.AppliedPrefab;
+            prefabsToScale.Add(entity);
+            return NightmareScalingResult.QueuedPrefab;
         }
+
+        if (!TryReadNightmareStats(prefabEntity, out Health baselineHealth, out UnitStats baselineUnitStats, out AiMoveSpeeds baselineAiMoveSpeeds))
+            return NightmareScalingResult.MissingBaseline;
 
         if (!MatchesNightmareBaseline(health, unitStats, aiMoveSpeeds, baselineHealth, baselineUnitStats, baselineAiMoveSpeeds))
             return NightmareScalingResult.AlreadyNonStandard;

--- a/Core.cs
+++ b/Core.cs
@@ -140,6 +140,7 @@ internal static class Core
     const float NIGHTMARE_HEALTH_MULTIPLIER = 5f;
     const float NIGHTMARE_POWER_MULTIPLIER = 1.5f;
     const float NIGHTMARE_MOVE_SPEED_MULTIPLIER = 1.25f;
+    const float NIGHTMARE_BASELINE_TOLERANCE = 0.001f;
 
     public static byte[] NEW_SHARED_KEY { get; set; }
 
@@ -445,6 +446,11 @@ internal static class Core
                 {
                     using (stream)
                     {
+                        int appliedPrefabs = 0;
+                        int appliedUnits = 0;
+                        int skippedNonStandard = 0;
+                        int missingBaseline = 0;
+
                         foreach (QueryResult result in stream.GetResults())
                         {
                             PrefabGUID prefabGuid = result.ResolveComponentData<PrefabGUID>();
@@ -452,7 +458,26 @@ internal static class Core
 
                             if (ShouldSkipNightmareTarget(prefabGuid, prefabName)) continue;
 
-                            ApplyNightmareStats(result.Entity);
+                            switch (TryApplyNightmareStats(result.Entity, prefabGuid))
+                            {
+                                case NightmareScalingResult.AppliedPrefab:
+                                    appliedPrefabs++;
+                                    break;
+                                case NightmareScalingResult.AppliedUnit:
+                                    appliedUnits++;
+                                    break;
+                                case NightmareScalingResult.AlreadyNonStandard:
+                                    skippedNonStandard++;
+                                    break;
+                                case NightmareScalingResult.MissingBaseline:
+                                    missingBaseline++;
+                                    break;
+                            }
+                        }
+
+                        if (appliedPrefabs > 0 || appliedUnits > 0 || skippedNonStandard > 0 || missingBaseline > 0)
+                        {
+                            Log.LogInfo($"[NightmareMode] Applied scaling to {appliedPrefabs} prefab(s) and {appliedUnits} unit(s); skipped {skippedNonStandard} nonstandard unit(s); skipped {missingBaseline} missing-baseline unit(s).");
                         }
                     }
                 }
@@ -474,7 +499,41 @@ internal static class Core
         return false;
     }
 
-    static void ApplyNightmareStats(Entity entity)
+    enum NightmareScalingResult
+    {
+        AppliedPrefab,
+        AppliedUnit,
+        AlreadyNonStandard,
+        MissingBaseline
+    }
+
+    static NightmareScalingResult TryApplyNightmareStats(Entity entity, PrefabGUID prefabGuid)
+    {
+        if (!SystemService.PrefabCollectionSystem._PrefabGuidToEntityMap.TryGetValue(prefabGuid, out Entity prefabEntity)
+            || !TryReadNightmareStats(prefabEntity, out Health baselineHealth, out UnitStats baselineUnitStats, out AiMoveSpeeds baselineAiMoveSpeeds)
+            || !TryReadNightmareStats(entity, out Health health, out UnitStats unitStats, out AiMoveSpeeds aiMoveSpeeds))
+            return NightmareScalingResult.MissingBaseline;
+
+        if (IsNightmarePrefabEntity(entity, prefabEntity))
+        {
+            ApplyNightmareStatMultipliers(entity);
+            return NightmareScalingResult.AppliedPrefab;
+        }
+
+        if (!MatchesNightmareBaseline(health, unitStats, aiMoveSpeeds, baselineHealth, baselineUnitStats, baselineAiMoveSpeeds))
+            return NightmareScalingResult.AlreadyNonStandard;
+
+        ApplyNightmareStatMultipliers(entity);
+        return NightmareScalingResult.AppliedUnit;
+    }
+
+    static bool IsNightmarePrefabEntity(Entity entity, Entity prefabEntity)
+    {
+        return entity.Equals(prefabEntity)
+            || entity.Has<Unity.Entities.Prefab>();
+    }
+
+    static void ApplyNightmareStatMultipliers(Entity entity)
     {
         entity.With((ref Health health) =>
         {
@@ -493,6 +552,32 @@ internal static class Core
             aiMoveSpeeds.Walk._Value *= NIGHTMARE_MOVE_SPEED_MULTIPLIER;
             aiMoveSpeeds.Run._Value *= NIGHTMARE_MOVE_SPEED_MULTIPLIER;
         });
+    }
+
+    static bool TryReadNightmareStats(Entity entity, out Health health, out UnitStats unitStats, out AiMoveSpeeds aiMoveSpeeds)
+    {
+        health = default;
+        unitStats = default;
+        aiMoveSpeeds = default;
+
+        return entity.Exists()
+            && entity.TryGetComponent(out health)
+            && entity.TryGetComponent(out unitStats)
+            && entity.TryGetComponent(out aiMoveSpeeds);
+    }
+
+    static bool MatchesNightmareBaseline(Health health, UnitStats unitStats, AiMoveSpeeds aiMoveSpeeds, Health baselineHealth, UnitStats baselineUnitStats, AiMoveSpeeds baselineAiMoveSpeeds)
+    {
+        return NearlyEqual(health.MaxHealth._Value, baselineHealth.MaxHealth._Value)
+            && NearlyEqual(unitStats.PhysicalPower._Value, baselineUnitStats.PhysicalPower._Value)
+            && NearlyEqual(unitStats.SpellPower._Value, baselineUnitStats.SpellPower._Value)
+            && NearlyEqual(aiMoveSpeeds.Walk._Value, baselineAiMoveSpeeds.Walk._Value)
+            && NearlyEqual(aiMoveSpeeds.Run._Value, baselineAiMoveSpeeds.Run._Value);
+    }
+
+    static bool NearlyEqual(float left, float right)
+    {
+        return MathF.Abs(left - right) <= NIGHTMARE_BASELINE_TOLERANCE;
     }
 
     static readonly HashSet<PrefabGUID> _shardBearers =

--- a/Systems/PrimalWarEventSystem.cs
+++ b/Systems/PrimalWarEventSystem.cs
@@ -250,6 +250,9 @@ public class PrimalWarEventSystem : SystemBase
 
         try
         {
+            int applied = 0;
+            int skipped = 0;
+
             foreach (var chunk in chunks)
             {
                 var gates = chunk.GetNativeArray(_gateHandle);
@@ -280,10 +283,26 @@ public class PrimalWarEventSystem : SystemBase
                             continue;
                         }
 
+                        if (ScalingMarkers.HasPrimalRiftScalingMarker(unitEntity, _serverGameManager))
+                        {
+                            isActive = true;
+                            skipped++;
+                            _handled.Add(unitEntity);
+                            continue;
+                        }
+
+                        if (!TryAddPrimalRiftScalingMarker(unitEntity))
+                        {
+                            isActive = true;
+                            _handled.Add(unitEntity);
+                            continue;
+                        }
+
                         Core.Delayed(() => unitEntity.TryApplyBuffWithLifeTimeNone(_variantBuffs.DrawRandom())); // blood buffs crash cause lifetime, noting before I forget again >_>
                         ModifyPrimalUnit(unitEntity, isGateBoss);
 
                         isActive = true;
+                        applied++;
                         _handled.Add(unitEntity);
                     }
 
@@ -302,6 +321,8 @@ public class PrimalWarEventSystem : SystemBase
                         activeRift.Hazard.TrySpawnHazard(_serverGameManager, translation.Value);
                 }
             }
+
+            LogScalingSummary(nameof(HandleActiveGates), applied, skipped);
         }
         catch (Exception e)
         {
@@ -318,6 +339,9 @@ public class PrimalWarEventSystem : SystemBase
 
         try
         {
+            int applied = 0;
+            int skipped = 0;
+
             foreach (var chunk in chunks)
             {
                 var portals = chunk.GetNativeArray(_portalHandle);
@@ -350,6 +374,20 @@ public class PrimalWarEventSystem : SystemBase
                             continue;
                         }
 
+                        if (ScalingMarkers.HasPrimalRiftScalingMarker(unitEntity, _serverGameManager))
+                        {
+                            // isActive = true;
+                            skipped++;
+                            _handled.Add(unitEntity);
+                            continue;
+                        }
+
+                        if (!TryAddPrimalRiftScalingMarker(unitEntity))
+                        {
+                            _handled.Add(unitEntity);
+                            continue;
+                        }
+
                         if (Misc.RollForChance(Constants.BUFF_CHANCE))
                         {
                             Core.Delayed(() => unitEntity.TryApplyBuffWithLifeTimeNone(_variantBuffs.DrawRandom()));
@@ -358,10 +396,13 @@ public class PrimalWarEventSystem : SystemBase
                         ModifyPrimalUnit(unitEntity);
 
                         // isActive = true;
+                        applied++;
                         _handled.Add(unitEntity);
                     }
                 }
             }
+
+            LogScalingSummary(nameof(HandleActivePortals), applied, skipped);
         }
         catch (Exception e)
         {
@@ -486,10 +527,28 @@ public class PrimalWarEventSystem : SystemBase
     }
     public static void TryStartPrimalRifts()
     {
+        _ = TryQueuePrimalRifts(out _);
+    }
+
+    /// <summary>
+    /// Attempts to queue a Primal Rift start event for RCON diagnostics.
+    /// </summary>
+    /// <param name="reason">A stable diagnostic reason for the queue result.</param>
+    /// <returns>True when a start event was queued.</returns>
+    public static bool TryStartPrimalRiftsForDiagnostics(out string reason)
+    {
+        return TryQueuePrimalRifts(out reason);
+    }
+
+    static bool TryQueuePrimalRifts(out string reason)
+    {
         _nextRiftTime = Core.ServerGameManager.ServerTime + RiftInterval;
 
         if (!PlayerService.SteamIdOnlinePlayerInfoCache.Any())
-            return;
+        {
+            reason = "no-online-player";
+            return false;
+        }
 
         var player = PlayerService.SteamIdOnlinePlayerInfoCache.Values.FirstOrDefault();
 
@@ -518,6 +577,8 @@ public class PrimalWarEventSystem : SystemBase
         entity.Write(networkEventType);
 
         Core.Log.LogWarning($"[PrimalWarEventSystem]: Primal Rifts - Active");
+        reason = "queued";
+        return true;
     }
     static void ModifyPrimalUnit(Entity entity, bool isGateBoss = false)
     {
@@ -529,6 +590,23 @@ public class PrimalWarEventSystem : SystemBase
         SetHealth(entity);
         SetPower(entity, isGateBoss);
         SetMoveSpeed(entity);
+    }
+    bool TryAddPrimalRiftScalingMarker(Entity entity)
+    {
+        if (!ScalingMarkers.TryAddPrimalRiftScalingMarker(entity, _serverGameManager))
+        {
+            Core.Log.LogWarning($"[PrimalWarEventSystem] Skipped scaling unit {entity}; failed to add marker.");
+            return false;
+        }
+
+        return true;
+    }
+    static void LogScalingSummary(string source, int applied, int skipped)
+    {
+        if (applied > 0 || skipped > 0)
+        {
+            Core.Log.LogInfo($"[PrimalWarEventSystem.{source}] Applied scaling to {applied} unit(s); skipped {skipped} already-marked unit(s).");
+        }
     }
     static void SetLevel(Entity entity, bool isGateBoss)
     {

--- a/Utilities/ScalingMarkers.cs
+++ b/Utilities/ScalingMarkers.cs
@@ -1,0 +1,145 @@
+using Bloodcraft.Resources;
+using ProjectM;
+using ProjectM.Gameplay.Scripting;
+using ProjectM.Network;
+using ProjectM.Scripting;
+using Stunlock.Core;
+using Unity.Entities;
+
+namespace Bloodcraft.Utilities;
+
+internal static class ScalingMarkers
+{
+    static readonly PrefabGUID _primalRiftMarkerBuff = PrefabGUIDs.Item_EquipBuff_MagicSource_BloodKey_T01;
+
+    const int PRIMAL_RIFT_MARKER_LEVEL = 731002;
+
+    /// <summary>
+    /// Returns whether the entity has the inert Primal Rift scaling marker buff.
+    /// </summary>
+    /// <param name="entity">The unit entity to inspect.</param>
+    /// <returns>True when the Primal marker buff exists with the expected marker value.</returns>
+    public static bool HasPrimalRiftScalingMarker(Entity entity)
+    {
+        return HasMarker(entity, _primalRiftMarkerBuff, PRIMAL_RIFT_MARKER_LEVEL);
+    }
+
+    /// <summary>
+    /// Returns whether the entity has the inert Primal Rift scaling marker buff.
+    /// </summary>
+    /// <param name="entity">The unit entity to inspect.</param>
+    /// <param name="serverGameManager">The server game manager to use for buff lookup.</param>
+    /// <returns>True when the Primal marker buff exists with the expected marker value.</returns>
+    public static bool HasPrimalRiftScalingMarker(Entity entity, ServerGameManager serverGameManager)
+    {
+        return HasMarker(entity, _primalRiftMarkerBuff, PRIMAL_RIFT_MARKER_LEVEL, serverGameManager);
+    }
+
+    /// <summary>
+    /// Adds or stamps the inert Primal Rift scaling marker buff on the entity.
+    /// </summary>
+    /// <param name="entity">The unit entity to mark.</param>
+    /// <returns>True when the marker was present or successfully stamped.</returns>
+    public static bool TryAddPrimalRiftScalingMarker(Entity entity)
+    {
+        return TryAddMarker(entity, _primalRiftMarkerBuff, PRIMAL_RIFT_MARKER_LEVEL);
+    }
+
+    /// <summary>
+    /// Adds or stamps the inert Primal Rift scaling marker buff on the entity.
+    /// </summary>
+    /// <param name="entity">The unit entity to mark.</param>
+    /// <param name="serverGameManager">The server game manager to use for buff lookup and creation.</param>
+    /// <returns>True when the marker was present or successfully stamped.</returns>
+    public static bool TryAddPrimalRiftScalingMarker(Entity entity, ServerGameManager serverGameManager)
+    {
+        return TryAddMarker(entity, _primalRiftMarkerBuff, PRIMAL_RIFT_MARKER_LEVEL, serverGameManager);
+    }
+
+    static bool HasMarker(Entity entity, PrefabGUID markerBuff, int markerLevel)
+    {
+        return entity.TryGetBuff(markerBuff, out Entity buffEntity)
+            && IsMarker(buffEntity, markerLevel);
+    }
+
+    static bool HasMarker(Entity entity, PrefabGUID markerBuff, int markerLevel, ServerGameManager serverGameManager)
+    {
+        return serverGameManager.TryGetBuff(entity, markerBuff.ToIdentifier(), out Entity buffEntity)
+            && IsMarker(buffEntity, markerLevel);
+    }
+
+    static bool TryAddMarker(Entity entity, PrefabGUID markerBuff, int markerLevel)
+    {
+        if (HasMarker(entity, markerBuff, markerLevel))
+        {
+            return true;
+        }
+
+        if (!entity.TryGetBuff(markerBuff, out Entity buffEntity)
+            && !entity.TryApplyAndGetBuff(markerBuff, out buffEntity))
+        {
+            return HasMarker(entity, markerBuff, markerLevel);
+        }
+
+        MakeInertMarkerBuff(buffEntity, markerLevel);
+        return IsMarker(buffEntity, markerLevel);
+    }
+
+    static bool TryAddMarker(Entity entity, PrefabGUID markerBuff, int markerLevel, ServerGameManager serverGameManager)
+    {
+        if (HasMarker(entity, markerBuff, markerLevel, serverGameManager))
+        {
+            return true;
+        }
+
+        if (!serverGameManager.TryGetBuff(entity, markerBuff.ToIdentifier(), out Entity buffEntity)
+            && !serverGameManager.TryInstantiateBuffEntityImmediate(entity, entity, markerBuff, out buffEntity))
+        {
+            return HasMarker(entity, markerBuff, markerLevel, serverGameManager);
+        }
+
+        MakeInertMarkerBuff(buffEntity, markerLevel);
+        return IsMarker(buffEntity, markerLevel);
+    }
+
+    static bool IsMarker(Entity buffEntity, int markerLevel)
+    {
+        return buffEntity.TryGetComponent(out SpellLevel spellLevel)
+            && spellLevel.Level == markerLevel;
+    }
+
+    static void MakeInertMarkerBuff(Entity buffEntity, int markerLevel)
+    {
+        buffEntity.AddWith((ref SpellLevel spellLevel) => spellLevel.Level = markerLevel);
+
+        buffEntity.AddWith((ref LifeTime lifeTime) =>
+        {
+            lifeTime.Duration = 0f;
+            lifeTime.EndAction = LifeTimeEndAction.None;
+        });
+
+        buffEntity.With((ref BuffCategory buffCategory) => buffCategory.Groups = BuffCategoryFlag.None);
+
+        buffEntity.Remove<PersistenceV2.DontSaveEntity>();
+        buffEntity.Remove<ScriptSpawn>();
+        buffEntity.Remove<RemoveBuffOnGameplayEvent>();
+        buffEntity.Remove<RemoveBuffOnGameplayEventEntry>();
+        buffEntity.Remove<CreateGameplayEventsOnSpawn>();
+        buffEntity.Remove<GameplayEventListeners>();
+        buffEntity.Remove<DestroyOnGameplayEvent>();
+        buffEntity.Remove<DealDamageOnGameplayEvent>();
+        buffEntity.Remove<HealOnGameplayEvent>();
+        buffEntity.Remove<ModifyUnitStatBuff_DOTS>();
+        buffEntity.Remove<ModifyMovementSpeedBuff>();
+        buffEntity.Remove<ModifyMovementSpeedBuffModification>();
+        buffEntity.Remove<ModifyTargetHUDBuff>();
+        buffEntity.Remove<SyncToUserBuffer>();
+        buffEntity.Remove<BuffModificationFlagData>();
+        buffEntity.Remove<Buff_Persists_Through_Death>();
+        buffEntity.Remove<UpdateLifeTimeWhenDisabled>();
+        buffEntity.Remove<StackLifeTimeModifier>();
+        buffEntity.Remove<SpawnRandomLifeTime>();
+        buffEntity.Remove<AbilityProjectileFanOnGameplayEvent_DataServer>();
+        buffEntity.Remove<SetOwnerRotateTowardsMouse>();
+    }
+}

--- a/thunderstore.toml
+++ b/thunderstore.toml
@@ -12,7 +12,7 @@ v-rising = ["oakveil-update", "mods", "server"]
 [package]
 namespace = "zfolmt"
 name = "Bloodcraft"
-versionNumber = "1.13.25"
+versionNumber = "1.13.26"
 description = "Leveling, expertise, legacies, professions, familiars, classes, quests!"
 websiteUrl = "https://github.com/mfoltz/Bloodcraft"
 containsNsfwContent = false


### PR DESCRIPTION
## Summary
- add a prefab-baseline idempotency guard for Nightmare Mode live-unit scaling
- add durable Primal Rift marker guards around variant buffs and direct stat scaling
- add Bloodcraft RCON diagnostics plus ScarletRCON/admin harness setup for repeatable restart scenarios

## Verification
- `bash .codex/install.sh` attempted; WSL reported: `Windows Subsystem for Linux has no installed distributions.`
- `dotnet build Bloodcraft.csproj --configuration Release --no-restore -p:RunGenerateREADME=false` passed with the expected `net6.0` EOL warning
- `git diff --check` passed for Bloodcraft and the companion Emery harness file
- `.codex/harness.settings.json` parses as JSON
- Bloodcraft scenario scripts and Emery harness parse with the PowerShell parser
- no remaining `HasNightmareModeScalingMarker` / `TryAddNightmareModeScalingMarker` call sites
- `bloodcraft-nightmare-primal-idempotency` passed: `.codex/runs/20260614-232843/bloodcraft-nightmare-primal-idempotency/receipt.json`
- live client crash/restart receipt captured Primal marker skip behavior: restart showed `Applied scaling to 0 unit(s); skipped 26 already-marked unit(s).`

## Notes
- Draft because the reusable scenario engine change is parked separately in Emery at `.codex/harness/Invoke-VRisingHarness.ps1`.
- No save repair is included; already nonstandard Nightmare units are skipped conservatively.